### PR TITLE
docs(mode-economics): fix internal inconsistency and amortisation basis

### DIFF
--- a/docs/mode-economics.md
+++ b/docs/mode-economics.md
@@ -201,7 +201,7 @@ per-token billing to hardware:
 
 | Inference path | Per-token cost | Typical hardware cost | Notes |
 |---|---|---|---|
-| Consumer GPU, Small-class quantised model | $0 | ~$0.10–0.50/hr amortised | Viable for Triage and short Mentoring/Drafting |
+| Consumer GPU, Small-class quantised model | $0 | ~$0.10–0.50/hr (capex amortised over ~3 yr lifespan × moderate utilisation) | Viable for Triage and short Mentoring/Drafting |
 | Cloud spot GPU, Mid-tier model | $0 | ~$1–4/hr depending on GPU class | Viable for all modes; latency is higher than hosted APIs |
 | CPU-only, quantised Small model | $0 | Near-zero | Very slow; not recommended for interactive Pairing |
 
@@ -223,9 +223,14 @@ paths use identical skill code to hosted paths.
    skill read only what is relevant.
 
 3. **Cache skill context.** Most agent CLIs support prompt-level
-   caching. The skill file (3 000–6 000 tokens) and stable project
-   configuration files are ideal cache candidates — the first invocation
-   pays; subsequent invocations are cheap on the cached portion.
+   caching. The skill file (size varies by skill class; see
+   [What "tokens" means here](#what-tokens-means-here)) and stable
+   project configuration files are ideal cache candidates — the first
+   invocation pays; subsequent invocations are cheap on the cached
+   portion. Note: most provider caches have a short TTL (Anthropic
+   prompt cache: 5 min default, 1 h extended at higher write cost),
+   so bursty same-session workloads benefit most; periodic triage runs
+   spaced hours apart will typically miss the cache.
 
 4. **Batch triage.** `issue-reassess` and `pr-management-stats`
    amortise context load across a pool. Running them weekly rather than


### PR DESCRIPTION
## Summary

Three small corrections to `docs/mode-economics.md`, all confined to the existing **Reducing costs** and **Local and self-hosted inference** sections. No new claims, no methodology changes, no new rows — only tightening claims already on the page.

1. **Cache section referenced a pre-correction anchor.** Item 3 ("Cache skill context") said _"The skill file (3 000–6 000 tokens) and stable project configuration files are ideal cache candidates"_. That `3 000–6 000` figure is the same anchor the PR description of #253 explicitly flagged as wrong and corrected elsewhere on the page — the **What \"tokens\" means here** table now reports measured ranges:

   | Skill class | Range |
   |---|---|
   | small setup/utility | ~1 000–3 000 |
   | typical workflow | ~3 500–9 000 (median ~5 300) |
   | large multi-step security | ~11 000–36 000 |

   The inline figure in the cache item was never updated, so the page contradicted itself. Replace the figure with a pointer to the corrected anchor.

2. **Cache TTL caveat (same paragraph).** The pattern \"first invocation pays; subsequent invocations cheap\" is real for bursty same-session workloads but typically misses for the periodic / day-spaced workloads listed in the per-mode tables above (Anthropic prompt cache TTL: 5 min default, 1 h extended at higher write cost). One sentence flagging the constraint avoids the footgun.

3. **Local-inference table: amortisation needed a denominator.** The Consumer-GPU row listed `~\$0.10–0.50/hr amortised` with no basis. \"Amortised\" without capex / lifespan / utilisation is uninterpretable. Inline the assumption (`capex amortised over ~3 yr lifespan × moderate utilisation`) so a reader can sanity-check the range against their own hardware.

## Out of scope (intentionally)

The page still has broader gaps that I think deserve discussion, not a unilateral edit: a measurement-date / coverage / tokenizer banner, splitting measured-vs-planned rows in the per-mode tables, p50 anchors on the wide ranges, a date stamp on the cross-class multipliers. I'll open a separate issue for those so #281's eval harness can inform the answers rather than my picking them in isolation.

## Test plan

- [x] `markdownlint` / `doctoc` / `typos` clean locally (only edits are in-paragraph text; no new anchors, ToC unchanged).
- [x] Internal anchor `#what-tokens-means-here` resolves to the existing section heading on the same page.
- [x] Diff is 9 lines added / 4 removed, scoped to a single file.