### PR TITLE
feat(tools/vcs): implement the source-control (VCS) abstraction

### DIFF
--- a/docs/labels-and-capabilities.md
+++ b/docs/labels-and-capabilities.md
@@ -230,6 +230,7 @@ Tools under [`tools/`](../tools/). Tools with two values (separated by
 | [`tools/skill-and-tool-validator`](../tools/skill-and-tool-validator/) | `capability:setup` | Skill-frontmatter and convention validator |
 | [`tools/spec-status-index`](../tools/spec-status-index/) | `capability:setup` + `capability:stats` | Index of spec / RFC implementation status — substrate that also doubles as a governance/stats view |
 | [`tools/spec-validator`](../tools/spec-validator/) | `capability:setup` | Spec-frontmatter and body-section validator — counterpart to `skill-and-tool-validator` for `tools/spec-loop/specs/` |
+| [`tools/vcs`](../tools/vcs/) | `capability:setup` | Backend-dispatching implementation of the source-control (VCS) capability ([`tools/github/source-control.md`](../tools/github/source-control.md)); complete Git backend plus detected extension points for non-Git VCS bridges (#601 Hg, #602 SVN) |
 
 A tool's capabilities are determined by its **use-case lifecycle
 phases**, not by which skills happen to consume it. `tools/github` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,4 +111,5 @@ members = [
   "tools/skill-evals",
   "tools/spec-status-index",
   "tools/spec-validator",
+  "tools/vcs",
 ]

--- a/tools/github/source-control.md
+++ b/tools/github/source-control.md
@@ -26,6 +26,14 @@ explicit `fetch` / `push`. A project can in principle pair GitHub's
 tracker with a different VCS, or a different forge with Git — see
 [*When to replace this capability*](#when-to-replace-this-capability).
 
+This contract has a runnable implementation in
+[`tools/vcs/`](../vcs/README.md) (`magpie-vcs`): one abstract
+`VCSBackend` interface, a complete Git backend, and detected extension
+points for the non-Git bridges. A skill can call the abstract operation
+(`magpie-vcs diff`, `magpie-vcs log`) instead of a raw `git` command and
+let the tool dispatch to whichever backend governs the working copy. The
+Git-binding tables below are the contract that tool implements.
+
 ## What the skills require
 
 The dev-loop skills (`issue-fix-workflow`, `pr-management-code-review`,

--- a/tools/vcs/README.md
+++ b/tools/vcs/README.md
@@ -1,0 +1,102 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [`magpie-vcs`](#magpie-vcs)
+  - [Why](#why)
+  - [The abstraction](#the-abstraction)
+  - [Backends](#backends)
+    - [Adding a backend](#adding-a-backend)
+  - [How to use](#how-to-use)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# `magpie-vcs`
+
+**Capability:** capability:setup
+
+Runnable implementation of the **source-control (VCS) capability**
+documented in
+[`tools/github/source-control.md`](../github/source-control.md). It
+extracts the abstraction the dev-loop skills assume — branch, stage,
+commit, diff, log, fetch, push, working-tree reset — out of inline
+`git` calls into one backend-dispatching CLI.
+
+A skill (or a person) runs the **abstract** operation:
+
+```bash
+uv run --project tools/vcs magpie-vcs -C <upstream> diff --base main
+uv run --project tools/vcs magpie-vcs -C <upstream> log --grep ISSUE-123
+```
+
+The active backend is **detected** from the working copy (or forced
+with `--backend` / `$MAGPIE_VCS`), so the same command works whatever
+VCS the project enables under *Tools enabled → Source control*.
+
+## Why
+
+Before this tool the skills hard-coded `git …` inline. PR #609 added
+the capability *contract* (`source-control.md`) and pointed each
+git-using skill at it; this tool is the *implementation* of that
+contract — the single place a non-Git VCS bridge plugs in, instead of
+editing every skill.
+
+## The abstraction
+
+`VCSBackend` is the abstract interface; each operation maps to the
+*What the skills require* table in `source-control.md`:
+
+| Operation | CLI | Read/Write |
+|---|---|---|
+| Detect backend | `detect`, `backends`, `root` | read |
+| Working-tree status | `status`, `clean` | read |
+| Current branch | `branch` | read |
+| Show changes | `diff [--base REF] [--cached] [paths…]` | read |
+| History read | `log [-n N] [--grep P] [--author A] [--since S] [paths…]` | read |
+| Create line of work | `new-branch <name>` | write |
+| Switch ref | `switch <ref>` | write |
+| Stage | `stage <paths…>` | write |
+| Commit | `commit -m <msg>` | write |
+| Sync from forge | `fetch [remote] [ref]` | write |
+| Publish | `push [-u] <remote> <ref>` | write |
+| Reset working copy | `reset-worktree` | write |
+
+Write operations stay gated on explicit user confirmation **in the
+calling skill**, exactly as the tracker write paths are — the tool does
+not add its own prompt.
+
+## Backends
+
+| Backend | Status | Notes |
+|---|---|---|
+| `git` | **complete** | GitHub's native VCS; the default binding |
+| `hg` (Mercurial) | extension point | detected; operations raise a clear error → [#601](https://github.com/apache/magpie/issues/601) |
+| `svn` (Subversion) | extension point | detected; centralized model (`distributed = False`) → [#602](https://github.com/apache/magpie/issues/602) |
+
+Detection is real for every backend (so `magpie-vcs detect` reports the
+working copy's VCS correctly); the non-Git backends raise an actionable
+`VCSError` naming their tracking issue until the full binding lands.
+
+### Adding a backend
+
+A VCS bridge (e.g. #601 Mercurial) implements the full binding by
+replacing that backend's `_UnimplementedBackend` base with a concrete
+`VCSBackend` subclass — `detect()`, the read operations, the write
+operations — and nothing else changes: detection, dispatch, the CLI,
+and every skill that calls `magpie-vcs` pick it up automatically.
+
+## How to use
+
+```bash
+# run the tests
+uv run --project tools/vcs --group dev pytest
+
+# in a skill / shell, against an upstream checkout
+uv run --project tools/vcs magpie-vcs -C ~/code/foo detect
+uv run --project tools/vcs magpie-vcs -C ~/code/foo status
+```
+
+Exit codes: `0` success, `1` for `clean` when the tree is dirty, `2`
+for any `VCSError` (unknown/unsupported backend, failed command).

--- a/tools/vcs/pyproject.toml
+++ b/tools/vcs/pyproject.toml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "magpie-vcs"
+version = "0.1.0"
+description = "Backend-dispatching implementation of the source-control (VCS) capability documented in tools/github/source-control.md — one abstract interface, a complete Git backend, and explicit extension points for non-Git VCS bridges."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+# stdlib-only — the abstraction shells out to the underlying VCS binary.
+dependencies = []
+
+[project.scripts]
+magpie-vcs = "magpie_vcs:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/magpie_vcs"]
+
+[tool.ruff]
+line-length = 110
+target-version = "py311"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+  "E",
+  "W",
+  "F",
+  "I",
+  "B",
+  "UP",
+  "SIM",
+  "C4",
+  "RUF",
+]
+ignore = [
+  "E501",
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B", "SIM"]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src", "tests"]
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unreachable = true
+check_untyped_defs = true
+no_implicit_optional = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-ra -q"
+testpaths = ["tests"]

--- a/tools/vcs/src/magpie_vcs/__init__.py
+++ b/tools/vcs/src/magpie_vcs/__init__.py
@@ -1,0 +1,537 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Backend-dispatching implementation of the source-control (VCS) capability.
+
+This module extracts the abstraction documented in
+``tools/github/source-control.md`` into runnable code: one abstract
+:class:`VCSBackend` interface listing the operations the dev-loop skills
+need, a complete :class:`GitBackend`, and explicit extension points for the
+non-Git VCS bridges (Mercurial #601, Subversion #602, Jujutsu #603,
+Fossil #604, Perforce #605).
+
+A skill calls the abstract operation (``magpie-vcs diff``) instead of a raw
+``git`` command; the active backend is detected from the working copy (or
+forced with ``--backend`` / ``MAGPIE_VCS``), so the same skill text works
+whatever VCS the project enables under *Tools enabled -> Source control*.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from pathlib import Path
+
+__all__ = [
+    "BACKENDS",
+    "GitBackend",
+    "MercurialBackend",
+    "SubversionBackend",
+    "VCSBackend",
+    "VCSError",
+    "detect_backend",
+    "get_backend",
+    "main",
+]
+
+# Env var a project / skill can set to force a backend instead of detecting it.
+BACKEND_ENV = "MAGPIE_VCS"
+
+# Location-redirecting VCS env vars. The tool resolves the working copy from
+# its --cwd, so these must not leak in from an outer context (e.g. when a skill
+# invokes magpie-vcs from inside a git hook, which exports GIT_DIR / GIT_INDEX_FILE
+# and would otherwise point operations at the wrong repository).
+_LOCATION_ENV_VARS = (
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_PREFIX",
+)
+
+
+def _clean_env() -> dict[str, str]:
+    """Process environment with location-redirecting VCS vars removed."""
+    return {k: v for k, v in os.environ.items() if k not in _LOCATION_ENV_VARS}
+
+
+class VCSError(Exception):
+    """A source-control operation failed, or is unsupported on this backend."""
+
+
+class VCSBackend(ABC):
+    """Abstract source-control capability.
+
+    Each concrete backend binds these abstract operations to one VCS. The
+    operation set mirrors the *What the skills require* table in
+    ``tools/github/source-control.md``. Backends that cannot satisfy an
+    operation raise :class:`VCSError` rather than silently degrading.
+    """
+
+    #: Short backend name (``git``, ``hg``, ``svn`` ...).
+    name: str = ""
+    #: Whether the backend is distributed (local commits + fetch/push split)
+    #: as opposed to centralized (server-side commits, e.g. Subversion).
+    distributed: bool = True
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    # -- detection ---------------------------------------------------------
+
+    @classmethod
+    @abstractmethod
+    def detect(cls, start: Path) -> Path | None:
+        """Return the working-copy root governed by this backend, or ``None``.
+
+        ``start`` is any path inside (or equal to) a candidate working copy.
+        """
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """Whether the backend's CLI binary is installed and runnable."""
+        return False
+
+    # -- read operations ---------------------------------------------------
+
+    @abstractmethod
+    def status(self) -> str:
+        """Porcelain working-tree status (one line per changed path)."""
+
+    def is_clean(self) -> bool:
+        """Whether the working tree has no uncommitted changes."""
+        return self.status().strip() == ""
+
+    @abstractmethod
+    def current_branch(self) -> str:
+        """Name of the current branch / bookmark / equivalent."""
+
+    @abstractmethod
+    def diff(self, base: str | None = None, cached: bool = False, paths: Sequence[str] = ()) -> str:
+        """Unified diff of the working copy (optionally vs ``base`` / staged)."""
+
+    @abstractmethod
+    def log(
+        self,
+        max_count: int | None = None,
+        grep: str | None = None,
+        author: str | None = None,
+        since: str | None = None,
+        paths: Sequence[str] = (),
+    ) -> str:
+        """History read, optionally filtered."""
+
+    # -- write operations (callers gate these on explicit confirmation) ----
+
+    @abstractmethod
+    def create_branch(self, name: str) -> None:
+        """Create and switch to a new line of work."""
+
+    @abstractmethod
+    def switch(self, ref: str) -> None:
+        """Switch the working copy to an existing ref."""
+
+    @abstractmethod
+    def stage(self, paths: Sequence[str]) -> None:
+        """Mark paths for inclusion in the next commit."""
+
+    @abstractmethod
+    def commit(self, message: str) -> None:
+        """Record the staged change."""
+
+    @abstractmethod
+    def fetch(self, remote: str | None = None, ref: str | None = None) -> None:
+        """Sync refs from the forge without changing the working copy."""
+
+    @abstractmethod
+    def push(self, remote: str, ref: str, set_upstream: bool = False) -> None:
+        """Publish a ref to the forge."""
+
+    @abstractmethod
+    def reset_worktree(self) -> None:
+        """Discard all uncommitted changes (the per-run reset protocol)."""
+
+
+def _run(
+    args: Sequence[str],
+    cwd: Path,
+    *,
+    capture: bool = True,
+    check: bool = True,
+) -> str:
+    """Run a subprocess, returning stdout. Raise :class:`VCSError` on failure."""
+    try:
+        proc = subprocess.run(
+            list(args),
+            cwd=cwd,
+            text=True,
+            capture_output=capture,
+            check=False,
+            env=_clean_env(),
+        )
+    except FileNotFoundError as exc:  # binary not installed
+        raise VCSError(f"{args[0]}: command not found") from exc
+    if check and proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip() if capture else ""
+        raise VCSError(f"`{' '.join(args)}` failed (rc={proc.returncode}): {detail}")
+    return proc.stdout if capture else ""
+
+
+class GitBackend(VCSBackend):
+    """Git binding of the source-control capability (GitHub's native VCS)."""
+
+    name = "git"
+    distributed = True
+
+    @classmethod
+    def detect(cls, start: Path) -> Path | None:
+        for d in (start, *start.parents):
+            if (d / ".git").exists():
+                return d
+        return None
+
+    @classmethod
+    def is_available(cls) -> bool:
+        try:
+            subprocess.run(["git", "--version"], capture_output=True, check=True)
+        except (OSError, subprocess.CalledProcessError):
+            return False
+        return True
+
+    def status(self) -> str:
+        return _run(["git", "status", "--porcelain"], self.root)
+
+    def current_branch(self) -> str:
+        return _run(["git", "rev-parse", "--abbrev-ref", "HEAD"], self.root).strip()
+
+    def diff(self, base: str | None = None, cached: bool = False, paths: Sequence[str] = ()) -> str:
+        args = ["git", "diff"]
+        if cached:
+            args.append("--cached")
+        if base:
+            args.append(base)
+        if paths:
+            args = [*args, "--", *paths]
+        return _run(args, self.root)
+
+    def log(
+        self,
+        max_count: int | None = None,
+        grep: str | None = None,
+        author: str | None = None,
+        since: str | None = None,
+        paths: Sequence[str] = (),
+    ) -> str:
+        args = ["git", "log", "--oneline"]
+        if max_count is not None:
+            args.append(f"-n{max_count}")
+        if grep:
+            args.append(f"--grep={grep}")
+        if author:
+            args.append(f"--author={author}")
+        if since:
+            args.append(f"--since={since}")
+        if paths:
+            args = [*args, "--", *paths]
+        return _run(args, self.root)
+
+    def create_branch(self, name: str) -> None:
+        _run(["git", "checkout", "-b", name], self.root, capture=False)
+
+    def switch(self, ref: str) -> None:
+        _run(["git", "checkout", ref], self.root, capture=False)
+
+    def stage(self, paths: Sequence[str]) -> None:
+        if not paths:
+            raise VCSError("stage: refusing to stage nothing (pass explicit paths)")
+        _run(["git", "add", "--", *paths], self.root, capture=False)
+
+    def commit(self, message: str) -> None:
+        _run(["git", "commit", "-m", message], self.root, capture=False)
+
+    def fetch(self, remote: str | None = None, ref: str | None = None) -> None:
+        args = ["git", "fetch"]
+        if remote:
+            args.append(remote)
+        if ref:
+            args.append(ref)
+        _run(args, self.root, capture=False)
+
+    def push(self, remote: str, ref: str, set_upstream: bool = False) -> None:
+        args = ["git", "push"]
+        if set_upstream:
+            args.append("-u")
+        args.extend([remote, ref])
+        _run(args, self.root, capture=False)
+
+    def reset_worktree(self) -> None:
+        # The Git binding of the reset protocol in
+        # tools/github/source-control.md / issue-reproducer runtime-recipes.
+        _run(["git", "stash", "--include-untracked"], self.root, check=False, capture=False)
+        _run(["git", "clean", "-fd"], self.root, capture=False)
+        _run(["git", "checkout", "--", "."], self.root, capture=False)
+
+
+class _UnimplementedBackend(VCSBackend):
+    """Shared base for detected-but-not-yet-implemented non-Git backends.
+
+    The detection logic is real (so ``magpie-vcs detect`` correctly reports
+    the working copy's VCS); every operation raises a clear, actionable
+    :class:`VCSError` pointing at the tracking issue for the full bridge.
+    """
+
+    marker: str = ""
+    issue: str = ""
+
+    @classmethod
+    def detect(cls, start: Path) -> Path | None:
+        for d in (start, *start.parents):
+            if (d / cls.marker).exists():
+                return d
+        return None
+
+    def _unsupported(self, op: str) -> VCSError:
+        return VCSError(
+            f"{self.name}: operation '{op}' is not implemented yet — "
+            f"the {self.name} backend is a tracked extension point ({self.issue}). "
+            f"Implement it by completing this backend in tools/vcs/."
+        )
+
+    def status(self) -> str:
+        raise self._unsupported("status")
+
+    def current_branch(self) -> str:
+        raise self._unsupported("current_branch")
+
+    def diff(self, base: str | None = None, cached: bool = False, paths: Sequence[str] = ()) -> str:
+        raise self._unsupported("diff")
+
+    def log(
+        self,
+        max_count: int | None = None,
+        grep: str | None = None,
+        author: str | None = None,
+        since: str | None = None,
+        paths: Sequence[str] = (),
+    ) -> str:
+        raise self._unsupported("log")
+
+    def create_branch(self, name: str) -> None:
+        raise self._unsupported("create_branch")
+
+    def switch(self, ref: str) -> None:
+        raise self._unsupported("switch")
+
+    def stage(self, paths: Sequence[str]) -> None:
+        raise self._unsupported("stage")
+
+    def commit(self, message: str) -> None:
+        raise self._unsupported("commit")
+
+    def fetch(self, remote: str | None = None, ref: str | None = None) -> None:
+        raise self._unsupported("fetch")
+
+    def push(self, remote: str, ref: str, set_upstream: bool = False) -> None:
+        raise self._unsupported("push")
+
+    def reset_worktree(self) -> None:
+        raise self._unsupported("reset_worktree")
+
+
+class MercurialBackend(_UnimplementedBackend):
+    """Mercurial (Hg) extension point — see apache/magpie#601."""
+
+    name = "hg"
+    distributed = True
+    marker = ".hg"
+    issue = "apache/magpie#601"
+
+
+class SubversionBackend(_UnimplementedBackend):
+    """Apache Subversion (SVN) extension point — see apache/magpie#602."""
+
+    name = "svn"
+    distributed = False
+    marker = ".svn"
+    issue = "apache/magpie#602"
+
+
+# Registry, in detection-priority order. New VCS bridges register here.
+BACKENDS: tuple[type[VCSBackend], ...] = (
+    GitBackend,
+    MercurialBackend,
+    SubversionBackend,
+)
+
+_BACKENDS_BY_NAME: dict[str, type[VCSBackend]] = {b.name: b for b in BACKENDS}
+
+
+def detect_backend(start: Path) -> VCSBackend | None:
+    """Detect the backend governing the working copy at/above ``start``.
+
+    When working copies of two VCS nest, the innermost (longest root path)
+    wins, matching how the VCS tools themselves resolve the active repo.
+    """
+    best: VCSBackend | None = None
+    best_len = -1
+    for backend_cls in BACKENDS:
+        root = backend_cls.detect(start)
+        if root is not None and len(root.parts) > best_len:
+            best = backend_cls(root)
+            best_len = len(root.parts)
+    return best
+
+
+def get_backend(start: Path, override: str | None = None) -> VCSBackend:
+    """Resolve the backend: explicit ``override`` / ``MAGPIE_VCS`` else detect."""
+    forced = override or os.environ.get(BACKEND_ENV)
+    if forced:
+        backend_cls = _BACKENDS_BY_NAME.get(forced)
+        if backend_cls is None:
+            known = ", ".join(sorted(_BACKENDS_BY_NAME))
+            raise VCSError(f"unknown backend '{forced}' (known: {known})")
+        root = backend_cls.detect(start) or start
+        return backend_cls(root)
+    backend = detect_backend(start)
+    if backend is None:
+        raise VCSError(f"no supported VCS working copy found at or above {start}")
+    return backend
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="magpie-vcs",
+        description="Source-control capability — backend-dispatching VCS operations.",
+    )
+    parser.add_argument("-C", "--cwd", default=".", help="working-copy path (default: .)")
+    parser.add_argument("--backend", help=f"force a backend (else detect / ${BACKEND_ENV})")
+    sub = parser.add_subparsers(dest="op", required=True)
+
+    sub.add_parser("detect", help="print the detected backend name")
+    sub.add_parser("backends", help="list registered backends + availability")
+    sub.add_parser("root", help="print the working-copy root")
+    sub.add_parser("status", help="porcelain working-tree status")
+    sub.add_parser("clean", help="exit 0 if clean, 1 if dirty")
+    sub.add_parser("branch", help="print the current branch")
+
+    p = sub.add_parser("diff", help="show changes")
+    p.add_argument("--base", help="diff against this ref")
+    p.add_argument("--cached", action="store_true", help="diff the staged change")
+    p.add_argument("paths", nargs="*")
+
+    p = sub.add_parser("log", help="history read")
+    p.add_argument("-n", "--max-count", type=int)
+    p.add_argument("--grep")
+    p.add_argument("--author")
+    p.add_argument("--since")
+    p.add_argument("paths", nargs="*")
+
+    p = sub.add_parser("new-branch", help="create + switch to a branch")
+    p.add_argument("name")
+
+    p = sub.add_parser("switch", help="switch to an existing ref")
+    p.add_argument("ref")
+
+    p = sub.add_parser("stage", help="stage paths for commit")
+    p.add_argument("paths", nargs="+")
+
+    p = sub.add_parser("commit", help="record the staged change")
+    p.add_argument("-m", "--message", required=True)
+
+    p = sub.add_parser("fetch", help="sync refs from the forge")
+    p.add_argument("remote", nargs="?")
+    p.add_argument("ref", nargs="?")
+
+    p = sub.add_parser("push", help="publish a ref to the forge")
+    p.add_argument("-u", "--set-upstream", action="store_true")
+    p.add_argument("remote")
+    p.add_argument("ref")
+
+    sub.add_parser("reset-worktree", help="discard all uncommitted changes")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns a process exit code."""
+    parser = _build_parser()
+    ns = parser.parse_args(argv)
+    start = Path(ns.cwd).resolve()
+
+    try:
+        if ns.op == "backends":
+            for backend_cls in BACKENDS:
+                avail = "available" if backend_cls.is_available() else "not installed"
+                print(f"{backend_cls.name}\t{avail}")
+            return 0
+
+        backend = get_backend(start, ns.backend)
+
+        if ns.op == "detect":
+            print(backend.name)
+        elif ns.op == "root":
+            print(str(backend.root))
+        elif ns.op == "status":
+            sys.stdout.write(backend.status())
+        elif ns.op == "clean":
+            return 0 if backend.is_clean() else 1
+        elif ns.op == "branch":
+            print(backend.current_branch())
+        elif ns.op == "diff":
+            sys.stdout.write(backend.diff(base=ns.base, cached=ns.cached, paths=ns.paths))
+        elif ns.op == "log":
+            sys.stdout.write(
+                backend.log(
+                    max_count=ns.max_count,
+                    grep=ns.grep,
+                    author=ns.author,
+                    since=ns.since,
+                    paths=ns.paths,
+                )
+            )
+        elif ns.op == "new-branch":
+            backend.create_branch(ns.name)
+        elif ns.op == "switch":
+            backend.switch(ns.ref)
+        elif ns.op == "stage":
+            backend.stage(ns.paths)
+        elif ns.op == "commit":
+            backend.commit(ns.message)
+        elif ns.op == "fetch":
+            backend.fetch(ns.remote, ns.ref)
+        elif ns.op == "push":
+            backend.push(ns.remote, ns.ref, set_upstream=ns.set_upstream)
+        elif ns.op == "reset-worktree":
+            backend.reset_worktree()
+        else:  # pragma: no cover - argparse enforces the choices
+            parser.error(f"unknown operation {ns.op!r}")
+    except VCSError as exc:
+        print(f"magpie-vcs: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tools/vcs/tests/test_vcs.py
+++ b/tools/vcs/tests/test_vcs.py
@@ -1,0 +1,222 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from magpie_vcs import (
+    BACKENDS,
+    GitBackend,
+    MercurialBackend,
+    SubversionBackend,
+    VCSError,
+    detect_backend,
+    get_backend,
+    main,
+)
+
+# Tests shell out to `git` in temp repos. If the process inherits
+# location-redirecting git env vars (e.g. when the suite runs inside a git
+# pre-commit hook), git would operate on the outer repo instead. Strip them
+# for the whole module so the fixture's own `git init` is unaffected; the tool
+# itself does the same scrub at runtime (see _clean_env).
+for _var in ("GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR", "GIT_PREFIX"):
+    os.environ.pop(_var, None)
+
+git_required = pytest.mark.skipif(not GitBackend.is_available(), reason="git not installed")
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True)
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-q", "-b", "main")
+    _git(repo, "config", "user.email", "t@example.com")
+    _git(repo, "config", "user.name", "Tester")
+    (repo / "file.txt").write_text("hello\n")
+    _git(repo, "add", "file.txt")
+    _git(repo, "commit", "-q", "-m", "initial commit")
+    return repo
+
+
+# -- detection -------------------------------------------------------------
+
+
+def test_detect_git(git_repo: Path) -> None:
+    backend = detect_backend(git_repo)
+    assert backend is not None
+    assert backend.name == "git"
+    assert backend.root == git_repo
+
+
+def test_detect_marks_hg_and_svn(tmp_path: Path) -> None:
+    (tmp_path / ".hg").mkdir()
+    backend = detect_backend(tmp_path)
+    assert isinstance(backend, MercurialBackend)
+
+    svn = tmp_path / "svn_wc"
+    svn.mkdir()
+    (svn / ".svn").mkdir()
+    assert isinstance(detect_backend(svn), SubversionBackend)
+
+
+def test_detect_none(tmp_path: Path) -> None:
+    assert detect_backend(tmp_path) is None
+
+
+def test_nested_innermost_wins(git_repo: Path) -> None:
+    inner = git_repo / "inner"
+    inner.mkdir()
+    (inner / ".hg").mkdir()
+    backend = detect_backend(inner)
+    assert isinstance(backend, MercurialBackend)
+    assert backend.root == inner
+
+
+def test_get_backend_override(git_repo: Path) -> None:
+    assert get_backend(git_repo, override="git").name == "git"
+    with pytest.raises(VCSError, match="unknown backend"):
+        get_backend(git_repo, override="bzr")
+
+
+def test_get_backend_env(git_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MAGPIE_VCS", "hg")
+    assert get_backend(git_repo).name == "hg"
+
+
+def test_get_backend_no_repo(tmp_path: Path) -> None:
+    with pytest.raises(VCSError, match="no supported VCS"):
+        get_backend(tmp_path)
+
+
+# -- git backend operations ------------------------------------------------
+
+
+@git_required
+def test_git_clean_then_dirty(git_repo: Path) -> None:
+    backend = GitBackend(git_repo)
+    assert backend.is_clean()
+    (git_repo / "file.txt").write_text("changed\n")
+    assert not backend.is_clean()
+    assert "file.txt" in backend.status()
+
+
+@git_required
+def test_git_branch_and_commit(git_repo: Path) -> None:
+    backend = GitBackend(git_repo)
+    assert backend.current_branch() == "main"
+    backend.create_branch("fix/thing")
+    assert backend.current_branch() == "fix/thing"
+    (git_repo / "new.txt").write_text("x\n")
+    backend.stage(["new.txt"])
+    assert "new.txt" in backend.diff(cached=True)
+    backend.commit("add new.txt")
+    assert backend.is_clean()
+    assert "add new.txt" in backend.log(max_count=1)
+
+
+@git_required
+def test_git_ignores_inherited_git_dir(git_repo: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Simulate running inside an outer git context (e.g. a pre-commit hook):
+    # the tool must resolve the repo from its cwd, not from $GIT_DIR.
+    monkeypatch.setenv("GIT_DIR", str(git_repo.parent / "elsewhere" / ".git"))
+    monkeypatch.setenv("GIT_INDEX_FILE", str(git_repo.parent / "elsewhere" / "index"))
+    backend = GitBackend(git_repo)
+    assert backend.current_branch() == "main"
+    assert backend.is_clean()
+
+
+@git_required
+def test_git_log_grep(git_repo: Path) -> None:
+    backend = GitBackend(git_repo)
+    assert "initial commit" in backend.log(grep="initial")
+    assert backend.log(grep="nonexistent-token").strip() == ""
+
+
+@git_required
+def test_git_stage_nothing_rejected(git_repo: Path) -> None:
+    with pytest.raises(VCSError, match="refusing to stage nothing"):
+        GitBackend(git_repo).stage([])
+
+
+@git_required
+def test_git_reset_worktree(git_repo: Path) -> None:
+    backend = GitBackend(git_repo)
+    (git_repo / "file.txt").write_text("dirty\n")
+    (git_repo / "untracked.txt").write_text("junk\n")
+    backend.reset_worktree()
+    assert backend.is_clean()
+    assert not (git_repo / "untracked.txt").exists()
+    assert (git_repo / "file.txt").read_text() == "hello\n"
+
+
+# -- unimplemented backends ------------------------------------------------
+
+
+def test_unimplemented_raise_with_issue(tmp_path: Path) -> None:
+    hg = MercurialBackend(tmp_path)
+    with pytest.raises(VCSError, match=r"apache/magpie#601"):
+        hg.status()
+    svn = SubversionBackend(tmp_path)
+    with pytest.raises(VCSError, match=r"apache/magpie#602"):
+        svn.commit("x")
+    assert svn.distributed is False  # centralized model flagged
+
+
+def test_registry_unique_names() -> None:
+    names = [b.name for b in BACKENDS]
+    assert names == sorted(set(names), key=names.index)
+    assert "git" in names
+
+
+# -- CLI -------------------------------------------------------------------
+
+
+@git_required
+def test_cli_detect_and_status(git_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["-C", str(git_repo), "detect"]) == 0
+    assert capsys.readouterr().out.strip() == "git"
+
+    (git_repo / "file.txt").write_text("z\n")
+    assert main(["-C", str(git_repo), "clean"]) == 1
+    main(["-C", str(git_repo), "reset-worktree"])
+    assert main(["-C", str(git_repo), "clean"]) == 0
+
+
+def test_cli_backends_lists_all(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["backends"]) == 0
+    out = capsys.readouterr().out
+    for name in ("git", "hg", "svn"):
+        assert name in out
+
+
+def test_cli_unknown_backend_errors(git_repo: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["-C", str(git_repo), "--backend", "bzr", "status"]) == 2
+    assert "unknown backend" in capsys.readouterr().err
+
+
+def test_cli_unimplemented_backend_errors(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    (tmp_path / ".hg").mkdir()
+    assert main(["-C", str(tmp_path), "status"]) == 2
+    assert "apache/magpie#601" in capsys.readouterr().err

--- a/uv.lock
+++ b/uv.lock
@@ -21,6 +21,7 @@ members = [
     "github-body-field",
     "github-rollup",
     "jira-bridge",
+    "magpie-vcs",
     "oauth-draft",
     "permission-audit",
     "pr-management-stats",
@@ -510,6 +511,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/62/4a/7d1415567027286a75ba1093ec4aca11f073e0f559c530cf3e0a757ad55c/librt-0.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:28edb433edde181112a908c78907af28f964eabc15f4dd16c9d66c834302677c", size = 124327, upload-time = "2026-05-10T18:17:05.465Z" },
     { url = "https://files.pythonhosted.org/packages/ce/62/b40b382fa0c66fee1478073eb8db352a4a6beda4a1adccf1df911d8c289c/librt-0.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dee008f20b542e3cd162ba338a7f9ec0f6d23d395f66fe8aeeec3c9d067ea253", size = 102572, upload-time = "2026-05-10T18:17:06.809Z" },
 ]
+
+[[package]]
+name = "magpie-vcs"
+version = "0.1.0"
+source = { editable = "tools/vcs" }
 
 [[package]]
 name = "mypy"


### PR DESCRIPTION
## Summary

Extracts the **source-control (VCS) capability** — whose contract landed in
#609 ([`tools/github/source-control.md`](tools/github/source-control.md)) —
into a runnable, tested, backend-dispatching tool: **`tools/vcs/`**
(`magpie-vcs`). A non-Git VCS now plugs in at **one** place (a backend class)
instead of editing every git-using skill.

## The abstraction

- **`VCSBackend`** — abstract interface with exactly the operations from the
  capability's *What the skills require* table: `status`/`is_clean`,
  `current_branch`, `diff`, `log`, `create_branch`, `switch`, `stage`,
  `commit`, `fetch`, `push`, `reset_worktree`.
- **`GitBackend`** — complete Git binding (the default; GitHub's native VCS).
- **`MercurialBackend` / `SubversionBackend`** — real **detection** (so
  `magpie-vcs detect` reports the working copy's VCS) but operations raise an
  actionable `VCSError` naming the bridge issue (#601 / #602). SVN carries
  `distributed = False`. A bridge lands by replacing the stub base with a
  concrete subclass — dispatch, the CLI, and every skill calling `magpie-vcs`
  pick it up unchanged.
- Backend **detection** is innermost-wins; override via `--backend` /
  `$MAGPIE_VCS`.
- Hardened against inherited `GIT_*` env so a skill invoking it from inside a
  git hook resolves the repo from `--cwd`, not a stray `GIT_DIR`.

```bash
uv run --project tools/vcs magpie-vcs -C <upstream> diff --base main
uv run --project tools/vcs magpie-vcs -C <upstream> log --grep ISSUE-123
uv run --project tools/vcs magpie-vcs -C <upstream> detect
```

Write operations stay gated on explicit user confirmation **in the calling
skill** — the tool adds no prompt of its own.

## Registration & wiring

- uv **workspace member** (`pyproject.toml`) + regenerated `uv.lock`
- **Capability to tool map** row in `docs/labels-and-capabilities.md`
  (`capability:setup`) — capability-sync validator passes
- Back-reference from `tools/github/source-control.md` → the implementation
- README with capability declaration + usage

## Validation

All hooks green via `prek run`:

- ruff / ruff-format / **mypy** clean
- **19 tests** (Git ops against a temp repo, detection/override, inherited-
  `GIT_*` regression, stub-backend errors, CLI exit codes)
- doctoc / markdownlint / lychee / check-placeholders / check-workspace-members
- **skill-and-tool-validate** (skills, tools, capability sync)
- **workspace-pytest** passes via `prek run --all-files`

> Note: a plain `git commit` (not `--no-verify`) trips `workspace-pytest`
> because git exports `GIT_DIR`/`GIT_INDEX_FILE` into hook subprocesses,
> which breaks any test that shells out to git in a temp repo — it hits the
> pre-existing `agent-isolation` tests too (they pass 54/54 standalone). This
> PR's tests are hardened against it; the hook passes outside the commit
> context. The `prek`-doesn't-scrub-`GIT_*` wrinkle is pre-existing and worth
> a separate issue.

## Follow-ups

The non-Git backends are deliberate extension points for the VCS bridge
issues: #601 (Mercurial), #602 (Subversion), #603 (Jujutsu), #604 (Fossil),
#605 (Perforce).

---

*Generated-by: Claude Code (Opus 4.8), reviewed by the submitter before opening.*
