### PR TITLE
docs(vulnogram): name the advisory tab "OSS/ASF Emails" in RM hand-off

### DIFF
--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
@@ -103,7 +103,7 @@ This tracker is now yours to drive from **Steps 13 → 14 → 15** of the securi
 
 Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** field at the top should read `REVIEW` — that is the precondition for this comment firing, so it should match. If it doesn't, stop and ping @potiuk; otherwise:
 
-1. **Click the [`#email` tab](EMAIL_TAB_URL)** on the same page. Scroll through any reviewer comments left by the ASF Security Team's CVE reviewers. **You do not need to act on reviewer comments yourself** — they arrive by email on `SECURITY_LIST` with the CVE ID in the subject, and sync detects them on the next run, opens corresponding body-field updates on this tracker, and re-pushes the JSON. If the comments tab is empty, or carries a closure note (*"OK, looks good"* / *"approved"*), proceed to the next step.
+1. **Click the [OSS/ASF Emails tab](EMAIL_TAB_URL)** (the `#email` anchor) on the same page. Scroll through any reviewer comments left by the ASF Security Team's CVE reviewers. **You do not need to act on reviewer comments yourself** — they arrive by email on `SECURITY_LIST` with the CVE ID in the subject, and sync detects them on the next run, opens corresponding body-field updates on this tracker, and re-pushes the JSON. If the comments tab is empty, or carries a closure note (*"OK, looks good"* / *"approved"*), proceed to the next step.
 
 2. **When the reviewer thread is clear** (no open comments, or all comments have an *"OK, looks good"*-style closer), click the **REVIEW button on the Editor tab** to advance the record from `REVIEW` → `READY`. Click **Save**. *The record is now staged for advisory send.*
 
@@ -113,7 +113,7 @@ Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** fie
 
 ### Step 2 of 3 — preview the advisory email, then send it
 
-With the record in `READY`, click the [`#email` tab](EMAIL_TAB_URL) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
+With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
 
 **Check that:**
 - The subject line is `CVE_ID: <one-line description>` and the description matches what you'd want public.

--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
@@ -105,7 +105,7 @@ RM_HANDLE — the release with the fix has shipped, and the CVE record on Vulnog
 
 Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** field at the top should read `REVIEW` — that is the precondition for this comment firing, so it should match. If it doesn't, stop and ping @potiuk; otherwise:
 
-1. **Click the [`#email` tab](EMAIL_TAB_URL)** on the same page. Scroll through any reviewer comments left by the ASF Security Team's CVE reviewers. **You do not need to act on reviewer comments yourself** — they arrive by email on `SECURITY_LIST` with the CVE ID in the subject, and sync detects them on the next run, opens corresponding body-field updates on this tracker, and re-pushes the JSON. If the comments tab is empty, or carries a closure note (*"OK, looks good"* / *"approved"*), proceed to the next step.
+1. **Click the [OSS/ASF Emails tab](EMAIL_TAB_URL)** (the `#email` anchor) on the same page. Scroll through any reviewer comments left by the ASF Security Team's CVE reviewers. **You do not need to act on reviewer comments yourself** — they arrive by email on `SECURITY_LIST` with the CVE ID in the subject, and sync detects them on the next run, opens corresponding body-field updates on this tracker, and re-pushes the JSON. If the comments tab is empty, or carries a closure note (*"OK, looks good"* / *"approved"*), proceed to the next step.
 
 2. **When the reviewer thread is clear** (no open comments, or all comments have an *"OK, looks good"*-style closer), click the **REVIEW button on the Editor tab** to advance the record from `REVIEW` → `READY`. Click **Save**. *The record is now staged for advisory send.*
 
@@ -115,7 +115,7 @@ Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** fie
 
 ### Step 2 of 3 — preview the advisory email, then send it
 
-With the record in `READY`, click the [`#email` tab](EMAIL_TAB_URL) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
+With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
 
 **Check that:**
 - The subject line is `CVE_ID: <one-line description>` and the description matches what you'd want public.


### PR DESCRIPTION
The release-manager hand-off comment templates referred to Vulnogram’s advisory/reviewer tab as **the `#email` tab**. The ASF Vulnogram UI actually labels that tab **OSS/ASF Emails**.

This renames the visible tab references in both hand-off variants (`release-manager-handoff-comment.md` and `-oauth-pushed.md`), keeping the `#email` URL anchor in the link target, so the RM finds the tab the comment tells them to click.

Reported by the Apache Airflow security team during a CVE sync run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)