### PR TITLE
feat(agent-isolation): protect secret env vars via sandbox.credentials

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,20 @@
         "*.crates.io"
       ],
       "enableWeakerNetworkIsolation": true
+    },
+    "credentials": {
+      "envVars": [
+        { "name": "ANTHROPIC_API_KEY", "mode": "deny" },
+        { "name": "ANTHROPIC_AUTH_TOKEN", "mode": "deny" },
+        { "name": "CLAUDE_CODE_OAUTH_TOKEN", "mode": "deny" },
+        { "name": "GH_TOKEN", "mode": "deny" },
+        { "name": "GITHUB_TOKEN", "mode": "deny" },
+        { "name": "AWS_ACCESS_KEY_ID", "mode": "deny" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "mode": "deny" },
+        { "name": "AWS_SESSION_TOKEN", "mode": "deny" },
+        { "name": "NPM_TOKEN", "mode": "deny" },
+        { "name": "TWINE_PASSWORD", "mode": "deny" }
+      ]
     }
   },
   "permissions": {

--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -427,6 +427,31 @@ below, annotated.
       // data-exfiltration vector through the trustd service." No-op
       // outside the sandbox (e.g. CI). macOS-only.
       "enableWeakerNetworkIsolation": true
+    },
+    // `sandbox.credentials` (claude-code 2.1.187+) is the only layer
+    // that protects secret ENVIRONMENT VARIABLES — `denyRead` and the
+    // `permissions.deny[Read(...)]` rules are filesystem-only and do
+    // NOT stop a sandboxed command from reading `$ANTHROPIC_API_KEY`
+    // or dumping `env`. `mode: "deny"` unsets the var for sandboxed
+    // commands only; the unsandboxed agent process keeps its own auth,
+    // and sandbox-bypassed commands (e.g. `gh`, which reads
+    // ~/.config/gh) are unaffected. Credential FILES are already
+    // covered by `denyRead: ["~/"]`, so only `envVars` is listed here.
+    // (`mode: "mask"` + `injectHosts` is the alternative: keep the var
+    // usable only for connections to named hosts — not needed here.)
+    "credentials": {
+      "envVars": [
+        { "name": "ANTHROPIC_API_KEY", "mode": "deny" },
+        { "name": "ANTHROPIC_AUTH_TOKEN", "mode": "deny" },
+        { "name": "CLAUDE_CODE_OAUTH_TOKEN", "mode": "deny" },
+        { "name": "GH_TOKEN", "mode": "deny" },
+        { "name": "GITHUB_TOKEN", "mode": "deny" },
+        { "name": "AWS_ACCESS_KEY_ID", "mode": "deny" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "mode": "deny" },
+        { "name": "AWS_SESSION_TOKEN", "mode": "deny" },
+        { "name": "NPM_TOKEN", "mode": "deny" },
+        { "name": "TWINE_PASSWORD", "mode": "deny" }
+      ]
     }
   },
   "permissions": {

--- a/tools/sandbox-lint/expected.json
+++ b/tools/sandbox-lint/expected.json
@@ -46,6 +46,20 @@
         "*.crates.io"
       ],
       "enableWeakerNetworkIsolation": true
+    },
+    "credentials": {
+      "envVars": [
+        { "name": "ANTHROPIC_API_KEY", "mode": "deny" },
+        { "name": "ANTHROPIC_AUTH_TOKEN", "mode": "deny" },
+        { "name": "CLAUDE_CODE_OAUTH_TOKEN", "mode": "deny" },
+        { "name": "GH_TOKEN", "mode": "deny" },
+        { "name": "GITHUB_TOKEN", "mode": "deny" },
+        { "name": "AWS_ACCESS_KEY_ID", "mode": "deny" },
+        { "name": "AWS_SECRET_ACCESS_KEY", "mode": "deny" },
+        { "name": "AWS_SESSION_TOKEN", "mode": "deny" },
+        { "name": "NPM_TOKEN", "mode": "deny" },
+        { "name": "TWINE_PASSWORD", "mode": "deny" }
+      ]
     }
   },
   "permissions": {


### PR DESCRIPTION
## What

Add a `sandbox.credentials.envVars` block to the dogfooded
`.claude/settings.json` (and its annotated copy in
`docs/setup/secure-agent-setup.md`), denying a set of secret environment
variables to **sandboxed** commands. Uses the `sandbox.credentials` setting
added in claude-code **2.1.187**.

Vars denied (`mode: "deny"`): `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`,
`CLAUDE_CODE_OAUTH_TOKEN`, `GH_TOKEN`, `GITHUB_TOKEN`, `AWS_ACCESS_KEY_ID`,
`AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `NPM_TOKEN`, `TWINE_PASSWORD`.

## Why

`sandbox.filesystem.denyRead` and the `permissions.deny[Read(...)]` rules are
**filesystem-only** — nothing currently stops a sandboxed Bash command from
reading `$ANTHROPIC_API_KEY` or dumping `env`. `sandbox.credentials.envVars`
is the only layer that covers environment variables, so this closes a real
exfiltration gap for a prompt-injection-driven command.

`mode: "deny"` unsets the variable for **sandboxed commands only**: the
unsandboxed agent process keeps its own auth, and sandbox-bypassed commands
(e.g. `gh`, which authenticates via `~/.config/gh`) are unaffected. Verified
the exact schema against the shipped 2.1.193 binary — `credentials` takes
`files[]` (`{path, mode}`) and `envVars[]` (`{name, mode: "deny"|"mask",
injectHosts?}`). Credential **files** are already covered by
`denyRead: ["~/"]`, so only `envVars` is added here. (`mask` + `injectHosts`
is the keep-usable-for-named-hosts alternative — not needed for these.)

Config + docs only; no skill/tool/mode behaviour change.

## Note for reviewers

Requires claude-code ≥ 2.1.187 to take effect; older runtimes ignore the
unknown key. Pairs naturally with the pending pin bump to 2.1.193
(`chore/bump-claude-code-2.1.193`).
