### PR TITLE
docs(spec): sync security-issue-lifecycle to reflect -from-scan and -via-forwarder skills

### DIFF
--- a/tools/spec-loop/specs/security-issue-lifecycle.md
+++ b/tools/spec-loop/specs/security-issue-lifecycle.md
@@ -29,10 +29,20 @@ publication, with a human gate and an audit-log entry at every step.
 
 ## Where it lives
 
-- Skills: `security-issue-import` (+ `-from-pr`, `-from-md`),
+- Skills: `security-issue-import` (+ `-from-pr`, `-from-md`,
+  `-from-scan`, `-via-forwarder`),
   `security-issue-triage`, `security-issue-deduplicate`,
   `security-cve-allocate`, `security-issue-fix`, `security-issue-sync`,
   `security-issue-invalidate`.
+  `security-issue-import-from-scan` is the scanner on-ramp: it ingests
+  multi-finding scan output through a pluggable scan-format adapter
+  (`tools/scan-format/`), buckets each finding for operator review, and
+  creates trackers only after per-finding confirmation.
+  `security-issue-import-via-forwarder` is the relay sub-skill: handles
+  reports relayed by an upstream broker (ASF security team or a
+  third-party disclosure platform) by applying preamble-detect,
+  credit-extract, and routing rules declared in
+  `tools/forwarder-relay/`; never mutates tracker state on its own.
 - Tools: `tools/cve-tool-vulnogram/generate-cve-json` (CVE 5.x JSON),
   `tools/cve-org`, `tools/gmail` + `tools/ponymail` (mail), and the
   `tools/privacy-llm` gate/redactor ([the privacy gate](privacy-llm-gate.md)).


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

`security-issue-import-from-scan` (scanner on-ramp via pluggable scan-format adapter) and `security-issue-import-via-forwarder` (relay sub-skill for upstream-broker reports) both ship on main but were absent from the spec skill inventory.

Generated-by: Claude (Opus 4.7)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
