### PR TITLE
docs(release-management): sync family README to reflect release-announce-draft shipped

### DIFF
--- a/docs/release-management/README.md
+++ b/docs/release-management/README.md
@@ -66,16 +66,20 @@ for the full backend table and per-step mapping.
 
 ## Status
 
-**Proposed.** No `release-*` skill code exists in the framework
-today. This family lands as docs first (this README, the 14-step
+**Experimental (1 of 10 skills shipped).**
+[`release-announce-draft`](../../skills/release-announce-draft/SKILL.md)
+(Step 11, `[ANNOUNCE]` email draft + site-bump PR) landed as
+`experimental` in #512. The remaining nine skills follow in
+subsequent PRs, each flagged `experimental` and tracked in
+[`docs/modes.md`](../modes.md).
+
+The family landed as docs first (this README, the 14-step
 [`process.md`](process.md), the per-skill [`spec.md`](spec.md), and
 the adopter scaffold
 [`projects/_template/release-management-config.md`](../../projects/_template/release-management-config.md))
 so the lifecycle, the state-change boundaries, and the adopter
 contract are reviewable independently from runtime behaviour.
-The skills follow in subsequent PRs, each shipped flagged
-`experimental` and tracked in [`docs/modes.md`](../modes.md). This
-pattern matches [Mentoring](../mentoring/README.md).
+This pattern matches [Mentoring](../mentoring/README.md).
 
 Promotion of any skill in this family from `experimental` to
 default-on, or from Drafting to a state-changing lane, requires
@@ -97,18 +101,18 @@ the lifecycle step(s) it owns. Read [`spec.md`](spec.md) for the
 per-skill state-change boundary; read [`process.md`](process.md)
 for the step it executes against.
 
-| Skill | Mode | Steps owned | Purpose |
-|---|---|---|---|
-| `release-prepare` | Drafting | 1, 2, 14 | Open the planning issue, draft the version-bump + changelog + NOTICE/LICENSE PR, then draft the post-release `-SNAPSHOT` bump. |
-| `release-keys-sync` | Drafting | 3 | Draft the `KEYS` diff for a Release Manager cutting their first release for the project. Agent never holds the private key. |
-| `release-rc-cut` | Drafting | 4, 5 | Emit the paste-ready command sequence, signed tag, build, detached signatures, checksums, `svn` import to `dist/dev/<project>/`. Agent never signs and never imports. |
-| `release-verify-rc` | Triage / Pairing | 6 | Read-only pre-flight: signatures against the project's `KEYS`, checksums, license headers (Apache RAT), NOTICE/LICENSE presence, no prohibited binaries, version-string consistency. Voters can run it in their own dev loop before posting `+1`. |
-| `release-vote-draft` | Drafting | 7 | Draft the `[VOTE]` email body to `dev@<project>`. Agent never sends. |
-| `release-vote-tally` | Triage | 9 | Parse the vote thread, classify each reply (+1 / 0 / -1) binding vs non-binding against the PMC roster, propose `[RESULT] [VOTE]`. Conservative on ambiguous votes, refuses to count, flags `AMBIGUOUS, needs RM call`. |
-| `release-promote` | Drafting | 10 | Emit the paste-ready `svn mv dist/dev → dist/release` command set plus commit message. Agent never moves; the human commit is the act of release. |
-| `release-announce-draft` | Drafting | 11 | Draft the `[ANNOUNCE]` email body to `announce@apache.org` and the site-bump PR (download page, release notes, version banner). Agent never sends mail and never merges the site PR. |
-| `release-archive-sweep` | Triage | 12 | Scan `dist/release/<project>/`, identify releases past retention, propose the `svn mv` sequence to `archive.apache.org`. Agent never moves. |
-| `release-audit-report` | Triage (dashboard) | 13 | Read-only structured report per release, RM, voters with binding flags, artefacts with sigs and checksums, promotion revision, `[ANNOUNCE]` archive URL. Output appended to the project's audit log. |
+| Skill | Mode | Steps owned | Status | Purpose |
+|---|---|---|---|---|
+| `release-prepare` | Drafting | 1, 2, 14 | proposed | Open the planning issue, draft the version-bump + changelog + NOTICE/LICENSE PR, then draft the post-release `-SNAPSHOT` bump. |
+| `release-keys-sync` | Drafting | 3 | proposed | Draft the `KEYS` diff for a Release Manager cutting their first release for the project. Agent never holds the private key. |
+| `release-rc-cut` | Drafting | 4, 5 | proposed | Emit the paste-ready command sequence, signed tag, build, detached signatures, checksums, `svn` import to `dist/dev/<project>/`. Agent never signs and never imports. |
+| `release-verify-rc` | Triage / Pairing | 6 | proposed | Read-only pre-flight: signatures against the project's `KEYS`, checksums, license headers (Apache RAT), NOTICE/LICENSE presence, no prohibited binaries, version-string consistency. Voters can run it in their own dev loop before posting `+1`. |
+| `release-vote-draft` | Drafting | 7 | proposed | Draft the `[VOTE]` email body to `dev@<project>`. Agent never sends. |
+| `release-vote-tally` | Triage | 9 | proposed | Parse the vote thread, classify each reply (+1 / 0 / -1) binding vs non-binding against the PMC roster, propose `[RESULT] [VOTE]`. Conservative on ambiguous votes, refuses to count, flags `AMBIGUOUS, needs RM call`. |
+| `release-promote` | Drafting | 10 | proposed | Emit the paste-ready `svn mv dist/dev → dist/release` command set plus commit message. Agent never moves; the human commit is the act of release. |
+| [`release-announce-draft`](../../skills/release-announce-draft/SKILL.md) | Drafting | 11 | **experimental** | Draft the `[ANNOUNCE]` email body to `announce@apache.org` and the site-bump PR (download page, release notes, version banner). Agent never sends mail and never merges the site PR. |
+| `release-archive-sweep` | Triage | 12 | proposed | Scan `dist/release/<project>/`, identify releases past retention, propose the `svn mv` sequence to `archive.apache.org`. Agent never moves. |
+| `release-audit-report` | Triage (dashboard) | 13 | proposed | Read-only structured report per release, RM, voters with binding flags, artefacts with sigs and checksums, promotion revision, `[ANNOUNCE]` archive URL. Output appended to the project's audit log. |
 
 Two non-negotiable boundaries cross every Drafting skill above:
 
@@ -173,8 +177,9 @@ file-by-file index. Required at minimum:
 Release-management is a **family**, not a mode. The lifecycle
 spans the existing Triage and Drafting modes; no new mode is
 introduced. See [`docs/modes.md`](../modes.md) for the
-family-by-mode breakdown, `release-*` skills appear under the
-**Triage** and **Drafting** subsections, each marked `proposed`.
+family-by-mode breakdown; `release-*` skills appear under the
+**Triage** and **Drafting** subsections (`release-announce-draft`
+is now `experimental`; the remaining nine remain `proposed`).
 
 The family's read-only dashboard skill
 (`release-audit-report`)

--- a/tools/spec-loop/.pr-body-release-management-docs-sync.md
+++ b/tools/spec-loop/.pr-body-release-management-docs-sync.md
@@ -1,0 +1,16 @@
+## Summary
+
+- `docs/release-management/README.md` Status section still said "No `release-*` skill code exists in the framework today" despite `release-announce-draft` shipping as experimental in #512.
+- Promote Status from **Proposed** to **Experimental (1 of 10 skills shipped)** with a direct link to the skill file.
+- Add a Status column to the Skills table so per-skill maturity is visible at a glance; mark nine skills `proposed` and `release-announce-draft` **experimental**.
+- Update the Mode mapping paragraph which said "each marked `proposed`" to reflect that `release-announce-draft` is now `experimental`.
+
+## Test plan
+
+- [ ] `test -f docs/release-management/spec.md` passes
+- [ ] `test -f docs/release-management/process.md` passes
+- [ ] `test -f projects/_template/release-management-config.md` passes
+- [ ] `uv run --project tools/skill-and-tool-validator skill-and-tool-validate` produces no hard errors (86 pre-existing SOFT ASF-coupling advisories only)
+- [ ] Link `../../skills/release-announce-draft/SKILL.md` resolves (skill shipped in #512)
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PR DESCRIPTION
## Summary

`release-announce-draft` (Step 11, [ANNOUNCE] email + site-bump PR) landed as experimental in #512, but docs/release-management/README.md still said "No release-* skill code exists in the framework today."

- Promote Status from "Proposed" to "Experimental (1 of 10 skills shipped)"; add a direct link to the skill file.
- Add a Status column to the Skills table so per-skill maturity is visible at a glance; nine skills remain proposed, release- announce-draft is now experimental.
- Update the Mode mapping paragraph ("each marked proposed") to acknowledge that release-announce-draft is now experimental.

Generated-by: Claude (Opus 4.7)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other: