### PR TITLE
cleanup(pyproject): remove stale uv cooldown override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,17 +64,6 @@ required-version = ">=0.11.8"
 # `.github/dependabot.yml`.
 exclude-newer = "7 days"
 
-# Per-package override: `uv` itself is exempt from the 7-day cooldown
-# above because the latest uv (which `required-version` pins to
-# `>=0.11.8`) was released within the last 7 days, and the global
-# cooldown would otherwise filter it out.
-#
-# TODO(remove on 2026-05-05): once 6 days have passed, uv 0.11.8
-# (released 2026-04-27) will be older than the 7-day window and the
-# global `exclude-newer` will cover it on its own — drop this
-# override to keep the config minimal.
-exclude-newer-package = { uv = "1 day" }
-
 # This pyproject.toml is purely a settings file; do not build or
 # install it as a package.
 package = false

--- a/tools/gmail/oauth-draft/uv.lock
+++ b/tools/gmail/oauth-draft/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
-
 [[package]]
 name = "certifi"
 version = "2026.2.25"

--- a/tools/privacy-llm/checker/uv.lock
+++ b/tools/privacy-llm/checker/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
-
 [[package]]
 name = "checker"
 version = "0.1.0"

--- a/tools/privacy-llm/redactor/uv.lock
+++ b/tools/privacy-llm/redactor/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
-
 [[package]]
 name = "colorama"
 version = "0.4.6"

--- a/tools/vulnogram/generate-cve-json/uv.lock
+++ b/tools/vulnogram/generate-cve-json/uv.lock
@@ -10,9 +10,6 @@ resolution-markers = [
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
-
 [[package]]
 name = "colorama"
 version = "0.4.6"

--- a/uv.lock
+++ b/uv.lock
@@ -6,9 +6,6 @@ requires-python = ">=3.11"
 exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
 exclude-newer-span = "P7D"
 
-[options.exclude-newer-package]
-uv = { timestamp = "0001-01-01T00:00:00Z", span = "P1D" }
-
 [[package]]
 name = "apache-steward"
 version = "0.0.0"


### PR DESCRIPTION
### Why

The root `pyproject.toml` contains a temporary per-package override:

```toml
exclude-newer-package = { uv = "1 day" }
```

This was added because `uv 0.11.8` (released 2026-04-27) fell inside the global `exclude-newer = "7 days"` window, which would have prevented uv from resolving itself. The override exempted `uv` from that window.

Today is 2026-05-05. Eight days have passed since the release, so the global 7-day cooldown already covers `uv 0.11.8`. The override is now redundant and adds unnecessary complexity to the configuration.

### What changes

- **Root `pyproject.toml`** — removes the 11-line comment block + `exclude-newer-package` override.
- **Root `uv.lock`** — re-resolved without the override (3 lines removed).
- **Subproject `uv.lock` files** — `tools/{vulnogram/generate-cve-json,gmail/oauth-draft,privacy-llm/{checker,redactor}}/` each re-resolved and dropped the same stale override metadata (3 lines each).

### Verification

- `uv sync --group dev` resolves correctly and installs `prek==0.3.10` without the override.
- `prek run --all-files` passes across the entire repository (28 hooks, including ruff/mypy/pytest for all 5 Python packages).

### Impact

- Zero functional change.
- Removes a date-bomb TODO that was guaranteed to become stale today.
- Keeps the dependency-resolution config minimal and self-explanatory.