### PR TITLE
docs(spec): correct stale eval-coverage Known Gap in meta-and-quality-tooling

### DIFF
--- a/tools/spec-loop/specs/meta-and-quality-tooling.md
+++ b/tools/spec-loop/specs/meta-and-quality-tooling.md
@@ -82,9 +82,10 @@ uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-valid
 
 ## Known gaps
 
-- **Eval coverage is incomplete** — the harness has ~15 suites but the
-  repo has more skills than that; skills added before the per-skill-eval
-  convention have no suite. Back-filling one suite per uncovered skill is
-  a tracked work item.
-- Other gaps appear as new quality checks worth adding (e.g. a spec
-  validator analogous to the skill validator) — recorded by the plan pass.
+- **Eval coverage is complete.** All 44 shipped skills have a matching
+  suite in `tools/skill-evals/evals/`; the soft eval-coverage check in
+  `skill-and-tool-validator` (check #8) warns when a newly added skill
+  has no suite, keeping coverage complete going forward.
+- Other gaps appear as new quality checks worth adding — recorded by the
+  plan pass. The spec validator (analogous to the skill validator) and
+  the ASF-coupling advisory lint are two recent additions to this surface.


### PR DESCRIPTION
## Summary

The Known Gaps section claimed "~15 suites, coverage incomplete". All 44 shipped skills now have a matching suite in tools/skill-evals/evals/; the soft eval-coverage check (check #8) in skill-and-tool-validator enforces this going forward. Remove the stale back-fill claim and state the actual coverage.

Generated-by: Claude (Opus 4.7)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
