### PR TITLE
fix(spec-validator): add dev dependency group and fix check-#9 comment

### DIFF
--- a/tools/spec-validator/pyproject.toml
+++ b/tools/spec-validator/pyproject.toml
@@ -46,6 +46,12 @@ ignore = ["E501"]
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["B", "SIM"]
 
+[dependency-groups]
+dev = [
+  "pytest>=8.0",
+  "ruff>=0.4",
+]
+
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra -q"

--- a/tools/spec-validator/src/spec_validator/__init__.py
+++ b/tools/spec-validator/src/spec_validator/__init__.py
@@ -40,7 +40,7 @@ Files without frontmatter (README.md, overview.md) are skipped silently.
 
 Run from repo root::
 
-    uv run --project tools/spec-validator --group dev pytest
+    uv run --project tools/spec-validator --group dev pytest tools/spec-validator/tests/
     uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/
 """
 
@@ -82,7 +82,7 @@ _FENCED_CODE_RE = re.compile(r"^ {0,3}```[\s\S]*?^ {0,3}```", re.MULTILINE)
 _YAML_BLOCK_SCALAR_HEADERS: frozenset[str] = frozenset({"|", ">", "|-", "|+", ">-", ">+"})
 
 # ---------------------------------------------------------------------------
-# Validation-path check constants (check #8)
+# Validation-path check constants (check #9)
 # ---------------------------------------------------------------------------
 
 # Patterns that extract filesystem paths from shell validation commands.

--- a/uv.lock
+++ b/uv.lock
@@ -803,6 +803,20 @@ name = "spec-validator"
 version = "0.1.0"
 source = { editable = "tools/spec-validator" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "ruff", specifier = ">=0.4" },
+]
+
 [[package]]
 name = "typing-extensions"
 version = "4.15.0"


### PR DESCRIPTION
## Summary

Add [dependency-groups] dev = [pytest, ruff] to
tools/spec-validator/pyproject.toml so that the standard monorepo invocation
  uv run --project tools/spec-validator --group dev pytest tools/spec-validator/tests/
works from the repo root, matching the pattern established by tools/skill-and-tool-validator (asf-coupling-lint) and documented in the module docstring.

Also fix a copy-paste comment mislabelling check #9 (validation-path existence as check #8 — SPDX header validation is check #8.

Generated-by: Claude (Opus 4.7)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other:

## Test plan

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other: