### PR TITLE
docs(agents): require a spec-sync pre-check before pushing a functionality PR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,6 +430,21 @@ to a home-dir path and update the tool to read from there.
   staging branch for the private-PR fallback described in
   [`README.md`](README.md). Unless the user explicitly says otherwise, base
   PRs on the tracker's default branch.
+- **Spec-sync pre-check before pushing a functionality PR.** The specs in
+  [`tools/spec-loop/specs/`](tools/spec-loop/specs/) are the source of truth
+  and must not fall behind the code. Before pushing a PR that ships or changes
+  a skill, tool, or mode — **and before pushing a rebase of one onto a `main`
+  that has moved** — confirm `tools/spec-loop/.last-sync` is at (or near) the
+  current `main` tip and that the affected specs reflect what actually
+  shipped. If they have drifted, run the sync
+  (`tools/spec-loop/loop.sh update`, which writes to a `spec/sync-specs`
+  branch — see
+  [`docs/spec-driven-development.md`](docs/spec-driven-development.md)) or,
+  for a small known gap, update the spec(s) and bump `.last-sync` by hand;
+  then either fold it into the PR or open a companion `sync-specs` PR. The
+  failure this prevents: a "sync specs" PR that lands already stale because
+  more functionality shipped while it sat. Pure-mechanical PRs (a rebase that
+  ships no new functionality, lint, docs-only edits) are exempt.
 - Keep the commit message focused on the user-visible change, not the mechanics of how the edit
   was made.
 


### PR DESCRIPTION
## What

Adds a Commit-and-PR convention to `AGENTS.md`: before pushing a PR that
ships or changes a skill, tool, or mode — **and before pushing a rebase of
one onto a `main` that has moved** — agents must verify the spec-loop specs
(`tools/spec-loop/specs/`) and `tools/spec-loop/.last-sync` reflect what
actually shipped, and run the sync (`tools/spec-loop/loop.sh update`, or a
small manual update + `.last-sync` bump) if they've drifted.

## Why

The specs are the source of truth but drift silently behind merged
functionality. Concretely: a "sync specs" PR (#539) was found already stale
on rebase — `main` had shipped 7 skills since the branch's sync point, so
several specs (repo-health family, triage mode, release lifecycle)
misstated reality and `.last-sync` was ~30 commits behind. A pre-push
pre-check catches this before it lands.

Pure-mechanical PRs (a rebase that ships no new functionality, lint,
docs-only edits) are exempt.
