### PR TITLE
fix(privacy-llm-redactor): correct --field help text and force UTF-8 mapping reads

### DIFF
--- a/tools/privacy-llm/redactor/src/redactor/mapping.py
+++ b/tools/privacy-llm/redactor/src/redactor/mapping.py
@@ -90,7 +90,7 @@ def load_mapping(path: pathlib.Path) -> dict[str, Entry]:
     """
     if not path.exists():
         return {}
-    raw = json.loads(path.read_text())
+    raw = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(raw, dict):
         raise ValueError(f"{path}: expected a JSON object at the top level")
     version = raw.get("version")

--- a/tools/privacy-llm/redactor/src/redactor/redact.py
+++ b/tools/privacy-llm/redactor/src/redactor/redact.py
@@ -130,7 +130,7 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "PII to redact, declared as type:value. "
             "Repeat for each field. Type is one of: "
-            "reporter, email, phone, ip, handle, address (or codes R, E, P, IP, H, A)."
+            "name, email, phone, ip, handle, address (or codes N, E, P, IP, H, A)."
         ),
     )
     parser.add_argument(

--- a/tools/privacy-llm/redactor/tests/test_mapping.py
+++ b/tools/privacy-llm/redactor/tests/test_mapping.py
@@ -148,6 +148,23 @@ def test_save_and_load_round_trip(tmp_path: pathlib.Path):
     assert loaded == mapping
 
 
+def test_load_round_trips_non_ascii_values(tmp_path: pathlib.Path):
+    """Non-ASCII PII values must survive a save/load round-trip.
+
+    Regression: ``load_mapping`` read the file with the locale-default
+    encoding while ``save_mapping_atomic`` writes UTF-8, corrupting
+    non-ASCII values (accented names, IDN domains) on non-UTF-8 hosts.
+    """
+    path = tmp_path / "pii.json"
+    mapping: dict[str, Entry] = {}
+    upsert(mapping, "N", "José Müller")
+    upsert(mapping, "E", "renée@exámple.com")
+
+    save_mapping_atomic(path, mapping)
+    loaded = load_mapping(path)
+    assert loaded == mapping
+
+
 def test_save_creates_parent_dir(tmp_path: pathlib.Path):
     path = tmp_path / "deeper" / "nested" / "pii.json"
     mapping: dict[str, Entry] = {}

--- a/tools/privacy-llm/redactor/tests/test_redact.py
+++ b/tools/privacy-llm/redactor/tests/test_redact.py
@@ -77,6 +77,23 @@ def test_parse_field_rejects_empty_value():
         redact.parse_field("name:")
 
 
+def test_field_help_text_lists_real_type_names(monkeypatch):
+    """The ``--field`` help must name types the parser accepts.
+
+    Regression: the help listed ``reporter`` / code ``R``, neither of
+    which exists. A user copying the help got ``SystemExit`` and their
+    PII flowed to the LLM unredacted.
+    """
+    stdout = io.StringIO()
+    monkeypatch.setattr("sys.stdout", stdout)
+    with pytest.raises(SystemExit):
+        redact.main(["--help"])
+    # argparse wraps the help line; collapse whitespace before matching.
+    help_text = " ".join(stdout.getvalue().split())
+    assert "reporter" not in help_text
+    assert "name, email, phone, ip, handle, address" in help_text
+
+
 # -- end-to-end redaction ------------------------------------------------
 
 
@@ -102,7 +119,7 @@ def test_redact_persists_mapping(mapping_path, monkeypatch):
     )
     assert rc == 0
     mapping = load_mapping(mapping_path)
-    # Exactly one entry, of type reporter, value "Jane Smith".
+    # Exactly one entry, of type name, value "Jane Smith".
     assert len(mapping) == 1
     [entry] = mapping.values()
     assert entry.type == "name"


### PR DESCRIPTION
## What

Fixes two critical correctness bugs in the `privacy-llm/redactor` package, surfaced by a code review.

### 1. `--field` help text lists type names the parser rejects

`redact.py` advertised `reporter` and code `R` in the `--field` help. Neither exists. The valid types come from `TYPE_CODES` in `mapping.py`: `name/email/phone/ip/handle/address`, codes `N/E/P/IP/H/A`.

A user copying the documented form (`--field reporter:Jane Smith` or `--field R:Jane Smith`) got a `SystemExit` and their PII flowed to the LLM unredacted. Help text now lists the real names and codes.

### 2. `load_mapping` reads with the locale-default encoding

`load_mapping` used `path.read_text()` with no `encoding`, which resolves to `locale.getpreferredencoding(False)` (e.g. `cp1252` on Windows). But `save_mapping_atomic` writes the file as UTF-8. On any non-UTF-8 host this corrupts non-ASCII PII values (accented names, IDN domains) on the save/load round-trip, so `pii-reveal` substitutes the wrong text.

`load_mapping` now reads with `encoding="utf-8"`, matching the writer.

## Changes

- `src/redactor/redact.py` — `--field` help text: `reporter/R` → `name/N`
- `src/redactor/mapping.py` — `load_mapping` reads `encoding="utf-8"`
- `tests/test_redact.py` — regression test on the `--help` output
- `tests/test_mapping.py` — regression test for a non-ASCII round-trip

## Validation

- `pytest`: 53 passed
- `ruff check` / `ruff format` / `mypy`: clean
- `prek`: all hooks pass