### PR TITLE
ci: add skill-and-tool validator workflow

### DIFF
--- a/.github/workflows/skill-and-tool-validator.yml
+++ b/.github/workflows/skill-and-tool-validator.yml
@@ -1,0 +1,58 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+---
+name: skill-and-tool-validator
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    paths:
+      - "skills/**"
+      - ".claude/skills/**"
+      - "tools/skill-and-tool-validator/**"
+      - ".github/workflows/skill-and-tool-validator.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/**"
+      - ".claude/skills/**"
+      - "tools/skill-and-tool-validator/**"
+      - ".github/workflows/skill-and-tool-validator.yml"
+
+permissions: {}
+
+jobs:
+  skill-and-tool-validator:
+    name: validate skills and tool contracts
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      FORCE_COLOR: "1"
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
+        with:
+          enable-cache: true
+      # Sync every workspace member so the validator's
+      # `[project.scripts]` entry point is available from the repo root.
+      - name: Sync workspace
+        run: uv sync --all-packages --group dev
+      - name: Run skill-and-tool-validator
+        run: uv run skill-and-tool-validate


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/skill-and-tool-validator.yml` for skill and validator changes.
- Mirrors the existing hardened workflow pattern with pinned actions, `persist-credentials: false`, and minimal permissions.
- Runs `uv sync --all-packages --group dev` before `uv run skill-and-tool-validate` so the validator entry point is available from the repo root.

Fixes #350

## Test plan

- `actionlint .github/workflows/skill-and-tool-validator.yml`
- `uv sync --all-packages --group dev && uv run skill-and-tool-validate`
  - Passed with existing SOFT advisory warnings only.
- `uv run --directory tools/skill-and-tool-validator pytest`
  - `258 passed in 1.41s`
- `uv run prek run --files .github/workflows/skill-and-tool-validator.yml`

Not run: `uv run prek run --all-files` did not finish locally after roughly two minutes with no output, so I stopped it after the targeted workflow and validator checks above passed.
