### PR TITLE
docs(vulnogram): name the send button "Send these Emails" in RM hand-off

### DIFF
--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
@@ -123,7 +123,7 @@ With the record in `READY`, click the [`#email` tab](EMAIL_TAB_URL) on the same 
 
 **If anything looks wrong**: don't edit it in Vulnogram. Comment on this tracker (just `@potiuk: the X field needs Y`) and we'll fix the corresponding body field here, regenerate the JSON, and re-push within the next sync. Re-preview after that.
 
-**If everything looks right**: click the **Send Email** button on the `#email` tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **That is the only manual send action you make for this CVE.**
+**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **That is the only manual send action you make for this CVE.**
 
 > ⚠️ **Do not touch the tracker labels yourself.** Sync flips `fix released` → `announced - emails sent` + `announced` automatically when it sees the advisory in the public archive (usually within the same day). If you flip them manually you race the automation.
 

--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
@@ -125,7 +125,7 @@ With the record in `READY`, click the [`#email` tab](EMAIL_TAB_URL) on the same 
 
 **If anything looks wrong**: don't edit it in Vulnogram. Comment on this tracker (just `@potiuk: the X field needs Y`) and we'll fix the corresponding body field here, regenerate the JSON, and re-push within the next sync. Re-preview after that.
 
-**If everything looks right**: click the **Send Email** button on the `#email` tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **That is the only manual send action you make for this CVE.**
+**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **That is the only manual send action you make for this CVE.**
 
 > ⚠️ **Do not touch the tracker labels yourself.** Sync flips `fix released` → `announced - emails sent` + `announced` automatically when it sees the advisory in the public archive (usually within the same day). If you flip them manually you race the automation.
 


### PR DESCRIPTION
The release-manager hand-off comment templates told the RM to click the **Send Email** button to ship the advisory. The ASF Vulnogram UI actually labels that button **Send these Emails**.

This renames it in both hand-off variants (`release-manager-handoff-comment.md` and `-oauth-pushed.md`) so the RM finds the control the comment points at.

Reported by the Apache Airflow security team during a CVE sync run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)