### PR TITLE
feat: Mode B prototype skill — `pr-management-mentor` (experimental)

### DIFF
--- a/.claude/skills/pr-management-mentor/SKILL.md
+++ b/.claude/skills/pr-management-mentor/SKILL.md
@@ -1,0 +1,206 @@
+---
+name: pr-management-mentor
+mode: B
+description: |
+  Draft a teaching-register comment on a single GitHub issue or
+  PR thread on the configured `<upstream>` repo (default: read
+  from `<project-config>/project.md → upstream_repo`), aimed at a
+  contributor who is missing repo context the maintainer would
+  otherwise have to spell out. The skill reads the thread,
+  decides whether a mentoring intervention is warranted, drafts
+  one comment per the project's tone guide and convention
+  pointers, runs the tone checklist, then waits for explicit
+  maintainer confirmation before posting via `gh`. Does **not**
+  triage (no labels, draft toggles, closes), review code (no
+  diff comments, approve / request-changes), or open PRs — those
+  are Mode A and Mode C surfaces. Bows out and pings the
+  configured maintainer team when the thread reaches
+  `max_agent_turns`, when the contributor pushes back on a
+  substantive design point, when the topic enters
+  `out_of_scope_topics`, or when the contributor explicitly asks
+  for a human.
+when_to_use: |
+  Invoke when a maintainer says "mentor PR NNN", "help the
+  reporter on issue NNN", "draft a clarifying comment for NNN",
+  "explain the convention to this contributor on NNN", or chains
+  this skill after `pr-management-triage` flags a PR as "first
+  contributor, missing repro / convention". Not appropriate for
+  PRs already mid-review with a maintainer (the agent should
+  not talk over a human reviewer), for security-sensitive
+  threads (Mode B always hands off these), or for any thread
+  where the maintainer has *deliberately* not replied yet — ask
+  before invoking.
+license: Apache-2.0
+---
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- Placeholder convention:
+     <repo>   → target GitHub repository in `owner/name` form (default: read from `<project-config>/project.md → upstream_repo`)
+     <viewer> → the authenticated GitHub login of the maintainer running the skill
+     Substitute these before running any `gh` command below. -->
+
+# pr-management-mentor
+
+**Status: experimental.** First prototype of Mode B
+([conversational mentoring](../../../docs/mentoring/spec.md)). The
+skill exists to make the spec executable on a single thread at
+a time so we can iterate on tone wording, convention pointers,
+and hand-off triggers against real contributor traffic before
+hardening the contract.
+
+This skill walks a maintainer through **one mentoring
+intervention** on **one thread** (issue or PR). Its job is to
+answer, for the invoked thread, one question:
+
+> *Is there a one-comment teaching intervention that lowers the
+> barrier to the contributor's next useful action — and if so,
+> what does it say?*
+
+If the answer is "no" (thread is already on track, maintainer
+already engaging, scope exceeds Mode B), the skill says so and
+exits without posting. The agent's silence is a feature, not a
+failure.
+
+The full spec — scope, register, hand-off rules, adopter knobs
+— lives in [`docs/mentoring/spec.md`](../../../docs/mentoring/spec.md).
+This SKILL.md is the runtime; detail files break the loop out
+topic-by-topic:
+
+| File | Purpose |
+|---|---|
+| [`comment-templates.md`](comment-templates.md) | Verbatim mentoring-comment bodies for the four canonical interventions: missing-repro, missing-version, convention-pointer, why-question. |
+| [`tone-checks.md`](tone-checks.md) | Pre-post checklist enforcing the spec's voice rules (no praise without specificity, no hedging, one ask per comment, etc.). The skill runs every draft through this list before showing it to the maintainer. |
+| [`hand-off.md`](hand-off.md) | The hand-off comment template + the four trigger conditions that fire it. |
+
+---
+
+## Adopter overrides
+
+Before running the default behaviour documented below, this
+skill consults
+[`.apache-steward-overrides/pr-management-mentor.md`](../../../docs/setup/agentic-overrides.md)
+in the adopter repo if it exists, and applies any
+agent-readable overrides it finds. See
+[`docs/setup/agentic-overrides.md`](../../../docs/setup/agentic-overrides.md)
+for the override file shape.
+
+## Adopter contract
+
+Per-project values live in
+`<project-config>/mentoring-config.md`. See the template at
+[`projects/_template/mentoring-config.md`](../../../projects/_template/mentoring-config.md).
+The keys this skill reads:
+
+| Key | Used for |
+|---|---|
+| `mentoring_invocation_command` | The slash-command name the maintainer types. |
+| `maintainer_team_handle` | `@<org>/<team>` mentioned on hand-off. |
+| `ai_attribution_footer` | Literal markdown appended to every contributor-facing comment. |
+| `convention_pointers` | Trigger → docs-link → label table. The skill links rather than paraphrases. |
+| `max_agent_turns` | Hard ceiling on consecutive agent comments per thread. Default 2. |
+| `out_of_scope_topics` | Topics on which the skill always hands off without drafting. |
+
+If any required key is missing, the skill aborts with a
+config-error message and points at the template. It does not
+guess defaults for project-specific values.
+
+## Runtime loop
+
+The skill runs against a single thread per invocation. The loop
+is short on purpose — one comment in, one decision out:
+
+1. **Resolve config**. Read `<project-config>/mentoring-config.md`.
+   Abort if any required key is missing.
+2. **Fetch the thread**. `gh issue view <N> --comments` (or
+   `gh pr view <N> --comments`). Cap the read at the last
+   `max_agent_turns + 5` comments — older context is not the
+   audience.
+3. **Out-of-scope check**. If the thread title or recent
+   comments touch any `out_of_scope_topics` entry, **do not
+   draft**. Surface "this thread is out of Mode B scope —
+   handing off" and run the [hand-off](hand-off.md) flow.
+4. **Maintainer-already-engaged check**. If a maintainer (login
+   in the configured committers team, see `pr-management-config.md →
+   committers_team`) has commented in the last
+   `max_agent_turns` turns, **do not draft**. The agent does
+   not talk over a human reviewer.
+5. **Pick the intervention**. Match the thread against the
+   `convention_pointers` triggers. If exactly one fires, pick
+   the matching template from
+   [`comment-templates.md`](comment-templates.md). If multiple
+   fire, ask the maintainer which one. If none fire, exit
+   silently (no draft, no comment).
+6. **Draft the comment**. Render the template with the
+   contributor's `<author>` login and the matched
+   `convention_pointers` row. Append the
+   `ai_attribution_footer` exactly as configured.
+7. **Run the tone checks**. Walk every rule in
+   [`tone-checks.md`](tone-checks.md) against the draft. If any
+   fail, revise and re-check. If revision can't satisfy a rule
+   in two passes, surface the failing rule to the maintainer
+   and ask for guidance — do not post a comment that fails
+   tone.
+8. **Show the maintainer**. Print the rendered comment, the
+   matched trigger, and the convention-pointer link. Wait for
+   explicit confirmation. Do not post on implicit signals.
+9. **Post or discard**. On `yes`, post via
+   `gh issue comment <N> --body-file <draft>` (or
+   `gh pr comment`). On `no`, exit silently.
+10. **Log**. Record the invocation outcome (drafted-and-posted,
+    drafted-and-discarded, declined-pre-draft) to the
+    framework's audit log so contributor-sentiment evaluation
+    can be retrospective.
+
+## Hand-off
+
+Four triggers fire the hand-off flow (see
+[`hand-off.md`](hand-off.md) for the comment template and the
+detection logic):
+
+1. Thread reaches `max_agent_turns`.
+2. Contributor pushes back on a substantive design point and
+   the skill's first answer didn't resolve it.
+3. Topic enters `out_of_scope_topics` mid-thread.
+4. Contributor explicitly asks for a human.
+
+The hand-off comment is one line: `@<maintainer_team_handle>`,
+a one-line summary of the open question, and silence
+afterwards. The skill does not summarise the conversation; the
+maintainer reads the thread.
+
+## What this skill does not do
+
+- **Code review.** No diff comments, no approvals, no
+  request-changes submissions.
+  [`pr-management-code-review`](../pr-management-code-review/SKILL.md)
+  owns that.
+- **Triage.** No labels, no draft toggles, no closes.
+  [`pr-management-triage`](../pr-management-triage/SKILL.md)
+  owns that.
+- **Authoring fixes.** No PRs opened. That is Mode C.
+- **Predicting maintainer decisions.** The skill never says
+  "the maintainers will probably want X". It says "a
+  maintainer will reply on this; in the meantime, here's the
+  convention" and stops.
+- **Mailing-list comments.** GitHub threads only.
+  Mailing-list mentoring lives in the human maintainer's
+  voice; the agent does not have a list-subscriber identity.
+- **Auto-fire.** Every invocation is opt-in by a maintainer.
+  No cron, no webhook, no auto-trigger. Auto-fire is a
+  Mode-D-shaped problem and inherits Mode D's sequencing
+  constraint.
+
+## Cross-references
+
+- [`docs/mentoring/spec.md`](../../../docs/mentoring/spec.md) —
+  the full spec this skill implements.
+- [`docs/mentoring/README.md`](../../../docs/mentoring/README.md) —
+  family overview + status.
+- [`docs/modes.md` § Mode B](../../../docs/modes.md#mode-b--conversational-mentoring) —
+  current implementation status (experimental once this skill
+  ships).
+- [`projects/_template/mentoring-config.md`](../../../projects/_template/mentoring-config.md) —
+  adopter scaffold.
+- [`MISSION.md` § Mode B](../../../MISSION.md#technical-scope) —
+  RAI empowerment framing.

--- a/.claude/skills/pr-management-mentor/comment-templates.md
+++ b/.claude/skills/pr-management-mentor/comment-templates.md
@@ -1,0 +1,116 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Comment templates
+
+Every contributor-facing comment this skill posts comes from
+this file. The templates exist to keep the teaching register
+consistent across threads and to make tone review tractable —
+the maintainer reviews the wording **here** once, not on every
+PR.
+
+Four canonical interventions are defined. The skill picks at
+most one per invocation.
+
+Placeholders:
+
+- `<author>` — contributor's GitHub login (without `@`; the
+  template adds it).
+- `<doc_label>` — short link label resolved from
+  `<project-config>/mentoring-config.md → convention_pointers`.
+- `<doc_url>` — link target, same source.
+- `<ai_attribution_footer>` — verbatim from
+  `<project-config>/mentoring-config.md → ai_attribution_footer`.
+
+If a template would render with a missing `<doc_label>` or
+`<doc_url>` (because the trigger fired but the
+`convention_pointers` row is incomplete), the skill aborts
+before showing the maintainer. Do not post a half-rendered
+comment.
+
+---
+
+## 1. Missing repro
+
+**Trigger**: bug report or PR description that asserts a
+problem without a way to reproduce it (no minimal example, no
+stack trace, no command, no input data shape).
+
+```markdown
+@<author> — to take a look at this we'll need a way to reproduce it. Could you add:
+
+1. The smallest example that triggers the behaviour (a few lines of code, or the exact command + input).
+2. What you expected to happen versus what actually happened.
+
+[<doc_label>](<doc_url>) walks through the format we look for.
+
+<ai_attribution_footer>
+```
+
+## 2. Missing version
+
+**Trigger**: bug report that omits the version of the project
+the contributor is running.
+
+```markdown
+@<author> — could you add the version you're running? [<doc_label>](<doc_url>) shows where to find it. Knowing the version tells us whether this is a known regression or new ground.
+
+<ai_attribution_footer>
+```
+
+## 3. Convention pointer
+
+**Trigger**: PR or issue where the contributor is missing a
+piece of repo convention they could have found themselves
+(commit-message format, PR-title prefix, where tests go,
+required changelog entry, etc.).
+
+```markdown
+@<author> — heads up, this repo has a convention for that: [<doc_label>](<doc_url>). Once you align with it a maintainer can take the next look.
+
+<ai_attribution_footer>
+```
+
+## 4. Why-question
+
+**Trigger**: contributor pushes back on a maintainer's existing
+review comment with "why does this need X?" and the answer is
+in public documentation. The skill answers **once**; if the
+contributor disagrees, the skill hands off (see
+[`hand-off.md`](hand-off.md)).
+
+```markdown
+@<author> — that's covered here: [<doc_label>](<doc_url>). The short version is in the first paragraph. If after reading you still think it shouldn't apply to this PR, drop a comment and a maintainer will weigh in.
+
+<ai_attribution_footer>
+```
+
+---
+
+## What is deliberately not a template
+
+Listed so reviewers see the choices and can push back.
+
+- **Greeting + welcome**. The first message in a contributor's
+  PR thread is often a maintainer's, not the agent's. The
+  agent posting "welcome to the project!" before the
+  maintainer has the chance is rude and cuts the maintainer
+  out of the relationship. If a project wants a welcome
+  comment, that is a triage-level concern, not a Mode B
+  concern.
+- **Closing comment**. The skill never posts on a thread it is
+  about to close — closing belongs to triage. If the
+  contributor's submission is out of scope or duplicate, the
+  skill exits without commenting and lets
+  [`pr-management-triage`](../pr-management-triage/SKILL.md)
+  handle the close.
+- **Approval / "looks good"**. Mode B does not signal review
+  outcomes. Even a casual "this looks like a good direction"
+  shifts contributor expectations.
+  [`pr-management-code-review`](../pr-management-code-review/SKILL.md)
+  owns that surface.
+- **Praise**. "Great question!", "Thanks for the
+  contribution!", "Awesome work" — all noise. They train the
+  contributor to skim the rest of the comment. The
+  [`tone-checks.md`](tone-checks.md) checklist rejects any
+  draft containing them.

--- a/.claude/skills/pr-management-mentor/hand-off.md
+++ b/.claude/skills/pr-management-mentor/hand-off.md
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Hand-off
+
+The agent bows out and pings a human under any of the four
+trigger conditions defined in
+[`docs/mentoring/spec.md` § Hand-off protocol](../../../docs/mentoring/spec.md#hand-off-protocol).
+This file gives the runtime: how to detect each trigger and
+what the hand-off comment looks like.
+
+---
+
+## When to hand off
+
+| # | Trigger | Detection |
+|---|---|---|
+| 1 | Thread reached `max_agent_turns`. | Count comments authored by `<viewer>` in the thread. If the count equals `max_agent_turns` and the thread is not yet resolved, the next move is a hand-off, not another draft. Default ceiling is `2`. |
+| 2 | Contributor pushed back on a substantive point. | After the agent has answered a why-question once (template 4 in [`comment-templates.md`](comment-templates.md)), the next contributor message that disagrees ("I don't think that applies here", "but in my case…", "that doesn't make sense") triggers hand-off. The skill answers the *why* once; it does not argue. |
+| 3 | Topic entered `out_of_scope_topics`. | Re-run the out-of-scope check (step 3 of the runtime loop in [`SKILL.md`](SKILL.md#runtime-loop)) on every new contributor message. If a previously in-scope thread mentions any `out_of_scope_topics` entry (security, deprecation, license, project-specific architecture, etc.), hand off. |
+| 4 | Contributor explicitly asked for a human. | Match against "can a maintainer", "can someone from the team", "is anyone there", "can a human", "can a real person", or any request whose subject is the contributor wanting non-agent attention. Always-fires; takes priority over the other three. |
+
+The triggers are checked in order **4 → 3 → 1 → 2** on every
+new contributor turn. The first one that fires runs the
+hand-off and the skill exits the thread.
+
+---
+
+## Hand-off comment
+
+One template, used for all four triggers. It does **not**
+summarise the conversation — the maintainer reads the thread.
+
+Placeholders:
+
+- `<maintainer_team_handle>` — from
+  `<project-config>/mentoring-config.md → maintainer_team_handle`.
+- `<open_question>` — one short sentence describing what is
+  unresolved. The skill drafts this; it must reference the
+  thread, not interpret it.
+- `<ai_attribution_footer>` — same footer as on regular
+  mentoring comments.
+
+```markdown
+<maintainer_team_handle> — handing this off: <open_question>
+
+<ai_attribution_footer>
+```
+
+The skill prints the rendered hand-off and waits for
+maintainer confirmation before posting, the same as for any
+regular comment. It does **not** auto-post hand-offs — a
+mis-rendered hand-off pings a whole team and the cost of an
+unnecessary ping is higher than the cost of a small delay.
+
+After the hand-off posts, the skill records the trigger that
+fired (1 / 2 / 3 / 4) and the thread URL in the audit log,
+then exits. The skill does not return to the thread on a
+later invocation; once handed off, the thread is the
+maintainer's.
+
+---
+
+## What the hand-off comment never contains
+
+- A summary of the thread.
+- A guess at what the maintainer should do next.
+- Apology for handing off ("sorry I couldn't help more").
+- A retry offer ("let me know if I can take another look").
+- An additional convention pointer or doc link beyond the
+  one-line `<open_question>`.
+
+The reason: the maintainer's job in the next message is to
+read the thread and answer the contributor in the maintainer's
+own voice. Anything the agent adds at hand-off time pre-loads
+the maintainer's read of the conversation and is net-negative.

--- a/.claude/skills/pr-management-mentor/tone-checks.md
+++ b/.claude/skills/pr-management-mentor/tone-checks.md
@@ -1,0 +1,71 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Tone checks
+
+Every drafted comment is run through this checklist before it
+is shown to the maintainer. The checks exist to enforce
+[`docs/mentoring/spec.md` § Voice](../../../docs/mentoring/spec.md#voice)
+and [§ Forbidden](../../../docs/mentoring/spec.md#forbidden) at
+runtime, so the maintainer reviews the *intervention*, not the
+register.
+
+A draft that fails any check is revised; if a second revision
+still fails, the skill surfaces the failing rule to the
+maintainer with the offending sentence and asks for guidance —
+it does **not** post a comment that fails tone.
+
+The checks run in order. The first failure stops the run.
+
+---
+
+## Hard fails (the comment cannot be posted)
+
+| # | Rule | Detection |
+|---|---|---|
+| 1 | No praise without specificity. | Reject if the draft contains "great question", "thanks for the contribution", "awesome", "amazing", "fantastic", "love this", or any standalone praise sentence (a sentence whose only content is positive affect). Praise *with* a specific reference ("nice catch on the off-by-one in `foo()`") is fine, but Mode B does not have that information by construction; in practice this rule means: no praise. |
+| 2 | No restating the contributor's message. | Reject if the draft contains "so what you're saying is", "if I understand correctly", "you mentioned that", or any sentence whose content is a paraphrase of the contributor's most recent message. |
+| 3 | No AI self-reference outside the footer. | Reject if the body (everything before `<ai_attribution_footer>`) contains "as an AI", "I'm an AI", "I cannot", "as a language model", "I was trained", "my training", or "I don't have access to". The footer says it once. The body says nothing. |
+| 4 | No speaking for the maintainer. | Reject if the draft contains "the maintainers will probably", "the maintainers want", "the team would prefer", or any forward-looking claim about a maintainer decision. The skill says "a maintainer will reply" and stops. |
+| 5 | No hedging. | Reject if the draft contains "it seems like", "perhaps", "I think maybe", "this might possibly", "I'm not sure but". The pointer is either right or shouldn't be posted. |
+| 6 | One ask per comment. | Reject if the draft contains more than one direct question (counted by `?` outside code blocks) or more than one imperative sentence aimed at the contributor. If the contributor is missing several things, ask as a numbered list, not as separate paragraphs. |
+| 7 | Footer present and verbatim. | Reject if the draft does not end with the literal `<ai_attribution_footer>` expansion from `<project-config>/mentoring-config.md`. Reject if anything follows the footer. |
+| 8 | Author tagged once. | Reject if `@<author>` appears zero times or more than once. The first line tags; the rest of the comment does not. |
+| 9 | No paraphrased docs. | Reject if the body contains a quoted block of more than two lines from a project doc. The convention is link, don't quote. |
+| 10 | No predictions about review outcome. | Reject if the draft contains "looks good", "this should be approved", "this will probably be merged", "I don't think this will land". Mode B does not signal review outcomes. |
+
+---
+
+## Soft fails (revise and re-check)
+
+These do not block posting, but the skill revises once before
+showing the maintainer. They exist to keep the register tight
+without stalling the loop on stylistic preference.
+
+| # | Rule | Detection |
+|---|---|---|
+| 11 | First line states the action. | The first sentence should be a question or imperative directed at the contributor. If it's meta ("I'm reaching out because…"), revise to lead with the action. |
+| 12 | Comment is short. | Soft cap at 6 sentences (excluding the footer). Beyond that, the comment is doing too much — likely violating rule 6. |
+| 13 | Plain English. | Reject jargon the contributor is unlikely to know without the link being clicked. If the draft uses a project-internal term, it should appear inside the linked label, not in prose. |
+| 14 | No exclamation marks outside the footer. | The teaching register is patient, not enthusiastic. Footer can keep them if the configured footer has them; the body does not add new ones. |
+
+---
+
+## Rules that are deliberately not checks
+
+Surfaced so reviewers can push back.
+
+- **Reading level / Flesch score.** Tone is judged by humans
+  in PR review of [`comment-templates.md`](comment-templates.md),
+  not by automated readability scoring. Readability checkers
+  reward different writing for different audiences and would
+  inject style noise that doesn't serve the contributor.
+- **Sentiment analysis.** Same reason. The forbidden-phrase
+  list above is more honest about what we actually want to
+  prevent.
+- **Length cap as hard fail.** Rule 12 is a soft cap because
+  the right length depends on the intervention; a why-question
+  answer can legitimately need a few sentences of context.
+- **Inclusivity / language scan.** Important, but lives in the
+  framework's general writing standards, not in the Mode B
+  tone checks specifically.

--- a/docs/mentoring/README.md
+++ b/docs/mentoring/README.md
@@ -1,0 +1,58 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Mentoring skill family](#mentoring-skill-family)
+  - [Status](#status)
+  - [Adopter contract (proposed)](#adopter-contract-proposed)
+  - [Cross-references](#cross-references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Mentoring skill family
+
+**Status: proposed.** No skill ships yet. The framework lands the
+spec — tone guide, hand-off protocol, adopter contract — ahead
+of any skill code so the project's tone choices are reviewable
+independently of runtime behaviour. See
+[`MISSION.md` § Mode B](../../MISSION.md#technical-scope) for
+the *why*.
+
+Why a framework skill family? Mentoring is named in
+[`MISSION.md`](../../MISSION.md) as the highest-value mode and
+the one off-the-shelf agent tooling skips. Lifting it into the
+framework lets every adopter pick up the tone work and the
+hand-off rules without re-deriving them, and lets the
+framework's contributor-sentiment evaluation cover all adopters
+at once.
+
+## Status
+
+Mode B is **proposed**. No SKILL.md exists yet. This directory
+currently contains:
+
+- [**`spec.md`**](spec.md) — what the future skill should do:
+  scope, triggers, tone, hand-off, adopter knobs.
+
+A prototype skill (`pr-management-mentor`, working name) lands
+in a follow-up PR after this spec is reviewed. The skill ships
+flagged `mode: B` + `experimental` per the
+[mode lifecycle](../modes.md#mode-lifecycle).
+
+## Adopter contract (proposed)
+
+The future skill resolves project-specific content from the
+adopter's `<project-config>/mentoring-config.md` — see the
+template at
+[`projects/_template/mentoring-config.md`](../../projects/_template/mentoring-config.md).
+
+## Cross-references
+
+- [`MISSION.md` § Mode B](../../MISSION.md#technical-scope) —
+  mode definition, RAI empowerment framing.
+- [`docs/modes.md` § Mode B](../modes.md#mode-b--conversational-mentoring) —
+  implementation status.
+- [`spec.md`](spec.md) — full spec.

--- a/docs/mentoring/spec.md
+++ b/docs/mentoring/spec.md
@@ -1,0 +1,218 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Mode B — conversational mentoring (spec)](#mode-b--conversational-mentoring-spec)
+  - [Status](#status)
+  - [Scope](#scope)
+  - [Triggers](#triggers)
+  - [Teaching register — tone guide](#teaching-register--tone-guide)
+    - [Voice](#voice)
+    - [Forbidden](#forbidden)
+    - [AI-attribution footer](#ai-attribution-footer)
+  - [Hand-off protocol](#hand-off-protocol)
+  - [Adopter contract](#adopter-contract)
+  - [Open questions](#open-questions)
+  - [Cross-references](#cross-references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Mode B — conversational mentoring (spec)
+
+## Status
+
+Proposed. No skill code yet. This document defines what Mode B
+should do once it exists; it lands ahead of any skill so the
+project's tone choices and hand-off rules are reviewable
+independently from runtime behaviour. See
+[`MISSION.md` § Mode B](../../MISSION.md#technical-scope) and
+[`docs/modes.md` § Mode B](../modes.md#mode-b--conversational-mentoring)
+for sequencing.
+
+## Scope
+
+Mode B joins issue and PR threads in a teaching register. The
+agent's job is to lower the barrier to a contributor's *next
+useful action*. Concretely, in scope:
+
+- **Clarifying questions** when the contributor's first message
+  is ambiguous (missing repro, missing version, missing intent),
+  so a human reviewer's first read is a productive one.
+- **Pointers to project conventions** with a direct link, when
+  the contributor is missing a piece of repo context they could
+  have found themselves but did not.
+- **Explanation of *why*** a request was made, when the
+  contributor pushes back on a maintainer's review comment ("why
+  does this need a test?", "why split the PR?").
+- **Paired examples from prior PRs** when a similar pattern has
+  shipped before and a one-line link saves the contributor
+  several hours.
+- **Hand-off** to a human when the question exceeds what an
+  agent should answer (architectural taste, security-sensitive
+  design, deprecation timing, anything embargoed).
+
+Out of scope:
+
+- *Reviewing code*. That is Mode A's
+  [`pr-management-code-review`](../../.claude/skills/pr-management-code-review/SKILL.md)
+  skill. Mode B does not approve, request changes, or post inline
+  diff comments.
+- *Triage routing*. That is Mode A's
+  [`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md)
+  skill. Mode B does not assign labels, mark draft, or close PRs.
+- *Authoring fixes*. That is Mode C. Mode B does not open PRs or
+  edit code.
+- *Speaking for the maintainer team* on disputed decisions. Mode
+  B says "a maintainer will weigh in" and stops.
+
+## Triggers
+
+Mode B never posts unprompted on a thread it has not been
+invoked on. The skill is opt-in per invocation. Three trigger
+paths:
+
+1. **Maintainer-on-demand**. A maintainer runs
+   `/pr-management-mentor <pr-number>` (working name). The skill
+   reads the thread, decides whether a mentoring intervention is
+   warranted, drafts the comment, and waits for the maintainer
+   to confirm before posting.
+2. **First-contact filter**. After
+   [`pr-management-triage`](../../.claude/skills/pr-management-triage/SKILL.md)
+   classifies a PR as "first contributor, missing repro" (or
+   equivalent triage flag), the maintainer can chain
+   `/pr-management-mentor` on that PR. The two skills compose;
+   Mode B does not run inside Mode A by default.
+3. **Issue-thread invocation**. Same opt-in, on issues rather
+   than PRs, for the "missing version / missing repro" case.
+
+Why no auto-fire: posting a teaching-register comment without
+explicit human authorization risks the agent talking past a
+maintainer who is mid-conversation with the contributor, or
+posting on a thread where the maintainer has *deliberately* not
+replied yet. Auto-fire is a Mode-D-shaped problem and inherits
+Mode D's sequencing constraint.
+
+## Teaching register — tone guide
+
+The contributor is the audience, not the maintainer. The
+agent's voice is **patient, specific, and short**. It is not
+formal. It does not lecture. It does not perform empathy. The
+reader should leave the comment knowing what to do next, not
+feeling managed.
+
+### Voice
+
+- **First line states the action**, not the meta. "Could you add
+  the version you're running? Find it via …" not "I noticed
+  your issue and would love to help by asking a clarifying
+  question."
+- **Link, don't quote**. Pointers to docs go as a single inline
+  link with a short label. Do not paste the docs back at the
+  contributor.
+- **One ask per comment**. If the contributor is missing three
+  things, ask for them as a numbered list, not three sequential
+  paragraphs.
+- **No hedging**. "This is a known pattern, see PR #1234" not
+  "It seems like this might possibly be similar to PR #1234,
+  although I'm not certain". The hedge tax falls on the
+  contributor, who then has to decide how seriously to take the
+  pointer.
+
+### Forbidden
+
+- Praise without specificity. "Great question!" and "Thanks for
+  the contribution!" are noise. They train the contributor to
+  skim.
+- Restating the contributor's message back to them. "So what
+  you're saying is …" — the contributor knows what they said.
+- AI self-reference outside the attribution footer. The footer
+  says it once; the body should not.
+- Speaking for the maintainer. "The maintainers will probably
+  want X" — Mode B does not predict maintainer decisions. It
+  says "a maintainer will reply on this; in the meantime,
+  here's the convention" and stops.
+
+### AI-attribution footer
+
+Every contributor-facing comment ends with the same footer
+convention used by
+[`pr-management-triage/comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md),
+adjusted to name the mentoring step rather than the triage
+step. The expansion lives in the adopter's
+`<project-config>/mentoring-config.md → ai_attribution_footer`.
+
+The footer is non-negotiable: it calibrates the contributor's
+trust (AI-drafted, may be wrong) and points at the project's
+documented two-stage process.
+
+## Hand-off protocol
+
+The agent bows out and pings a human when:
+
+1. The contributor pushes back on a substantive design point.
+   Mode B answers "why is this convention" once. If the
+   contributor disagrees, Mode B does not argue; it pings the
+   maintainer.
+2. The question touches security, embargoed work, deprecation
+   timing, or anything not covered by public documentation.
+   Mode B does not improvise on these surfaces.
+3. The thread reaches `<max_agent_turns>` (configurable, default
+   2). After that the agent stops engaging on the thread
+   regardless of content.
+4. The contributor explicitly asks for a human ("can a
+   maintainer look at this?").
+
+The hand-off is one comment: a `@`-mention of the configured
+maintainer team, a one-line summary of the open question, and
+the agent's silence afterwards. The agent does not summarise
+the conversation; the maintainer reads the thread.
+
+## Adopter contract
+
+Per-project values live in `<project-config>/mentoring-config.md`.
+See the template at
+[`projects/_template/mentoring-config.md`](../../projects/_template/mentoring-config.md).
+Required keys:
+
+| Key | Purpose |
+|---|---|
+| `mentoring_invocation_command` | Slash-command name (e.g. `/pr-management-mentor`). |
+| `maintainer_team_handle` | `@<org>/<team>` mentioned on hand-off. |
+| `ai_attribution_footer` | Literal footer markdown. Mirrors the triage-footer convention. |
+| `convention_pointers` | Table of `{trigger phrase} → {docs link, one-line label}` so the agent links rather than paraphrases. |
+| `max_agent_turns` | Integer, default 2. Hard ceiling on consecutive agent comments per thread. |
+| `out_of_scope_topics` | Explicit list of topics on which the agent always hands off (security, deprecation, license, etc.). |
+
+## Open questions
+
+Surfaced here so reviewers can weigh in before the skill is
+built.
+
+- **Should Mode B post on the project's mailing list, or only
+  on GitHub threads?** Current draft: GitHub only. Mailing-list
+  mentoring lives in the human maintainer's voice; the agent
+  does not have a list-subscriber identity.
+- **Is the AI-attribution footer the same wording as the triage
+  footer, or distinct?** Current draft: same wording, different
+  step token. One contributor-trust calibration is easier to
+  reason about than two.
+- **Should the maintainer review every Mode B draft, or can
+  they pre-authorize a class of comments (e.g., "always ok to
+  ask for repro")?** Current draft: every draft is reviewed.
+  Pre-authorization is Mode-D-shaped and inherits the same
+  sequencing constraint.
+
+## Cross-references
+
+- [`MISSION.md` § Mode B](../../MISSION.md#technical-scope) —
+  the mode definition + responsible-AI framing.
+- [`docs/modes.md` § Mode B](../modes.md#mode-b--conversational-mentoring) —
+  current implementation status (proposed).
+- [`.claude/skills/pr-management-triage/comment-templates.md`](../../.claude/skills/pr-management-triage/comment-templates.md) —
+  closest existing surface; informs the tone-footer convention
+  but is not Mode B.
+- [`AGENTS.md`](../../AGENTS.md) — repository-level rules every
+  mode inherits.

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -93,10 +93,20 @@ Two notes on the boundaries:
 
 [`MISSION.md` § Mode B](../MISSION.md#technical-scope) names this
 the highest-value mode and the one off-the-shelf agent tooling
-skips. Implementation is tracked as future work; spec, tone
-guide, and adopter configuration template land in a follow-up
-PR before any skill code, so the project's tone choices are
-reviewable independently from the runtime behaviour.
+skips. Per MISSION sequencing, the spec — tone guide, hand-off
+protocol, adopter contract — lands ahead of any skill code so
+the project's tone choices are reviewable independently from
+the runtime behaviour.
+
+| Doc | Purpose |
+|---|---|
+| [`docs/mentoring/README.md`](mentoring/README.md) | Family overview, current status, planned shape. |
+| [`docs/mentoring/spec.md`](mentoring/spec.md) | What the future skill should do: scope, triggers, register, hand-off, adopter knobs. |
+| [`projects/_template/mentoring-config.md`](../projects/_template/mentoring-config.md) | Adopter-config scaffold the future skill will read. |
+
+A prototype skill (`pr-management-mentor`, working name) lands
+in a follow-up PR after the spec is reviewed; it ships flagged
+`mode: B` + `experimental`.
 
 The closest existing surface is
 [`pr-management-triage/comment-templates.md`](../.claude/skills/pr-management-triage/comment-templates.md),

--- a/projects/_template/mentoring-config.md
+++ b/projects/_template/mentoring-config.md
@@ -41,8 +41,8 @@ link the comment should reference instead of paraphrasing.
 | Trigger | Link | One-line label |
 |---|---|---|
 | Missing version on bug report | https://airflow.apache.org/docs/apache-airflow/stable/start.html | "How to find your Airflow version" |
-| Missing repro | https://github.com/apache/airflow/blob/main/contributing-docs/quick-start.rst | "Quick-start for reproducing" |
-| First-time contributor PR setup | https://github.com/apache/airflow/blob/main/contributing-docs/02_how_to_pull_request.rst | "How to open a PR" |
+| Missing repro | https://github.com/apache/airflow/blob/main/contributing-docs/03_contributors_quick_start.rst | "Contributors quick start" |
+| First-time contributor PR setup | https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst | "How to open a PR" |
 
 ## Out-of-scope topics
 

--- a/projects/_template/mentoring-config.md
+++ b/projects/_template/mentoring-config.md
@@ -1,0 +1,66 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Apache Airflow — mentoring (Mode B) configuration](#apache-airflow--mentoring-mode-b-configuration)
+  - [Identifiers](#identifiers)
+  - [Convention pointers](#convention-pointers)
+  - [Out-of-scope topics](#out-of-scope-topics)
+  - [AI-attribution footer](#ai-attribution-footer)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Apache Airflow — mentoring (Mode B) configuration
+
+**This file is a placeholder ahead of the Mode B skill landing.**
+The skill does not exist yet (Mode B is proposed per
+[`docs/modes.md`](../../docs/modes.md#mode-b--conversational-mentoring)).
+The keys below match the
+[Mode B spec](../../docs/mentoring/spec.md#adopter-contract)
+and are the values the future skill will read. New adopters
+should copy this file into their own
+`<project-config>/mentoring-config.md` and replace every
+Airflow-specific value with their project's equivalents.
+
+## Identifiers
+
+| Key | Value |
+|---|---|
+| `mentoring_invocation_command` | `/pr-management-mentor` |
+| `maintainer_team_handle` | `@apache/airflow-committers` |
+| `max_agent_turns` | `2` |
+
+## Convention pointers
+
+Triggers that the future skill will detect, mapped to the docs
+link the comment should reference instead of paraphrasing.
+
+| Trigger | Link | One-line label |
+|---|---|---|
+| Missing version on bug report | https://airflow.apache.org/docs/apache-airflow/stable/start.html | "How to find your Airflow version" |
+| Missing repro | https://github.com/apache/airflow/blob/main/contributing-docs/quick-start.rst | "Quick-start for reproducing" |
+| First-time contributor PR setup | https://github.com/apache/airflow/blob/main/contributing-docs/02_how_to_pull_request.rst | "How to open a PR" |
+
+## Out-of-scope topics
+
+The skill always hands off to a human when the thread touches:
+
+- Security-sensitive design (CVE-adjacent, embargoed work)
+- Deprecation timing (which release will drop X)
+- License questions (compatibility, header policy)
+- Provider-specific architectural taste
+
+## AI-attribution footer
+
+```markdown
+---
+
+_Note: This comment was drafted by an AI-assisted mentoring tool and may contain mistakes. Once you have addressed the points above, an Apache Airflow maintainer — a real person — will take the next look. We use this [two-stage process](https://github.com/apache/airflow/blob/main/PROCESS.md) so that our maintainers' limited time is spent where it matters most: the conversation with you._
+```
+
+Replace the two-stage-process URL with the project's documented
+mentoring/triage policy. Replace `Apache Airflow` with the
+project name.


### PR DESCRIPTION
Stacked on top of #63 — diff here includes the 2 commits from `feat/mentoring-spec` plus 1 new commit (`4bb5151`). Once #63 lands I'll rebase and the diff collapses to the skill commit alone.

First skill against the Mode B spec from #63. Ships flagged `mode: B` + experimental per the [mode lifecycle](docs/modes.md#mode-lifecycle). The point of having a skill this early isn't to declare Mode B done; it's to make the spec executable on one thread at a time so we can find out what tone wording, convention pointers, and hand-off triggers actually need before hardening the contract.

Adds [`.claude/skills/pr-management-mentor/`](.claude/skills/pr-management-mentor/) with:

- [`SKILL.md`](.claude/skills/pr-management-mentor/SKILL.md) — the runtime. One thread per invocation, ten steps, one comment in / one decision out. Reads `<project-config>/mentoring-config.md` for the per-project knobs, and consults `.apache-steward-overrides/pr-management-mentor.md` if the adopter has one.
- [`comment-templates.md`](.claude/skills/pr-management-mentor/comment-templates.md) — verbatim bodies for the four interventions the spec names: missing-repro, missing-version, convention-pointer, why-question. The skill links rather than paraphrases.
- [`tone-checks.md`](.claude/skills/pr-management-mentor/tone-checks.md) — the pre-post checklist that enforces the spec's voice rules. Every draft walks the list before the maintainer ever sees it.
- [`hand-off.md`](.claude/skills/pr-management-mentor/hand-off.md) — the one-line `@<team>` hand-off and the four conditions that fire it (max turns, contributor push-back, out-of-scope mid-thread, explicit human ask).

The runtime is deliberately short. Resolve config, fetch the thread (capped at the last `max_agent_turns + 5` comments — older context isn't the audience), check whether the thread is out of Mode B scope, check whether a maintainer is already engaging (the agent doesn't talk over a human reviewer), match the thread against the configured `convention_pointers` triggers. If exactly one fires, draft from the matching template, append the AI-attribution footer, run the tone checks, show it to the maintainer, post on explicit `yes` only. If none fire, exit silently. Silence on a thread that doesn't need an intervention is a feature.

What this skill does not do, just to spell it out: no diff comments, no approvals, no labels, no draft toggles, no closes, no PRs opened, no predicting maintainer decisions, no mailing-list comments, no auto-fire. Each one of those is either Mode A (triage / review), Mode C (authoring), or Mode-D-shaped (auto-fire, which inherits Mode D's sequencing constraint and stays off).

Audit log shape (step 10) is currently a stub. Leaning toward wiring it up properly in a follow-up so this PR stays scoped to "the spec, but executable".