### PR TITLE
docs(spec-loop): sync IMPLEMENTATION_PLAN to current done-state

### DIFF
--- a/tools/spec-loop/IMPLEMENTATION_PLAN.md
+++ b/tools/spec-loop/IMPLEMENTATION_PLAN.md
@@ -53,7 +53,7 @@ one PR** (the branch-per-feature constraint).
   has `pyproject.toml`, `src/`, and a `tests/` directory with pytest
   coverage for the sandbox profiles and clean-env wrapper.
   Spec: [`specs/agent-isolation-sandbox.md`](specs/agent-isolation-sandbox.md).
-- **Eval coverage — complete** — 37 skill eval suites exist in
+- **Eval coverage — complete** — 60 skill eval suites exist in
   `tools/skill-evals/evals/`, covering all skills including the full
   setup-family (setup, setup-isolated-setup-doctor,
   setup-isolated-setup-install, setup-isolated-setup-update,
@@ -75,6 +75,14 @@ one PR** (the branch-per-feature constraint).
   ASF-coupling category landed in `tools/skill-and-tool-validator`
   (formerly planned work item 5), and `drafting-mode.md` Known Gaps is
   synced to the shipped drafting skills (formerly planned work item 6).
+- **Project-agnosticism — capability-flag vocabulary enumerated** — the
+  contributor/committer-intake (ICLA vs DCO), security-intake, and
+  CVE-allocation option sets and defaults are enumerated as
+  `projects/_template/committer-onboarding-config.md`,
+  `security-intake-config.md`, and `cve-allocation-config.md`, following
+  the backend-flag precedent in `release-management-lifecycle.md`. Wiring
+  the skills to read these flags is tracked as work item 3.
+  Spec: [`specs/project-agnosticism.md`](specs/project-agnosticism.md).
 - **Repo-health — three-skill family shipped** — `ci-runner-audit`,
   `workflow-security-audit`, and `dependency-audit` landed (read-only,
   `experimental`). Spec: [`specs/repo-health-family.md`](specs/repo-health-family.md).
@@ -90,13 +98,17 @@ one PR** (the branch-per-feature constraint).
 The following items are already built on local branches or open as PRs.
 Do not duplicate them.
 
-None in flight. The previous in-flight batch (spec-validator SPDX /
-path-existence / Known-gaps checks, the `spec-validate` pre-commit hook,
-the SOFT eval-coverage check, `pr-management-quick-merge`, the
-security-tracker dashboard pytest suite, the loop incremental-sync and
-CLI-UX changes, the markdownlint Node bump, the AGENTS.md slim, and the
-modes / mentoring / setup-status doc syncs) has all merged and is
-reflected in the code and in **What's been built** above.
+| Branch slug | PR | Description |
+|---|---|---|
+| `non-asf-profile-fixture` | open | Non-ASF adopter profile under `projects/_template/` + `non-asf-profile-smoke` eval (former work item 3) |
+
+The previous in-flight batch (spec-validator SPDX / path-existence /
+Known-gaps checks, the `spec-validate` pre-commit hook, the SOFT
+eval-coverage check, `pr-management-quick-merge`, the security-tracker
+dashboard pytest suite, the loop incremental-sync and CLI-UX changes, the
+markdownlint Node bump, the AGENTS.md slim, and the modes / mentoring /
+setup-status doc syncs) has all merged and is reflected in the code and
+in **What's been built** above.
 
 ---
 
@@ -146,22 +158,31 @@ slugs, not numbers (numbering implies an order the specs don't carry).
    Spec: [`specs/skill-reconciler.md`](specs/skill-reconciler.md).
    Branch `skill-reconciler`.
 
-3. **Non-ASF adopter profile fixture + smoke eval.**
-   `specs/project-agnosticism.md` acceptance #3 requires that a non-ASF
-   profile can be declared without editing any skill body, but there is
-   no fixture to prove it. Add a worked non-ASF profile under
-   `projects/_template/` (non-ASF values for the existing placeholders
-   and any capability flags) plus a smoke eval that drives a
-   representative skill through it and asserts no skill-body edits are
-   needed. This turns acceptance #3 into a measurable gate. Pure
-   engineering, no policy decision required.
+3. **Clear the high-confidence ASF-coupling advisory backlog.**
+   The SOFT ASF-coupling lint (shipped, see **What's been built**) still
+   flags ~62 high-confidence couplings, almost all in the
+   release-management skills: hardcoded ASF dist-tree paths (`dist/dev/`,
+   `dist/release/`), `svn mv` / `svn commit` / `svn checkout`
+   distribution commands, and the literal `announce@apache.org` list. The
+   capability-flag vocabulary and `release-management-config.md`'s backend
+   flags (`release-dist-backend`, `release-announce-backend`) already
+   exist; this item wires the release skills (`release-rc-cut`,
+   `release-promote`, `release-archive-sweep`, `release-keys-sync`,
+   `release-prepare`, `release-verify-rc`, `release-vote-draft`,
+   `release-vote-tally`, `release-announce-draft`) plus
+   `security-issue-sync` to read those flags / use the `<announce-list>`
+   placeholder instead of hardcoding ASF specifics, regressing no
+   behaviour for the ASF default profile. Low-confidence advisories (bare
+   `PMC`, `ICLA`, `incubator`) are out of scope: the SOFT lint leaves
+   those to contributor self-judgement. Done when the validator reports
+   zero high-confidence asf-coupling warnings.
    Validation:
    ```bash
    uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate
-   uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/non-asf-profile-smoke/
+   uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/release-promote/
    ```
    Spec: [`specs/project-agnosticism.md`](specs/project-agnosticism.md).
-   Branch `non-asf-profile-fixture`.
+   Branch `asf-coupling-cleanup`.
 
 ---
 
@@ -190,12 +211,17 @@ slugs, not numbers (numbering implies an order the specs don't carry).
   a direct build item.
 - **Project-agnosticism:** the ASF-coupling advisory lint has shipped
   (recorded in **What's been built**); the non-ASF adopter profile
-  fixture is work item 3. The remaining gap, the capability-flag
-  vocabulary for contributor intake (ICLA vs DCO), security intake, and
-  CVE allocation, is deferred only until someone enumerates the option
-  sets and defaults, following the backend-flag precedent already set by
-  `release-management-lifecycle.md` (distribution / approval / announcement
-  backends). That is a spec-authoring task, not yet a build item.
+  fixture is in flight (PR open, see **In-flight**). The capability-flag
+  vocabulary for contributor/committer intake (ICLA vs DCO), security
+  intake, and CVE allocation has been enumerated and shipped to main
+  (recorded in **What's been built**), following the backend-flag
+  precedent set by `release-management-lifecycle.md` (distribution /
+  approval / announcement backends). The remaining follow-on is wiring
+  the skills to read those flags (work item 3) — an engineering task, not
+  a spec-authoring one. The SOFT ASF-coupling lint still reports ~62
+  high-confidence couplings (hardcoded `dist/` paths, `svn` commands,
+  `announce@apache.org`), almost all in the release-management skills,
+  which is the measurable backlog work item 3 clears.
 - **General-issue dedupe and backlog dashboard** (`triage-mode.md` Known
   Gaps) have shipped (`issue-deduplicate`, `issue-backlog-stats`) alongside
   `issue-stale-sweep`; see **What's been built**. No longer planned items.


### PR DESCRIPTION
## Summary

- Move non-asf-profile-fixture from planned work items into In-flight
- Record capability-flag vocabulary as shipped; fix stale deferral note
- Fix eval coverage count (37 -> 60 suites)
- Add work item 3: clear high-confidence ASF-coupling advisory backlog

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
