### PR TITLE
docs: 'need help → adopt a family' guide + utilities family overview

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 
 - [What is Apache Magpie?](#what-is-apache-magpie)
   - [How it works](#how-it-works)
+  - [Need help with one of these? Adopt a family of skills](#need-help-with-one-of-these-adopt-a-family-of-skills)
   - [Who is this for?](#who-is-this-for)
     - [Maintainers wanting to adopt Magpie in their project](#maintainers-wanting-to-adopt-magpie-in-their-project)
     - [Security team members](#security-team-members)
@@ -38,6 +39,26 @@ Five **modes** describe what the agent can do, from low-risk to high:
 | **Auto-merge** | Merge trivial changes without human review | Off (deliberately) |
 
 Each project picks the modes that fit. You can run just Triage and nothing else.
+
+---
+
+## Need help with one of these? Adopt a family of skills
+
+Magpie's skills ship in **families**. You don't adopt all of them — you pick the ones that match a problem you actually have today. Each family page explains what it does, which skills it includes, and how to turn it on.
+
+| If you're dealing with… | Adopt the family |
+|---|---|
+| Setting up agents safely — sandbox, clean environment, privacy routing | [setup](setup/README.md) |
+| Security reports that need careful, audited handling | [security](security/README.md) |
+| A pull-request queue that's out of control | [pr-management](pr-management/README.md) |
+| An issue backlog full of duplicates and stale reports | [issue-management](issue-management/README.md) |
+| Repo hygiene slipping — CI runners, dependencies, licenses, flaky tests | [repo-health](repo-health/README.md) |
+| Releases that are a manual, error-prone slog | [release-management](release-management/README.md) |
+| New contributors getting stuck and drifting away | [mentoring](mentoring/README.md) |
+| Growing contributors into committers | [contributor-growth](contributor-growth/README.md) |
+| Building or maintaining your own skills | [utilities](utilities/README.md) |
+
+Start with [`setup`](setup/README.md) regardless — it is the prerequisite every adopter installs first — then add the families above as you need them.
 
 ---
 

--- a/docs/utilities/README.md
+++ b/docs/utilities/README.md
@@ -1,0 +1,69 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Utilities skill family](#utilities-skill-family)
+  - [Skills](#skills)
+  - [When to adopt this family](#when-to-adopt-this-family)
+  - [Adopter contract](#adopter-contract)
+  - [Status](#status)
+  - [Cross-references](#cross-references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Utilities skill family
+
+Framework meta-skills — the tools you use to **build and maintain skills
+themselves**, rather than to run a maintainership mode on your project. They
+sit outside the MISSION mode taxonomy (Triage, Mentoring, Drafting, Pairing,
+Auto-merge): nothing here acts on your issues, PRs, or contributor threads.
+They are for skill authors and framework contributors.
+
+---
+
+## Skills
+
+| Skill | Purpose | Status |
+|---|---|---|
+| [`write-skill`](../../skills/write-skill/SKILL.md) | Author a new framework skill or update an existing one: frontmatter, placeholder convention, injection defenses, Privacy-LLM gate-check, and validator sign-off. | stable |
+| [`optimize-skill`](../../skills/optimize-skill/SKILL.md) | Optimize an existing skill by applying restructuring patterns — split an oversized `SKILL.md` into linked sibling docs, trim frontmatter, and improve eval alignment. | stable |
+| [`list-skills`](../../skills/list-skills/SKILL.md) | Print a live index of every skill in this repository, grouped by family, with each skill's name and first-sentence description. | stable |
+
+---
+
+## When to adopt this family
+
+Adopt `utilities` if you intend to **write or maintain your own skills** —
+whether contributing them back to Magpie or keeping them in your own project.
+If you are only adopting existing skills to run on your project, you do not
+need this family; the [`setup`](../setup/README.md) family is your starting
+point instead.
+
+---
+
+## Adopter contract
+
+The utilities skills have no project-specific config files and make no state
+changes to your project's tracker, label set, or shared infrastructure.
+`list-skills` and `optimize-skill` are read-only; `write-skill` only creates or
+edits skill files under your control, which you review before committing.
+
+---
+
+## Status
+
+**Stable.** All three skills are shipped and validate under
+`skill-and-tool-validate`. They are framework-authoring tools, so they evolve
+with the framework's own conventions rather than with adopter pilots.
+
+---
+
+## Cross-references
+
+- [`docs/modes.md` § Outside the modes](../modes.md#outside-the-modes) — why
+  these skills sit outside the maintainership-mode taxonomy.
+- [`docs/spec-driven-development.md`](../spec-driven-development.md) — the
+  authoring loop `write-skill` and `optimize-skill` support.


### PR DESCRIPTION
## Summary

Docs changes to support the website's new "adopt a family" framing (the [apache/magpie-site](https://github.com/apache/magpie-site) landing now leads with pain-point CTAs and links each skill-family card to that family's overview).

- **`docs/index.md`** — add a *"Need help with one of these? Adopt a family of skills"* section: a table mapping common maintainer pain points (out-of-control PR queue, security reports, slow onboarding, release slog, repo hygiene, …) to the skill family that addresses each, linking to the family overviews.
- **`docs/utilities/README.md`** — new family overview for the meta-skills (`write-skill`, `optimize-skill`, `list-skills`), matching the structure of the other family READMEs. This was the one family without an overview page; the website's `utilities` card now has a real target to link to.

## Validation

Ran the repo's own hooks on the changed files — all green: **doctoc** (TOCs regenerated), **markdownlint**, **typos**, **lychee** (link check).

Generated-by: Claude Opus 4.8 (1M context)
