### PR TITLE
fix(tools/dev): scrub location-redirecting git env vars in run-workspace-check.sh

### DIFF
--- a/tools/dev/run-workspace-check.sh
+++ b/tools/dev/run-workspace-check.sh
@@ -66,6 +66,16 @@ CHECK_KEY="$1"
 CHECK_CMD="$2"
 shift 2
 
+# Scrub location-redirecting git env vars. When pre-commit runs this script
+# as a git hook, git exports GIT_DIR / GIT_INDEX_FILE / GIT_WORK_TREE (etc.)
+# pointing at *this* repository. Any member test that shells out to `git` in
+# a throwaway repo (e.g. tools/agent-isolation, tools/vcs) would otherwise
+# inherit those and operate on the wrong repository — passing standalone but
+# failing under `git commit`. Unsetting them makes git resolve the repo from
+# each test's own cwd. This script reads pyproject.toml via Python, not git,
+# so it needs none of these itself.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_PREFIX
+
 # On Apple Silicon Macs, git ships as x86_64 (Rosetta). Pre-commit hooks
 # invoked by git therefore run in an x86_64 context where universal Python
 # binaries also run as x86_64, which cannot load arm64-compiled extensions


### PR DESCRIPTION
## Summary

Fixes the `workspace-*` pre-commit hooks failing under a real `git commit`
while passing standalone.

When pre-commit runs `tools/dev/run-workspace-check.sh` **as a git hook**, git
exports the location-redirecting env vars (`GIT_DIR`, `GIT_INDEX_FILE`,
`GIT_WORK_TREE`, …) pointing at *this* repository. Any workspace member test
that shells out to `git` in a throwaway repo — `tools/agent-isolation`,
`tools/vcs` — inherited those and operated on the wrong repository, so it
passed standalone but failed under `git commit` (forcing `--no-verify`).

## Fix

Unset the location-redirecting `GIT_*` vars at the top of
`run-workspace-check.sh`, so git resolves each test's repo from its own cwd.
The script reads `pyproject.toml` via Python, never git, so it needs none of
them itself. One change fixes every member — current and future — at the
single chokepoint the four `workspace-*` hooks already route through.

```sh
unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_PREFIX
```

## Verification

- **Negative control:** `agent-isolation` pytest *fails* with
  `GIT_DIR`/`GIT_INDEX_FILE` set and no scrub → root cause confirmed.
- **Positive:** fixed script under a simulated hook env → all **21** workspace
  members pass.
- **Definitive:** a real `git commit` (not `--no-verify`) of this change ran
  the hooks and **`pytest (workspace)` passed** — the exact stage that failed
  before.

## Context

Surfaced while landing #610 (`tools/vcs`), whose git-touching tests hit the
same wrinkle and had to be merged with `--no-verify`. This removes the need
for that going forward.

---

*Generated-by: Claude Code (Opus 4.8), reviewed by the submitter before opening.*
