### PR TITLE
chore(agent-isolation): bump pinned claude-code 2.1.172 -> 2.1.193

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -158,7 +158,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.2-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.172
+npm install -g --no-save @anthropic-ai/claude-code@2.1.193
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -266,7 +266,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.172
+npm install -g --no-save @anthropic-ai/claude-code@2.1.193
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -52,7 +52,7 @@
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-06-12"
+pinned_at = "2026-06-27"
 
 [tools.bubblewrap]
 version = "0.11.2"
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.172"
-released = "2026-06-10"
+version = "2.1.193"
+released = "2026-06-25"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.172"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.172 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.193"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.193 (when available)"


### PR DESCRIPTION
## What

Bump the pinned `claude-code` in `tools/agent-isolation/pinned-versions.toml`
from **2.1.172 → 2.1.193**, and the matching `@2.1.172` install pins in
`docs/setup/secure-agent-setup.md`. `pinned_at` advanced to 2026-06-27.
`bubblewrap` (0.11.2) and `socat` (1.8.1.1) are unchanged — already current.

After the bump, `tools/agent-isolation/check-tool-updates.sh` reports all
three pinned tools ✓ up to date.

## Why

2.1.193 (released 2026-06-25) has aged past `claude-code`'s 1-day cooldown.
Reviewed the 2.1.173..2.1.193 changelog for behavioural changes affecting the
secure setup's permission/sandbox posture — no regressions. Notable additions,
flagged here as **separate follow-ups** (kept out of this version-bump PR per
the manifest's "own PR" guidance):

- `sandbox.credentials` (2.1.187) — blocks credential-file / secret-env reads
  from sandboxed commands; directly aligned with the framework's `denyRead`
  credential-isolation posture and worth adopting in the dogfooded
  `.claude/settings.json`.
- `Tool(param:value)` permission-rule matcher (2.1.178).
- Auto-mode destructive-command guards (2.1.183).

Docs + pin manifest only; no skill/tool/mode behaviour change (spec-sync
pre-check exempt).
