### PR TITLE
ci(tests): add privacy-llm checker and redactor to pytest matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,6 +48,10 @@ jobs:
             path: tools/vulnogram/generate-cve-json
           - name: skill-validator
             path: tools/skill-validator
+          - name: privacy-llm-checker
+            path: tools/privacy-llm/checker
+          - name: privacy-llm-redactor
+            path: tools/privacy-llm/redactor
     # GitHub Actions log viewer renders ANSI colour escapes; without
     # an attached TTY most tools default to monochrome. `FORCE_COLOR`
     # is the de-facto signal honoured by uv, ruff, mypy, and pytest's


### PR DESCRIPTION
### Why

The CI pytest matrix in `.github/workflows/tests.yml` currently exercises three Python projects:

- `tools/gmail/oauth-draft`
- `tools/vulnogram/generate-cve-json`
- `tools/skill-validator`

Two additional projects under `tools/privacy-llm/` have full test suites but are **not** in the matrix:

| Project | Tests | Status |
| --- | --- | --- |
| `checker` | 33  | passing locally |
| `redactor` | 48  | passing locally |

This means regressions in privacy-llm code would not be caught by the visible CI signal (the `tests.yml` workflow). The `prek` workflow does exercise pytest as a hook, but the per-project matrix in `tests.yml` is the triage-friendly surface that shows green/red per package in the PR checks list.

### What changes

- **`.github/workflows/tests.yml`** — adds two entries to the `matrix.project` list:
  - `name: privacy-llm-checker`, `path: tools/privacy-llm/checker`
  - `name: privacy-llm-redactor`, `path: tools/privacy-llm/redactor`

### Verification

- Both suites pass locally:
  - `uv run --directory tools/privacy-llm/checker --group dev pytest --color=yes` → 33 passed
  - `uv run --directory tools/privacy-llm/redactor --group dev pytest --color=yes` → 48 passed
- `prek run --all-files` passes with the workflow YAML change (markdownlint + yamllint implicit via prek hooks).

### Impact

- CI now surfaces independent pass/fail badges for `privacy-llm-checker` and `privacy-llm-redactor`, matching the actual test surface.
- No changes to source code, test code, or lockfiles — purely a CI coverage fix.