### PR TITLE
feat: surface MISSION mode taxonomy in code, skills, and adopter-facing docs

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -18,7 +18,7 @@
 # https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
 ---
 github:
-  description: "Reusable framework for handling security vulnerabilities in Apache projects — agent skills, tracker conventions, and tooling."
+  description: "Agent-assisted maintainership framework for Apache projects — triage (Mode A) and agent-authored fixes with human review (Mode C); mentoring (Mode B) and narrowly-scoped auto-merge (Mode D) on the roadmap."
   homepage: "https://github.com/apache/airflow-steward"
   labels:
     # Note that GitHub only supports <=20 labels/topics per repo! Pipeline

--- a/.claude/skills/pr-management-code-review/SKILL.md
+++ b/.claude/skills/pr-management-code-review/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: maintainer-review
+mode: A
 description: |
   Walk a maintainer through deep code review of open pull requests on the configured `<upstream>` repo (default: read from `<project-config>/project.md → upstream_repo`). The
   default working list — referred to throughout the docs as **"my reviews"** — is the union of five signals on the

--- a/.claude/skills/pr-management-stats/SKILL.md
+++ b/.claude/skills/pr-management-stats/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pr-management-stats
+mode: A
 description: |
   Produce maintainer-facing statistics about open pull requests on
   the configured `<upstream>` repo (default: read from `<project-config>/project.md → upstream_repo`). Successor to

--- a/.claude/skills/pr-management-triage/SKILL.md
+++ b/.claude/skills/pr-management-triage/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: pr-management-triage
+mode: A
 description: |
   Sweep open pull requests on the configured `<upstream>` repo
   (default: read from `<project-config>/project.md →

--- a/.claude/skills/security-cve-allocate/SKILL.md
+++ b/.claude/skills/security-cve-allocate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-cve-allocate
+mode: A
 description: |
   Walk a security team member through allocating a CVE for an
   <tracker> tracking issue. Prints the ASF Vulnogram

--- a/.claude/skills/security-issue-deduplicate/SKILL.md
+++ b/.claude/skills/security-issue-deduplicate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-deduplicate
+mode: A
 description: |
   Merge two <tracker> tracking issues that describe the same
   root-cause vulnerability (typically discovered independently by two

--- a/.claude/skills/security-issue-fix/SKILL.md
+++ b/.claude/skills/security-issue-fix/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-fix
+mode: C
 description: |
   Attempt to fix a security issue tracked in <tracker> by
   implementing the change in a public <upstream> PR. Runs the

--- a/.claude/skills/security-issue-import-from-md/SKILL.md
+++ b/.claude/skills/security-issue-import-from-md/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-import-from-md
+mode: A
 description: |
   Open one or more `<tracker>` tracking issues from a markdown file
   containing a batch of security findings (typically the output of an

--- a/.claude/skills/security-issue-import-from-pr/SKILL.md
+++ b/.claude/skills/security-issue-import-from-pr/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-import-from-pr
+mode: A
 description: |
   Open a tracking issue in <tracker> for a security-relevant fix that
   has already been opened (or merged) as a public PR in <upstream>,

--- a/.claude/skills/security-issue-import/SKILL.md
+++ b/.claude/skills/security-issue-import/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-import
+mode: A
 description: |
   Scan <security-list> for reports that have not yet been
   copied into <tracker> as tracking issues, present the proposed

--- a/.claude/skills/security-issue-invalidate/SKILL.md
+++ b/.claude/skills/security-issue-invalidate/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-invalidate
+mode: A
 description: |
   Close an `<tracker>` tracking issue as invalid: apply the
   `invalid` label, remove the scope label, post a short closing

--- a/.claude/skills/security-issue-sync/SKILL.md
+++ b/.claude/skills/security-issue-sync/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: security-issue-sync
+mode: A
 description: |
   Synchronize a security issue in <tracker> with the state of its
   GitHub discussion, the <security-list> mailing thread, and any

--- a/MISSION.md
+++ b/MISSION.md
@@ -82,7 +82,9 @@ Three design choices set the project apart from "just bolt a code-review bot on 
 
 ## Technical scope
 
-A platform substrate — issue and PR ingestion, GitHub API write-back, conversation threading, audit logging, integration with adjacent systems (Gmail, PonyMail, Vulnogram, generic CVE submission, an extensible adapter layer so non-ASF adopters plug in their own equivalents) — with four modes built on top:
+A platform substrate — issue and PR ingestion, GitHub API write-back, conversation threading, audit logging, integration with adjacent systems (Gmail, PonyMail, Vulnogram, generic CVE submission, an extensible adapter layer so non-ASF adopters plug in their own equivalents) — with four modes built on top.
+
+[`docs/modes.md`](docs/modes.md) is the honest snapshot mapping each mode below to the skills currently shipped, with a `stable / experimental / proposed / off` status legend.
 
 **Mode A — triage assistant** for issues, security reports, and PRs. *On the security side:* spots inbound reports, classifies against prior triaged cases, surfaces likely duplicates, identifies anything that should not have been filed publicly, proposes initial routing to the security team. *On the regular side:* suggests labels, spots duplicates, links related discussions, proposes routing. Every output is a suggestion the human signs off on; nothing lands without review. Lowest risk surface.
 

--- a/README.md
+++ b/README.md
@@ -189,11 +189,15 @@ Three skill families ship in the framework. Pick whichever the
 adopter wants to use; symlinks for the picked families land in
 the adopter's skill directory.
 
-| Family | Purpose | Detail |
-|---|---|---|
-| [**setup**](docs/setup/README.md) | Isolated agent setup, framework adoption + maintenance, shared-config sync. The prerequisite — at minimum the `setup-steward` skill itself runs out of this family. | 6 skills, [`docs/setup/`](docs/setup/) |
-| [**security**](docs/security/README.md) | 16-step security-issue handling lifecycle — from `security@` import through CVE publication. Maintainer-only. | 8 skills, [`docs/security/`](docs/security/) |
-| [**pr-management**](docs/pr-management/README.md) | Maintainer-facing PR-queue management — triage, stats, deep code review. | 3 skills, [`docs/pr-management/`](docs/pr-management/) |
+The **Modes** column maps each family to the MISSION agent-assistance
+taxonomy — see [`docs/modes.md`](docs/modes.md) for what each mode
+means and which modes are still proposed vs. shipping today.
+
+| Family | Modes | Purpose | Detail |
+|---|---|---|---|
+| [**setup**](docs/setup/README.md) | (infra) | Isolated agent setup, framework adoption + maintenance, shared-config sync. The prerequisite — at minimum the `setup-steward` skill itself runs out of this family. | 6 skills, [`docs/setup/`](docs/setup/) |
+| [**security**](docs/security/README.md) | A, C | 16-step security-issue handling lifecycle — from `security@` import through CVE publication. Maintainer-only. | 8 skills, [`docs/security/`](docs/security/) |
+| [**pr-management**](docs/pr-management/README.md) | A | Maintainer-facing PR-queue management — triage, stats, deep code review. | 3 skills, [`docs/pr-management/`](docs/pr-management/) |
 
 ## Maintenance
 

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -49,7 +49,7 @@ sequencing commitments behind them.
 |---|---|---|---|
 | **A** — triage | Issues, security reports, PRs: spot, classify, route, surface duplicates. Every output is a suggestion the human signs off on. | stable (security) / experimental (pr-management) | 10 |
 | **B** — conversational mentoring | Joins issue and PR threads in a teaching register: clarifying questions, pointers to project conventions, paired examples from prior PRs, hand-off to a human when scope exceeds the agent. | proposed | 0 |
-| **C** — agent-authored fixes with human review | Agent drafts a fix for a well-scoped problem and opens a PR; every PR is reviewed and merged by a human committer. | partial (security-only) | 1 |
+| **C** — agent-authored fixes with human review | Agent drafts a fix for a well-scoped problem and opens a PR; every PR is reviewed and merged by a human committer. | stable (security-only); generic case proposed | 1 |
 | **D** — narrowly-scoped fix-and-merge | Auto-merge restricted to objectively boring change classes (lint, dependency bumps inside an allow-list, license-header insertion, formatting, broken-link repair). | off | 0 |
 
 A few skills sit **outside** the mode taxonomy by design — see

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -1,0 +1,207 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Modes — MISSION taxonomy mapped to current skills](#modes--mission-taxonomy-mapped-to-current-skills)
+  - [Status legend](#status-legend)
+  - [Modes at a glance](#modes-at-a-glance)
+  - [Mode A — triage](#mode-a--triage)
+  - [Mode B — conversational mentoring](#mode-b--conversational-mentoring)
+  - [Mode C — agent-authored fixes with human review](#mode-c--agent-authored-fixes-with-human-review)
+  - [Mode D — narrowly-scoped fix-and-merge](#mode-d--narrowly-scoped-fix-and-merge)
+  - [Outside the modes](#outside-the-modes)
+  - [Mode lifecycle](#mode-lifecycle)
+  - [Cross-references](#cross-references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/legal/release-policy.html -->
+
+# Modes — MISSION taxonomy mapped to current skills
+
+[`MISSION.md`](../MISSION.md) frames the framework around four
+toggleable **modes** of agent-assisted repository maintainership:
+**A** (triage), **B** (mentoring), **C** (agent-authored fixes
+with human review), and **D** (narrowly-scoped fix-and-merge).
+Each adopting project picks the modes that match its culture and
+risk tolerance.
+
+This document maps that taxonomy to the skills that currently
+ship in the framework. It is the **honest snapshot** — modes
+that are not yet implemented are listed as such, with a tracking
+issue or roadmap pointer rather than a placeholder shell. Read
+[`MISSION.md`](../MISSION.md) for the *why* of each mode and the
+sequencing commitments behind them.
+
+## Status legend
+
+| Status | Meaning |
+|---|---|
+| **stable** | Implemented, in use by at least one adopter, behaviour expected to remain backward-compatible across minor framework versions. |
+| **experimental** | Implemented but not yet covered by an adopter pilot or contributor-sentiment evaluation; shape may change. |
+| **proposed** | Designed in [`MISSION.md`](../MISSION.md) but no skill yet exists; tracked for future implementation. |
+| **off** | Deliberately not implemented per a MISSION-level sequencing rule (Mode D). |
+
+## Modes at a glance
+
+| Mode | Purpose | Status | Skill count |
+|---|---|---|---|
+| **A** — triage | Issues, security reports, PRs: spot, classify, route, surface duplicates. Every output is a suggestion the human signs off on. | stable (security) / experimental (pr-management) | 10 |
+| **B** — conversational mentoring | Joins issue and PR threads in a teaching register: clarifying questions, pointers to project conventions, paired examples from prior PRs, hand-off to a human when scope exceeds the agent. | proposed | 0 |
+| **C** — agent-authored fixes with human review | Agent drafts a fix for a well-scoped problem and opens a PR; every PR is reviewed and merged by a human committer. | partial (security-only) | 1 |
+| **D** — narrowly-scoped fix-and-merge | Auto-merge restricted to objectively boring change classes (lint, dependency bumps inside an allow-list, license-header insertion, formatting, broken-link repair). | off | 0 |
+
+A few skills sit **outside** the mode taxonomy by design — see
+[Outside the modes](#outside-the-modes) below.
+
+## Mode A — triage
+
+Inbound report and PR triage. The lowest-risk surface and the
+foundation everything else builds on. Skills propose labels,
+spot duplicates, link related discussions, classify reports
+against prior triaged cases, and route to the right human; they
+do not act without human review.
+
+| Skill | Domain | Status |
+|---|---|---|
+| [`pr-management-triage`](../.claude/skills/pr-management-triage/SKILL.md) | Generic PR queue triage. | experimental |
+| [`pr-management-stats`](../.claude/skills/pr-management-stats/SKILL.md) | PR-queue reporting (supports triage decisions). | experimental |
+| [`pr-management-code-review`](../.claude/skills/pr-management-code-review/SKILL.md) | Maintainer-facing deep code review. | experimental |
+| [`security-issue-import`](../.claude/skills/security-issue-import/SKILL.md) | Inbound security-report classification + initial routing. | stable |
+| [`security-issue-import-from-pr`](../.claude/skills/security-issue-import-from-pr/SKILL.md) | Open a tracker from a security-relevant public PR. | stable |
+| [`security-issue-import-from-md`](../.claude/skills/security-issue-import-from-md/SKILL.md) | Bulk-import findings from a markdown report. | stable |
+| [`security-issue-deduplicate`](../.claude/skills/security-issue-deduplicate/SKILL.md) | Merge two trackers describing the same root-cause vulnerability. | stable |
+| [`security-issue-invalidate`](../.claude/skills/security-issue-invalidate/SKILL.md) | Close a tracker as invalid with a polite-but-firm reporter reply. | stable |
+| [`security-issue-sync`](../.claude/skills/security-issue-sync/SKILL.md) | Reconcile a tracker against its mail thread, fix PR, release train, and archives. | stable |
+| [`security-cve-allocate`](../.claude/skills/security-cve-allocate/SKILL.md) | Allocate a CVE for a tracker (Vulnogram URL + paste-ready JSON). | stable |
+
+Two notes on the boundaries:
+
+- `pr-management-code-review` is a deeper variant of triage —
+  the agent reads diff and surrounding code rather than only
+  metadata, but the output is still a suggestion for the human
+  reviewer. It belongs to Mode A by the same rule.
+- `security-cve-allocate` is procedural rather than classificatory
+  (CVE allocation happens after assessment), but it shares Mode A's
+  shape: the agent prepares a paste-ready artefact, the human
+  PMC member submits it. Listed here for navigability.
+
+## Mode B — conversational mentoring
+
+**Status: proposed. No skill yet.**
+
+[`MISSION.md` § Mode B](../MISSION.md#technical-scope) names this
+the highest-value mode and the one off-the-shelf agent tooling
+skips. Implementation is tracked as future work; spec, tone
+guide, and adopter configuration template land in a follow-up
+PR before any skill code, so the project's tone choices are
+reviewable independently from the runtime behaviour.
+
+The closest existing surface is
+[`pr-management-triage/comment-templates.md`](../.claude/skills/pr-management-triage/comment-templates.md),
+which carries Mode A classification responses — informational,
+not pedagogical. It is **not** Mode B.
+
+## Mode C — agent-authored fixes with human review
+
+The agent drafts a fix for a well-scoped problem (a tracked
+issue, a triaged security report with team consensus on scope, a
+failing test with an obvious cause, a documentation hole) and
+opens a PR. Every PR is reviewed and merged by a human committer;
+the agent never merges its own work.
+
+| Skill | Domain | Status |
+|---|---|---|
+| [`security-issue-fix`](../.claude/skills/security-issue-fix/SKILL.md) | Draft a fix PR in `<upstream>` from a triaged, CVE-allocated tracker. | stable (security-only) |
+
+**Generic Mode C is proposed.** [`MISSION.md`](../MISSION.md)
+names lint fixes, audit-tool findings (Apache Verum, Apache Caer,
+CodeQL, equivalents), failing tests with obvious causes, and
+documentation holes as in-scope for Mode C beyond the security
+case. None of those are implemented yet; security-issue-fix is
+the only Mode C skill in the framework today.
+
+For security-class Mode C PRs, the public surface strips CVE and
+private context per the project's disclosure policy, so the
+public surface stays clean until the embargo lifts — see
+[`AGENTS.md` § Confidentiality](../AGENTS.md#confidentiality-of-the-tracker-repository)
+for the rules the skill enforces.
+
+## Mode D — narrowly-scoped fix-and-merge
+
+**Status: off. Deliberately not implemented.**
+
+[`MISSION.md` § Mode D](../MISSION.md#technical-scope) holds
+auto-merge off until Modes A, B, and C have been running for
+two quarters and contributor-sentiment data says the project is
+healthier, not just faster. Security-class changes are
+explicitly **out** of Mode D — no auto-merge ever touches
+anything embargoed or CVE-tagged.
+
+The framework's current `.asf.yaml` configuration reflects this
+posture: `pull_requests.allow_auto_merge` is set to `false`
+([`.asf.yaml`](../.asf.yaml)).
+
+When Mode D ships, the eligible change classes will be declared
+per-adopter in `<project-config>/` and gated by an allow-list
+that the framework refuses to grow without an adopter PR.
+
+## Outside the modes
+
+Several skills are framework infrastructure rather than
+maintainership modes. They support adoption, isolation, and
+upgrade flows; they do not act on issues, PRs, or contributor
+threads on their own.
+
+| Skill | Purpose |
+|---|---|
+| [`setup-steward`](../.claude/skills/setup-steward/SKILL.md) | Adopt the framework into an adopter repo; manage the snapshot, symlinks, and overrides. |
+| [`setup-isolated-setup-install`](../.claude/skills/setup-isolated-setup-install/SKILL.md) | Install the credential-isolation sandbox harness. |
+| [`setup-isolated-setup-update`](../.claude/skills/setup-isolated-setup-update/SKILL.md) | Update pinned system tools (`bubblewrap`, `socat`, agent CLI) past the cooldown window. |
+| [`setup-isolated-setup-verify`](../.claude/skills/setup-isolated-setup-verify/SKILL.md) | Read-only health check of the sandbox harness. |
+| [`setup-override-upstream`](../.claude/skills/setup-override-upstream/SKILL.md) | Promote an adopter's local override into a framework PR. |
+| [`setup-shared-config-sync`](../.claude/skills/setup-shared-config-sync/SKILL.md) | Sync shared configuration across worktrees. |
+
+These ship as a single **setup family** — see
+[`docs/setup/README.md`](setup/README.md).
+
+## Mode lifecycle
+
+A mode moves through four states as it matures:
+
+1. **proposed** — designed in [`MISSION.md`](../MISSION.md), no
+   skill code yet. Spec PRs may land before any skill code so
+   tone, scope, and adopter knobs are reviewable in isolation.
+2. **experimental** — at least one skill exists, behaviour may
+   change, no adopter pilot has run an evaluation. Adopters
+   can opt-in but should expect breaking changes between
+   framework versions.
+3. **stable** — at least one adopter is running the mode in
+   production, behaviour is backward-compatible across minor
+   framework versions. The default state for skills shipped to
+   adopters.
+4. **graduated-to-D-eligible** *(future state, Mode A/B/C only)* —
+   the mode has run stable for two quarters with positive
+   contributor-sentiment evidence, the framework will start
+   considering an equivalent change class for Mode D auto-merge.
+   This state does not exist yet because Mode D itself is off.
+
+A mode can be **retracted** from any state. The retraction
+triggers MISSION names — sustained negative contributor
+sentiment, a confidentiality leak, a sandbox bypass that escapes
+detection — apply per-adopter and per-mode. A retraction in one
+adopter does not auto-retract in another, but the framework
+records it for cross-adopter pattern detection.
+
+## Cross-references
+
+- [`MISSION.md`](../MISSION.md) — the *why* of each mode, the
+  sequencing commitments, and the privacy/security/vendor-
+  neutrality posture each mode inherits.
+- [`README.md`](../README.md#skill-families) — adopter-facing
+  skill family table; this document is the maintainer-facing
+  taxonomy view of the same skills.
+- [`AGENTS.md`](../AGENTS.md) — repository-level rules every
+  mode inherits (external content as data, polite-but-firm
+  tone, brevity, confidentiality).

--- a/tools/skill-validator/src/skill_validator/__init__.py
+++ b/tools/skill-validator/src/skill_validator/__init__.py
@@ -50,8 +50,11 @@ DOCS_DIR = Path("docs")
 PROJECTS_TEMPLATE_DIR = Path("projects/_template")
 
 REQUIRED_FRONTMATTER_KEYS = {"name", "description", "license"}
-OPTIONAL_FRONTMATTER_KEYS = {"when_to_use"}
+OPTIONAL_FRONTMATTER_KEYS = {"when_to_use", "mode"}
 ALLOWED_LICENSES = {"Apache-2.0"}
+# MISSION mode taxonomy — see docs/modes.md.
+# "D" deliberately excluded: Mode D (auto-merge) is off per MISSION sequencing.
+ALLOWED_MODES = {"A", "B", "C"}
 
 # Forbidden hardcoded project references (fixed strings, case-sensitive)
 FORBIDDEN_PATTERNS: list[str] = [
@@ -214,6 +217,13 @@ def validate_frontmatter(path: Path, text: str) -> Iterable[Violation]:
 
     if "license" in fm and fm["license"] not in ALLOWED_LICENSES:
         yield Violation(path, 1, f"frontmatter license '{fm['license']}' not in {ALLOWED_LICENSES}")
+
+    if "mode" in fm and fm["mode"] not in ALLOWED_MODES:
+        yield Violation(
+            path,
+            1,
+            f"frontmatter mode '{fm['mode']}' not in {sorted(ALLOWED_MODES)} (see docs/modes.md)",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill-validator/tests/test_validator.py
+++ b/tools/skill-validator/tests/test_validator.py
@@ -111,6 +111,40 @@ class TestValidateFrontmatter:
         violations = list(validate_frontmatter(path, text))
         assert any("MIT" in v.message for v in violations)
 
+    def test_valid_mode(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        for mode in ("A", "B", "C"):
+            text = (
+                "---\n"
+                "name: foo\n"
+                "description: bar\n"
+                "license: Apache-2.0\n"
+                f"mode: {mode}\n"
+                "---\n"
+            )
+            violations = list(validate_frontmatter(path, text))
+            assert violations == [], f"mode '{mode}' should be valid"
+
+    def test_invalid_mode(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = (
+            "---\n"
+            "name: foo\n"
+            "description: bar\n"
+            "license: Apache-2.0\n"
+            "mode: D\n"
+            "---\n"
+        )
+        violations = list(validate_frontmatter(path, text))
+        assert any("mode" in v.message and "'D'" in v.message for v in violations)
+
+    def test_mode_optional(self, tmp_path: Path) -> None:
+        # Skills without a mode (e.g. setup-* infrastructure) must not fail.
+        path = tmp_path / "SKILL.md"
+        text = "---\nname: foo\ndescription: bar\nlicense: Apache-2.0\n---\n"
+        violations = list(validate_frontmatter(path, text))
+        assert violations == []
+
 
 # ---------------------------------------------------------------------------
 # Heading / anchor helpers


### PR DESCRIPTION
## Summary

[`MISSION.md`](MISSION.md) frames the framework around four toggleable **modes** of agent-assisted repository maintainership (A: triage, B: mentoring, C: agent-authored fixes with human review, D: narrowly-scoped auto-merge). The codebase did not yet reflect that taxonomy. This PR surfaces it in three layers, smallest blast radius first:

1. **[`docs/modes.md`](docs/modes.md)** — honest snapshot mapping every shipped skill to a mode (or to *outside the modes* for the setup family) with a `stable / experimental / proposed / off` status legend. Mode B is **proposed** (no skill yet), Mode D is **off** (deliberately not implemented per [`MISSION.md` § Mode D](MISSION.md#technical-scope)). Includes a mode lifecycle and explicit cross-references to MISSION, README, and AGENTS.
2. **`mode:` frontmatter on SKILL.md** — every skill that fits a mode gets `mode: A` or `mode: C`. Setup-family skills are infrastructure and intentionally omit the field. `tools/skill-validator` is extended to recognise `mode` as an optional frontmatter key and validate the value against `{A, B, C}` (Mode D is excluded because shipping a `mode: D` skill would be a sequencing violation, not a typo). New unit tests cover both branches.
3. **README + .asf.yaml** — the `Skill families` table gains a `Modes` column linking to `docs/modes.md`; the GitHub repo description widens from "security vulnerabilities" to "agent-assisted maintainership", since security is one mode of one family rather than the project's identity.

## Why this ordering

The three commits are independently reviewable but ship together because they are mutually load-bearing: the validator change is meaningless without `mode:` in SKILL.md, the README column is meaningless without `docs/modes.md` to link to. Splitting them would force readers to context-switch across PRs to evaluate any single piece. They land as one PR with three commits so each layer remains greppable in `git log`.

## Test plan

- [x] `uv run --project tools/skill-validator pytest -k 'not test_real_repo_passes'` — 33 passed (the `test_real_repo_passes` integration test fails on `main` with 191 pre-existing link-validation violations and is out of scope for this PR)
- [x] `prek run --files <changed-files>` clean on every commit
- [x] `skill-validate` reports zero new mode-related violations against the real repo
- [ ] Maintainer review of the proposed/off statuses in [`docs/modes.md`](docs/modes.md) — these are MISSION interpretations and should match the PMC's read of the sequencing commitments
- [ ] Maintainer confirmation that the .asf.yaml description rewording is the framing the project wants on its GitHub card

## Out of scope

- Implementing Mode B (a separate, larger workstream — spec PR first, then runtime).
- Generic Mode C beyond security (lint fixes, audit-tool findings, failing tests, doc holes).
- Fixing the pre-existing 191 link-validation violations the integration test surfaces.