### PR TITLE
feat(tools): require and document a Prerequisites section for every tool

### DIFF
--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -4,7 +4,7 @@
 
 - [How Magpie achieves vendor neutrality](#how-magpie-achieves-vendor-neutrality)
   - [Two questions that get conflated](#two-questions-that-get-conflated)
-  - [The five axes of neutrality](#the-five-axes-of-neutrality)
+  - [The six axes of neutrality](#the-six-axes-of-neutrality)
   - [The mechanism: skills, tools, capabilities](#the-mechanism-skills-tools-capabilities)
     - [Skills target the abstraction, never a vendor's client](#skills-target-the-abstraction-never-a-vendors-client)
     - [Tools are the only place vendor-specific code lives](#tools-are-the-only-place-vendor-specific-code-lives)
@@ -13,8 +13,9 @@
     - [1. LLM backend](#1-llm-backend)
     - [2. Agentic runtime](#2-agentic-runtime)
     - [3. Forge and tracker](#3-forge-and-tracker)
-    - [4. Source control (VCS)](#4-source-control-vcs)
-    - [5. Project governance](#5-project-governance)
+    - [4. Communication channels](#4-communication-channels)
+    - [5. Source control (VCS)](#5-source-control-vcs)
+    - [6. Project governance](#6-project-governance)
   - [What keeps it neutral over time](#what-keeps-it-neutral-over-time)
   - [The contribution model — neutrality as an invitation](#the-contribution-model--neutrality-as-an-invitation)
   - [Status at a glance](#status-at-a-glance)
@@ -74,20 +75,21 @@ documented contract — not a fork of the workflows.** That is what
 "vendor neutral" means here, and it is the only definition that is both
 achievable and useful.
 
-## The five axes of neutrality
+## The six axes of neutrality
 
-"Vendor" is not one thing. Magpie is neutral across five independent
+"Vendor" is not one thing. Magpie is neutral across six independent
 axes, and a backend choice on one axis never constrains the others:
 
 | Axis | The "vendor" | Neutral by… |
 |---|---|---|
 | **LLM backend** | Anthropic, OpenAI, Google, Bedrock, local Ollama/vLLM, a future ASF endpoint | Skills written against a model *contract* (capability floor), not a client; a privacy gate that keys on endpoint identity, not on who hosts it |
 | **Agentic runtime** | Claude Code, Codex, Cursor, Gemini CLI, Copilot, OpenCode, Kiro, … | Skills are [`AGENTS.md`](https://agents.md/)-standard markdown under a shared `.agents/skills/` home that every runtime reads |
-| **Forge / tracker** | GitHub, GitLab, Gitea, Forgejo, Pagure, Bitbucket, Jira, mailing lists | Per-interface **tools** behind capability contracts; many tools are pure adapter *specs* with pluggable backends |
+| **Forge / tracker** | GitHub, GitLab, Gitea, Forgejo, Pagure, Bitbucket, Jira, Bugzilla | Per-interface **tools** behind capability contracts; many tools are pure adapter *specs* with pluggable backends |
+| **Communication channels** | Mailing lists, GitHub Discussions, Discourse, Zulip, Matrix, IRC | Mail-archive / mail-source adapter contracts; chat and forum bridges as sibling tools |
 | **Source control (VCS)** | Git, Mercurial, Subversion, Jujutsu, Fossil, Perforce, … | A single `VCSBackend` contract; skills call the abstract operation, the backend is detected from the working copy |
 | **Project governance** | ASF PMC, foundation-hosted, single-vendor, informal maintainer group | Modes and thresholds are adopter config; non-ASF adopters are first-class ([`PRINCIPLES.md` §3](../PRINCIPLES.md#3-project-autonomy-is-the-structural-starting-point)) |
 
-The rest of this page walks the mechanism that makes all five true,
+The rest of this page walks the mechanism that makes all six true,
 then states exactly where each axis stands today.
 
 ## The mechanism: skills, tools, capabilities
@@ -153,6 +155,15 @@ with pluggable backends already include:
 | [`tools/forwarder-relay`](../tools/forwarder-relay/) | ASF Security relay, huntr.com, HackerOne triagers |
 | [`tools/scan-format`](../tools/scan-format/) | security-scanner report formats (ASVS reference) |
 | [`tools/vcs`](../tools/vcs/) | Git (complete), Mercurial, Subversion, … (extension points) |
+
+The security-team surface follows the same pattern: CNA backends live
+behind [`tools/cve-tool`](../tools/cve-tool/) (the ASF Vulnogram adapter
+[`tools/cve-tool-vulnogram`](../tools/cve-tool-vulnogram/) is the landed
+reference), inbound report relays behind
+[`tools/forwarder-relay`](../tools/forwarder-relay/), scanner formats
+behind [`tools/scan-format`](../tools/scan-format/), and an OSV.dev
+vulnerability cross-reference bridge is the open extension point
+([#311](https://github.com/apache/magpie/issues/311)).
 
 The distinction Magpie enforces: **vendor-specific *integrations* are
 expected and welcome; vendor-specific *workflows* are forbidden.** A
@@ -247,7 +258,7 @@ issue`, not hypothetical:
 [Codeberg / Gitea / Forgejo](https://github.com/apache/magpie/issues/310),
 [Pagure](https://github.com/apache/magpie/issues/312) (Fedora /
 `pagure.io`),
-[Bitbucket](https://github.com/apache/magpie/issues/306) (deep Jira
+[Bitbucket](https://github.com/apache/magpie/issues/606) (deep Jira
 pairing), and
 [SourceHut](https://github.com/apache/magpie/issues/607) (email-patch
 review). Tracker-only surfaces are tracked the same way — e.g.
@@ -257,7 +268,33 @@ tracker capability and the source-control capability are *separable*: a
 project can pair, say, GitHub issues with a Subversion working copy, or
 a Bitbucket forge over Git, because each is a distinct contract.
 
-### 4. Source control (VCS)
+### 4. Communication channels
+
+Project conversation does not all live on the forge. The intake and
+mentoring skills read mailing-list archives, and a project may run its
+discussion on a forum or chat system instead of (or alongside) a list.
+Both surfaces sit behind adapter contracts:
+
+- [`tools/mail-archive`](../tools/mail-archive/) — public archive reads
+  across PonyMail, Hyperkitty, Discourse, Google Groups, GitHub
+  Discussions.
+- [`tools/mail-source`](../tools/mail-source/) — raw mail ingestion
+  across mbox, IMAP, Mailman 3.
+
+The open extension points are labelled `good first issue`:
+mail-source backends —
+[mbox](https://github.com/apache/magpie/issues/304),
+[IMAP](https://github.com/apache/magpie/issues/303),
+[Mailman 3 / Hyperkitty](https://github.com/apache/magpie/issues/306);
+and chat / forum bridges —
+[Discourse](https://github.com/apache/magpie/issues/307),
+[Zulip](https://github.com/apache/magpie/issues/308),
+[Matrix / Element](https://github.com/apache/magpie/issues/309). A
+project on IRC, Slack, or any other channel plugs in the same way — a
+sibling tool fulfilling the read capability the mentoring / intake
+skills declare, with no skill change.
+
+### 5. Source control (VCS)
 
 The newest axis to be abstracted, and a good worked example of the
 mechanism. Earlier, dev-loop skills inlined `git …` calls. Two changes
@@ -271,19 +308,29 @@ fixed that:
   (`magpie-vcs`) runs the *abstract* operation and detects the active
   backend from the working copy.
 
-Today: **Git is complete** (the default binding); Mercurial and
-Subversion are real, detected extension points that raise an actionable
-error naming their tracking issue until the full binding lands. Adding
-a backend means replacing one `_UnimplementedBackend` with a concrete
-`VCSBackend` subclass — detection, dispatch, the CLI, and every skill
-that calls `magpie-vcs` pick it up automatically. Nothing else changes.
+Today: **Git is complete** (the default binding); Mercurial
+([#601](https://github.com/apache/magpie/issues/601)) and Subversion
+([#602](https://github.com/apache/magpie/issues/602)) are real, detected
+extension points that raise an actionable error naming their tracking
+issue until the full binding lands. Adding a backend means replacing one
+`_UnimplementedBackend` with a concrete `VCSBackend` subclass —
+detection, dispatch, the CLI, and every skill that calls `magpie-vcs`
+pick it up automatically. Nothing else changes.
 
-Tracking issues exist for the non-Git systems — Mercurial, Subversion
-(ASF-critical: `svn.apache.org` and the release `dist.apache.org` area
-are SVN), Jujutsu, Fossil, Perforce, Bitbucket, SourceHut — so the
-extension points are public and labelled, not hypothetical.
+Tracking issues exist, labelled `good first issue`, for the rest of the
+non-Git systems:
+[Mercurial](https://github.com/apache/magpie/issues/601),
+[Subversion](https://github.com/apache/magpie/issues/602) (ASF-critical:
+`svn.apache.org` and the release `dist.apache.org` area are SVN; the
+full ASF SVN surface is [#608](https://github.com/apache/magpie/issues/608)),
+[Jujutsu](https://github.com/apache/magpie/issues/603),
+[Fossil](https://github.com/apache/magpie/issues/604), and
+[Perforce](https://github.com/apache/magpie/issues/605) — so the
+extension points are public and labelled, not hypothetical. (The
+Bitbucket and SourceHut forges, which carry their own VCS, are tracked
+under the forge axis above.)
 
-### 5. Project governance
+### 6. Project governance
 
 Vendor neutrality extends to *how a project is run*, not just to its
 tooling. Each adopting project picks which modes run and how much
@@ -344,8 +391,9 @@ coverage without pretending one team can implement an open-ended set.
 |---|---|---|---|
 | LLM backend | ✅ by construction | Claude Code, Ollama, vLLM, Apache-hosted, Bedrock, direct Anthropic | Any endpoint meeting the capability floor + privacy gate |
 | Agentic runtime | ✅ by construction (`AGENTS.md` standard) | Claude Code; community use under Codex, Cursor, Gemini CLI, Copilot, OpenCode, Kiro | Runtime adapters [#313–#322](https://github.com/apache/magpie/issues?q=is%3Aissue+state%3Aopen+adapter+in%3Atitle) |
-| Forge / tracker | ✅ by construction | GitHub, Jira; mail/CVE/scan/relay via adapter contracts | GitLab [#305](https://github.com/apache/magpie/issues/305), Forgejo/Gitea [#310](https://github.com/apache/magpie/issues/310), Pagure [#312](https://github.com/apache/magpie/issues/312), Bitbucket [#306](https://github.com/apache/magpie/issues/306), SourceHut [#607](https://github.com/apache/magpie/issues/607), Bugzilla [#302](https://github.com/apache/magpie/issues/302) |
-| Source control (VCS) | ✅ by construction | **Git (complete)** | Mercurial, Subversion (detected); Jujutsu, Fossil, Perforce, Bitbucket, SourceHut (tracked) |
+| Forge / tracker | ✅ by construction | GitHub, Jira; CVE/scan/relay via adapter contracts | GitLab [#305](https://github.com/apache/magpie/issues/305), Forgejo/Gitea [#310](https://github.com/apache/magpie/issues/310), Pagure [#312](https://github.com/apache/magpie/issues/312), Bitbucket [#606](https://github.com/apache/magpie/issues/606), SourceHut [#607](https://github.com/apache/magpie/issues/607), Bugzilla [#302](https://github.com/apache/magpie/issues/302) |
+| Communication channels | ✅ by construction | PonyMail / mail-archive reads | mbox [#304](https://github.com/apache/magpie/issues/304), IMAP [#303](https://github.com/apache/magpie/issues/303), Mailman 3 [#306](https://github.com/apache/magpie/issues/306); Discourse [#307](https://github.com/apache/magpie/issues/307), Zulip [#308](https://github.com/apache/magpie/issues/308), Matrix [#309](https://github.com/apache/magpie/issues/309) |
+| Source control (VCS) | ✅ by construction | **Git (complete)** | Mercurial [#601](https://github.com/apache/magpie/issues/601), Subversion [#602](https://github.com/apache/magpie/issues/602)/[#608](https://github.com/apache/magpie/issues/608) (detected); Jujutsu [#603](https://github.com/apache/magpie/issues/603), Fossil [#604](https://github.com/apache/magpie/issues/604), Perforce [#605](https://github.com/apache/magpie/issues/605) (tracked) |
 | Project governance | ✅ by construction | ASF + non-ASF adopter profiles | Adopter config (modes, thresholds) |
 
 ✅ "by construction" means the workflows carry no vendor assumption;

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,90 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [AGENTS — conventions for `tools/`](#agents--conventions-for-tools)
+  - [Every tool is a directory with a README](#every-tool-is-a-directory-with-a-readme)
+  - [Refresh the cross-references when tools change](#refresh-the-cross-references-when-tools-change)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# AGENTS — conventions for `tools/`
+
+Operational context for everything under `tools/`. It is loaded in
+addition to the repository-wide [`/AGENTS.md`](../AGENTS.md), which still
+governs everything (commit trailers, placeholder convention,
+privacy/security posture). Where the two overlap, the repo-wide
+`AGENTS.md` wins.
+
+A **tool** is the only layer that is allowed to know a specific vendor
+exists — the generic skills target capabilities, and each tool fulfils a
+capability for one concrete backend. See
+[`docs/vendor-neutrality.md`](../docs/vendor-neutrality.md) for how the
+skills / tools / capabilities split delivers vendor neutrality, and
+[`docs/labels-and-capabilities.md`](../docs/labels-and-capabilities.md)
+for the capability taxonomy.
+
+## Every tool is a directory with a README
+
+Each tool lives at `tools/<name>/` and **must** have a `README.md` that
+declares, up front:
+
+1. **Its capability** — a line of the exact form
+
+   ```markdown
+   **Capability:** capability:NAME
+   ```
+
+   (multi-value: `capability:NAME + capability:NAME`), with NAME drawn
+   from the taxonomy in `docs/labels-and-capabilities.md`. Substrate
+   bridges default to `capability:setup`.
+
+2. **Its prerequisites** — a `## Prerequisites` section stating what the
+   tool needs *before it can run*, so an adopter never discovers a
+   missing dependency at first invocation. Cover the bullets that apply:
+
+   - **Runtime** — e.g. `Python 3.11+ run via uv`, `Bash + coreutils`,
+     `Python stdlib only`, `Node.js 20+`. State it even when trivial.
+   - **CLIs** — external commands the tool shells out to (`gh`, `git`,
+     `svn`, `jq`, `groovy`, `docker`/`podman`, `bubblewrap`, `socat`, …),
+     or `None beyond the runtime`.
+   - **Credentials / auth** — `gh auth status`, an OAuth token at a
+     home-dir path, an API-token env var, …, or `None`.
+   - **Network** — the hosts it reaches (`api.github.com`,
+     `*.apache.org`, a JIRA host, …), or state that it runs fully
+     offline / on local files.
+   - **Optional** — real optional dependencies or features only.
+
+   Keep it factual and tight (≈3–6 bullets); never invent a dependency.
+   A pure interface-spec tool (an adapter *contract* with no executable
+   code) says so and defers concrete prerequisites to its adapters.
+
+Both are **HARD** checks in
+[`tools/skill-and-tool-validator`](skill-and-tool-validator/) — a tool
+README missing either the `**Capability:**` line or the
+`## Prerequisites` section fails `skill-and-tool-validate` (and the
+`prek` / pre-commit hook that runs it).
+
+## Refresh the cross-references when tools change
+
+The tool inventory is referenced from a few hand-maintained places.
+When you **add, rename, remove, or re-scope** a tool — or change which
+backends it supports or the tracking issues behind its extension
+points — review and refresh:
+
+- [`docs/labels-and-capabilities.md`](../docs/labels-and-capabilities.md)
+  — the *Capability to tool map* row. The validator's `capability-sync`
+  check enforces that every tool with a `**Capability:**` declaration has
+  a matching row, so this one fails the build if you forget it.
+- [`docs/vendor-neutrality.md`](../docs/vendor-neutrality.md) — the
+  per-axis extension-point citations (the axis prose, the
+  *contract tool* table, and the *Status at a glance* table). This list
+  is **not** machine-checked; it is the public explanation of which
+  backends work today and which are open extension points, so it has to
+  be refreshed by hand whenever a tool or its tracking issue changes.
+
+When in doubt about whether a doc references the tool you touched, grep
+`docs/` for the tool name before opening the PR.

--- a/tools/agent-guard/README.md
+++ b/tools/agent-guard/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [agent-guard](#agent-guard)
+  - [Prerequisites](#prerequisites)
   - [Guards](#guards)
   - [Per-command overrides](#per-command-overrides)
   - [Wiring](#wiring)
@@ -27,6 +28,13 @@ It is **stdlib-only** and is invoked directly as
 `python3 <path>/agent_guard/__init__.py` (never via `uv run`) so it returns in a
 few milliseconds for any command that is not a guarded `gh` / `git commit` /
 `git push`.
+
+## Prerequisites
+
+- **Runtime:** Python stdlib only — the hook runs as `python3 .../agent_guard/__init__.py` (3.11+), never via `uv`, so it needs no built/installed environment. The test suite runs under `uv run --project tools/agent-guard pytest`.
+- **CLIs:** `git` and `gh` — the guards shell out (via `ctx.run`) to inspect commits, branch state, and GitHub Actions runs. None otherwise.
+- **Credentials / auth:** None. The guards read local `git` / `gh` state; `gh` must be on `PATH` for the `mark-ready` guard's Actions lookup.
+- **Network:** None in the hot path; the `mark-ready` guard reaches `api.github.com` (via `gh`) when it checks for awaiting-approval Actions runs.
 
 ## Guards
 

--- a/tools/agent-isolation/README.md
+++ b/tools/agent-isolation/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/agent-isolation/` — secure agent setup helpers](#toolsagent-isolation--secure-agent-setup-helpers)
+  - [Prerequisites](#prerequisites)
   - [Files](#files)
   - [Usage at a glance](#usage-at-a-glance)
   - [Referenced by](#referenced-by)
@@ -22,6 +23,13 @@ references. It is not a Python project (unlike the sibling tools
 under `tools/cve-tool-vulnogram/` and `tools/gmail/oauth-draft/`) — these are
 plain shell scripts plus a TOML manifest of pinned upstream
 versions.
+
+## Prerequisites
+
+- **Runtime:** Bash + coreutils — this directory is plain shell scripts plus a TOML manifest, not a Python project (the `pyproject.toml` ships only the test harness, which runs under Python 3.11+ via `uv`). `claude-term-bg.sh` uses `python3` / `python` for one heuristic and falls back to calm when absent.
+- **CLIs:** `jq` (required by `check-tool-updates.sh` and the status-line scripts), `curl` (the update check), `git` (status line / git hooks), and `gh` (optional — status-line PR title). The secure setup itself installs the pinned `bubblewrap` and `socat` (via `apt-get`) and `@anthropic-ai/claude-code` (via `npm`).
+- **Credentials / auth:** None for these helpers; the wrapped `claude` session authenticates on its own (and `claude-iso.sh` deliberately strips credential-shaped env vars).
+- **Network:** `api.github.com` and `www.dest-unreach.org` (the release checks in `check-tool-updates.sh`); the install step also reaches the apt and npm registries.
 
 ## Files
 

--- a/tools/apache-projects/README.md
+++ b/tools/apache-projects/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/apache-projects/`](#toolsapache-projects)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -23,3 +24,10 @@ roster-resolution paths in the security skills. For ASF projects it
 is a mandatory pre-flight prerequisite, installed from the latest
 `main` of `apache/comdev`. See [`tool.md`](tool.md) for the
 operation catalogue, setup, and the track-`main` install contract.
+
+## Prerequisites
+
+- **Runtime:** Node.js 20+ — the backing tool is the official `apache/comdev` `apache-projects-mcp` server (a Node.js package), run as `node .../index.js`. This directory ships no code of its own.
+- **CLIs:** `git` (clone the `apache/comdev` checkout), `npm` (install the server's deps), `node` (run it).
+- **Credentials / auth:** None — the server is read-only and unauthenticated; every field it returns is already public.
+- **Network:** `projects.apache.org` (the public JSON feeds the server fetches at run time); `github.com` to clone and track `apache/comdev` at `main`.

--- a/tools/cve-org/README.md
+++ b/tools/cve-org/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/cve-org/`](#toolscve-org)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:resolve + capability:intake
 
 CVE.org publication client. Submits CVE records via the CVE.org REST API; consumed by `security-cve-allocate` once a CVE has been allocated via the ASF Vulnogram path. See [`tool.md`](tool.md) for the protocol detail and `cve.org` field mapping.
+
+## Prerequisites
+
+- **Runtime:** None of its own — this directory documents a read-only adapter; the publication-state check is a `curl` + `jq` one-liner (see `tool.md`).
+- **CLIs:** `curl` and `jq`.
+- **Credentials / auth:** None — cve.org is the public CVE registry and the CVE Services API has no auth.
+- **Network:** `cveawg.mitre.org` (CVE Services API v2) and `www.cve.org` (the HTML record); optionally `nvd.nist.gov` for the alternative public registry.

--- a/tools/cve-tool-vulnogram/README.md
+++ b/tools/cve-tool-vulnogram/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/cve-tool-vulnogram/`](#toolscve-tool-vulnogram)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:resolve
 
 ASF Vulnogram CVE-allocation client. OAuth-authenticated API that allocates a CVE ID through the ASF's Vulnogram instance and publishes the CVE record. Consumed by `security-cve-allocate`. See [`allocation.md`](allocation.md), [`record.md`](record.md), and [`bot-credits-policy.md`](bot-credits-policy.md) for the protocol.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (the `generate-cve-json` and `oauth-api` helpers are stdlib-only — no system install needed).
+- **CLIs:** `gh` (authenticated) — `generate-cve-json` shells out to it for tracker/GitHub access.
+- **Credentials / auth:** `gh auth status` must pass; the Vulnogram API helpers read a session token at `~/.config/apache-magpie/vulnogram-session.json` (mode `0600`, created by `vulnogram-api-setup`).
+- **Network:** `cveprocess.apache.org` (Vulnogram session API) and `api.github.com` (via `gh`).

--- a/tools/cve-tool/README.md
+++ b/tools/cve-tool/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/cve-tool/`](#toolscve-tool)
+  - [Prerequisites](#prerequisites)
   - [What this is](#what-this-is)
   - [Today's adapters](#todays-adapters)
   - [Interface](#interface)
@@ -24,6 +25,11 @@
 # `tools/cve-tool/`
 
 **Capability:** capability:setup
+
+## Prerequisites
+
+- **Runtime:** None — this directory is a Markdown contract spec; no executable code ships here. It is read by the framework, not run.
+- **CLIs / credentials / network:** Provided entirely by the resolved adapter — the sibling `tools/cve-tool-<name>/` directory named by `cve_authority.tool` in `project.md` (the ASF default is Vulnogram at `tools/cve-tool-vulnogram/`). See that adapter for its concrete prerequisites.
 
 ## What this is
 

--- a/tools/dashboard-generator/README.md
+++ b/tools/dashboard-generator/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Dashboard generator](#dashboard-generator)
+  - [Prerequisites](#prerequisites)
   - [Layout](#layout)
   - [Invocation](#invocation)
   - [Contract](#contract)
@@ -29,6 +30,17 @@ The agent-emitted version (via the skill) is the **default**; the
 reference implementations are a *deterministic* alternative for
 adopters who want byte-for-byte reproducibility (CI pipelines,
 audit trails).
+
+## Prerequisites
+
+- **Runtime:** Groovy (JVM) for the working `reference.groovy`
+  (`MarkupBuilder` + `JsonSlurper`); `reference.py` is a Python 3
+  stdlib-only stub.
+- **CLIs:** `groovy` to run the Groovy reference. None beyond that.
+- **Credentials / auth:** None.
+- **Network:** None — reads local `<campaign-dir>/<KEY>/verdict.json`
+  files and emits self-contained HTML (inline CSS, no JS, no external
+  assets).
 
 ## Layout
 

--- a/tools/dev/README.md
+++ b/tools/dev/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/dev/`](#toolsdev)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:setup
 
 Framework dev-loop helpers (placeholder check, agent pre-commit hook). Invoked by prek and CI; not consumed by any skill directly. See the individual scripts in this directory for usage.
+
+## Prerequisites
+
+- **Runtime:** Bash + coreutils; `check-workspace-members.py` runs under `python3`.
+- **CLIs:** `uv` (the workspace checks run `uv run`), `git`, and `prek` (or `pre-commit`) — these scripts wire up the framework's hooks.
+- **Credentials / auth:** None.
+- **Network:** Local checks; `uv` may resolve workspace dependencies from PyPI (`pypi.org`, `files.pythonhosted.org`) on first sync.

--- a/tools/egress-gateway/README.md
+++ b/tools/egress-gateway/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [egress-gateway](#egress-gateway)
+  - [Prerequisites](#prerequisites)
   - [Run it](#run-it)
   - [Point tools at it](#point-tools-at-it)
   - [The allowlist](#the-allowlist)
@@ -29,6 +30,20 @@ destination is blocked.
 
 The contract (what/why) lives in [`tool.md`](tool.md); this file is the
 how-to.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (no system install needed).
+- **Dependencies:** `proxy.py` (`>=2.4,<3`) — the forward-proxy runtime,
+  resolved by `uv` from PyPI; the allowlist policy is the only first-party code.
+- **CLIs:** None beyond the runtime.
+- **Credentials / auth:** None.
+- **Network:** Binds a loopback listen socket (default `127.0.0.1:8899`) and
+  makes unrestricted outbound by design — must run in a **non-sandboxed**
+  context. Needs a writable `$HOME` (or a `HOME` override) for runtime state
+  under `~/.proxy`. Default allowlist mirrors the sandbox's curated domains
+  (ASF infra, GitHub, Google APIs, PyPI).
+- **Optional:** the `dev` dependency group (`pytest`, `ruff`, `mypy`) to run the test suite.
 
 ## Run it
 

--- a/tools/forwarder-relay/README.md
+++ b/tools/forwarder-relay/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [tools/forwarder-relay/ — adapter contract](#toolsforwarder-relay--adapter-contract)
+  - [Prerequisites](#prerequisites)
   - [What "a relay message" means](#what-a-relay-message-means)
   - [Today's adapters](#todays-adapters)
     - [Sub-skill consumers](#sub-skill-consumers)
@@ -46,6 +47,17 @@ that adopters whose security inbox sits behind huntr.com,
 HackerOne, GitHub Security Advisories, an internal SOC, or any
 other forwarding service can plug in an adapter without
 patching the skill bodies.
+
+## Prerequisites
+
+- **Runtime:** None — this is a prose adapter *contract*; no executable
+  ships in this directory. The interface is implemented by the security
+  skills that dispatch through it.
+- **CLIs:** None.
+- **Credentials / auth:** None directly; consuming skills authenticate
+  through the mail-source layer (e.g. Gmail) for inbound reads and drafts.
+- **Network:** None directly — the contract performs no I/O. Mail
+  fetch/draft happens in the [`tools/mail-source`](../mail-source/contract.md) layer.
 
 ## What "a relay message" means
 

--- a/tools/github-body-field/README.md
+++ b/tools/github-body-field/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [github-body-field](#github-body-field)
+  - [Prerequisites](#prerequisites)
   - [Why](#why)
   - [Invocation](#invocation)
     - [`get <issue> --field "<name>"`](#get-issue---field-name)
@@ -22,6 +23,13 @@
 
 Read or rewrite a single `### Field` section of a GitHub issue
 body **without bringing the body into agent context**.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (`uv run --directory tools/github-body-field body-field …`); stdlib-only, no third-party dependencies.
+- **CLIs:** `uv`; `gh` — the script shells out to it for all GitHub access (the `--repo` argument is forwarded verbatim).
+- **Credentials / auth:** an authenticated `gh` session (`gh auth status` must pass) — the body read / parse / replace / push all go through `gh`.
+- **Network:** `api.github.com` via `gh`.
 
 ## Why
 

--- a/tools/github-rollup/README.md
+++ b/tools/github-rollup/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [github-rollup](#github-rollup)
+  - [Prerequisites](#prerequisites)
   - [Why](#why)
   - [Invocation](#invocation)
     - [`append <issue> --action "<label>" ...`](#append-issue---action-label-)
@@ -21,6 +22,13 @@
 
 Append to (or create) the status-rollup comment on a GitHub
 issue **without bringing the rollup body into agent context**.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (`uv run --directory tools/github-rollup github-rollup …`); stdlib-only, no third-party dependencies.
+- **CLIs:** `uv`; `gh` — the script shells out to it for all GitHub access (the default `@user` comes from `gh api user`).
+- **Credentials / auth:** an authenticated `gh` session (`gh auth status` must pass) — the comment read / append / PATCH all go through `gh`.
+- **Network:** `api.github.com` via `gh`.
 
 ## Why
 

--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/github/`](#toolsgithub)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:setup
 
 GitHub REST + GraphQL substrate. Pure read/write wrapper used by every lifecycle phase (triage / intake / fix / resolve / stats). See [`tool.md`](tool.md) for the operation catalogue and the per-area files ([`issue-template.md`](issue-template.md), [`labels.md`](labels.md), [`operations.md`](operations.md), [`project-board.md`](project-board.md), [`status-rollup.md`](status-rollup.md)) for specifics.
+
+## Prerequisites
+
+- **Runtime:** Bash — this is a doc-only adapter; skills invoke the `gh` CLI (`gh` / `gh api`) and `git`, no local package.
+- **CLIs:** `gh` (authenticated), `git` (source-control capability), `jq` (used via `gh api --jq`).
+- **Credentials / auth:** `gh auth status` must show a logged-in user with the needed scopes — every skill's Step 0 runs it.
+- **Network:** `api.github.com` (REST + GraphQL) and `github.com` (the `git` remote); source-control recipes are offline except explicit `fetch` / `push`.

--- a/tools/gmail/README.md
+++ b/tools/gmail/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/gmail/`](#toolsgmail)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,11 @@
 **Capability:** capability:setup
 
 Gmail API substrate. Read + draft-only — never sends. Used by the security-issue-import / sync / invalidate flows for inbound report intake and outbound courtesy-reply drafting. See [`tool.md`](tool.md) for the operation catalogue and the per-area files for ASF relay routing, draft backends, threading, search queries.
+
+## Prerequisites
+
+- **Runtime:** claude.ai Gmail MCP (`mcp__claude_ai_Gmail__*`) for search / read / draft; the preferred `oauth_curl` draft backend is Python 3.11+ run via `uv` (`tools/gmail/oauth-draft`) plus `curl`.
+- **CLIs:** None beyond the runtime on the MCP path; `uv` + `curl` for the `oauth_curl` backend.
+- **Credentials / auth:** claude.ai Gmail MCP authenticated. For `oauth_curl`, a Google OAuth refresh-token file (default `~/.config/apache-magpie/gmail-oauth.json`, overridable via `$GMAIL_OAUTH_CREDENTIALS` or `tools.gmail.oauth_credentials_path`) created once by `oauth-draft-setup`. Read + draft only — never sends.
+- **Network:** Gmail API (`gmail.googleapis.com`); `lists.apache.org` for the adjacent PonyMail archive lookups.
+- **Optional:** `google-auth-oauthlib` (pulled by `uv` for the one-time `oauth-draft-setup` consent flow only).

--- a/tools/jira/README.md
+++ b/tools/jira/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [JIRA bridge](#jira-bridge)
+  - [Prerequisites](#prerequisites)
   - [Layout](#layout)
   - [Invocation](#invocation)
   - [Read subcommands](#read-subcommands)
@@ -41,6 +42,14 @@ Write operations require `JIRA_API_TOKEN` and follow the same
 write-path discipline as the GitHub bridge: every mutation is
 gated on explicit user confirmation in the calling skill — the
 bridge only executes confirmed actions.
+
+## Prerequisites
+
+- **Runtime:** Groovy 4.x+ on `PATH` (`groovy tools/jira/bridge.groovy …`); `@Grab` pulls the HTTP-client dependencies on first run, no separate install step. Python 3.11+ via `uv` is needed only for the pytest test harness.
+- **CLIs:** `groovy` (4.x — the `@Grab` coordinate uses the `org.apache.groovy` group ID); `uv` only to run the tests.
+- **Credentials / auth:** `ISSUE_TRACKER_URL` (required) and `ISSUE_TRACKER_PROJECT` exported by the caller; write subcommands require `JIRA_API_TOKEN` (`JIRA_AUTH_SCHEME` = `Basic` default, or `Bearer` for ASF PATs). Anonymous-read trackers need no auth for read subcommands.
+- **Network:** the configured `<issue-tracker>` JIRA host (e.g. `issues.apache.org/jira`); `@Grab` reaches Maven Central on first run to resolve dependencies.
+- **Optional:** `groovy` on `PATH` for the pytest suite — tests auto-skip when Groovy is absent.
 
 ## Layout
 

--- a/tools/mail-archive/README.md
+++ b/tools/mail-archive/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [tools/mail-archive/](#toolsmail-archive)
+  - [Prerequisites](#prerequisites)
   - [Today's adapters](#todays-adapters)
   - [Interface](#interface)
     - [`search_thread_url(list, year, month, query) to string`](#search_thread_urllist-year-month-query-to-string)
@@ -62,6 +63,20 @@ ASF projects keep the existing PonyMail behaviour by default. A
 non-ASF adopter declares a different `archive_system.kind` in
 `projects/<project>/project.md` and the adapter for that kind is
 loaded in place of PonyMail. Skills do not change.
+
+## Prerequisites
+
+- **Runtime:** None of its own — this file is an adapter-contract
+  *specification* (pure Markdown). Concrete prerequisites belong to
+  whichever adapter the project declares.
+- **CLIs:** None for the contract itself.
+- **Credentials / auth:** Per adapter. The shipping `ponymail`
+  adapter needs ASF LDAP OAuth for private lists (`security@`,
+  `private@`) and anonymous read for public lists; the placeholder
+  adapters (Hyperkitty / Discourse / Google Groups / GitHub
+  Discussions / none) each bring their own auth model.
+- **Network:** Per adapter. The ASF default reaches
+  `lists.apache.org`; the `none` adapter performs no network access.
 
 ## Today's adapters
 

--- a/tools/mail-source/README.md
+++ b/tools/mail-source/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/mail-source/`](#toolsmail-source)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:setup + capability:intake
 
 Mail-source backend abstraction. Pluggable backends (mbox, IMAP, future Mailman 3 / Hyperkitty) that feed the security-issue-import intake pipeline a uniform thread/message view. See [`contract.md`](contract.md) for the backend interface.
+
+## Prerequisites
+
+- **Runtime:** None of its own — this is a backend-contract abstraction (pure Markdown spec). Concrete prerequisites belong to whichever backend adapter the adopter wires in.
+- **CLIs:** None for the contract itself.
+- **Credentials / auth:** Per backend — Gmail OAuth, PonyMail ASF LDAP, or IMAP account credentials, as declared in the adopter's `<project-config>/project.md` *Mail sources* section.
+- **Network:** Per backend — the chosen adapter reaches Gmail / PonyMail (`lists.apache.org`) / the configured IMAP server; the `mbox` snapshot backend is offline.

--- a/tools/permission-audit/README.md
+++ b/tools/permission-audit/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [permission-audit](#permission-audit)
+  - [Prerequisites](#prerequisites)
   - [Why](#why)
   - [Install](#install)
   - [CLI](#cli)
@@ -28,6 +29,17 @@ in `<repo>/.claude/settings.json` and `<repo>/.claude/settings.local.json`.
 Backs the `--apply-permission-audit` flag of
 [`/magpie-setup verify`](../../skills/setup/verify.md#8d-permission-allow-list-hygiene)
 (check 8d), and is also directly usable as a CLI.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (`uv sync` / `uv run`); the
+  tool itself is stdlib-only.
+- **CLIs:** None beyond the runtime.
+- **Credentials / auth:** None.
+- **Network:** None — operates entirely on local
+  `.claude/settings.json` / `.claude/settings.local.json` files.
+- **Optional:** dev group adds `pytest`, `ruff`, `mypy` for the test
+  + lint suite.
 
 ## Why
 

--- a/tools/ponymail/README.md
+++ b/tools/ponymail/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/ponymail/`](#toolsponymail)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:setup + capability:intake
 
 PonyMail archive substrate. Read-only ASF mailing-list archive client; complements `gmail` for threads not present in the inbox. Used by security-issue-import + sync to cross-reference public mailing-list discussions. See [`tool.md`](tool.md) for the operation catalogue and [`operations.md`](operations.md) for usage.
+
+## Prerequisites
+
+- **Runtime:** Node.js 20+ — the backing MCP server is the `apache/comdev` `mcp/ponymail-mcp/` package, reached from Claude Code via the `mcp__ponymail__*` tools. This directory is documentation for that substrate.
+- **CLIs:** `git` + `npm` / `node` to clone and run the comdev MCP server; `claude mcp add` to register it with Claude Code.
+- **Credentials / auth:** ASF LDAP OAuth via `mcp__ponymail__login` (session cached at `~/.ponymail-mcp/session.json`) for private lists; anonymous read for public lists.
+- **Network:** `lists.apache.org` (PonyMail HTTP API), `oauth.apache.org` (LDAP login redirect), and `github.com` (cloning `apache/comdev`).

--- a/tools/pr-management-stats/README.md
+++ b/tools/pr-management-stats/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [pr-management-stats reference implementation](#pr-management-stats-reference-implementation)
+  - [Prerequisites](#prerequisites)
   - [Layout](#layout)
   - [Invocation](#invocation)
   - [Configuration and vendor neutrality](#configuration-and-vendor-neutrality)
@@ -40,6 +41,19 @@ exists for two reasons:
    this script on a schedule, extend it with the full render per
    [`render.md`](../../skills/pr-management-stats/render.md),
    and publish the HTML as a build artefact or gist.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+, stdlib-only; run as
+  `python3 reference.py` / `python3 dashboard.py`.
+- **CLIs:** `gh` (GitHub CLI) for the GraphQL fetch; `bash` + `awk`
+  for the optional `gen_charts.sh` SVG helper.
+- **Credentials / auth:** an authenticated `gh` session
+  (`gh auth status` must succeed for the viewer against `<upstream>`).
+- **Network:** `api.github.com` via `gh` GraphQL. (The test suite
+  stubs every `gh` call — no network.)
+- **Optional:** `pytest` (dev-only) via `uv run pytest` or
+  `python3 -m pytest`.
 
 ## Layout
 

--- a/tools/preflight-audit/README.md
+++ b/tools/preflight-audit/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [preflight-audit](#preflight-audit)
+  - [Prerequisites](#prerequisites)
   - [Why](#why)
   - [Invocation](#invocation)
     - [Live mode](#live-mode)
@@ -24,6 +25,13 @@ Dry-run the bulk-mode pre-flight classifier against a real or
 replayed tracker. Use to **measure skip-rate before / after any
 rule change** — closes the tune-then-verify loop so rule edits
 are made against evidence, not guesswork.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (stdlib only, no third-party deps).
+- **CLIs:** `gh` (GitHub CLI) for live mode; replay mode needs none.
+- **Credentials / auth:** `gh` authenticated to the tracker repo (live mode only).
+- **Network:** GitHub GraphQL API via `gh` (live mode); replay mode runs fully offline.
 
 ## Why
 

--- a/tools/privacy-llm/README.md
+++ b/tools/privacy-llm/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`tools/privacy-llm/`](#toolsprivacy-llm)
+  - [Prerequisites](#prerequisites)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -14,3 +15,10 @@
 **Capability:** capability:setup
 
 Privacy-LLM PII-scrubbing gate. Standalone redactor / checker pair that screens content for PII before it reaches an external LLM. See [`tool.md`](tool.md) and [`wiring.md`](wiring.md) for integration details, [`models.md`](models.md) for the model catalogue, and [`pii.md`](pii.md) for the PII taxonomy.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (stdlib only) — the `redactor/` and `checker/` sub-tools.
+- **CLIs:** None beyond the runtime.
+- **Credentials / auth:** None.
+- **Network:** Runs fully offline/local; the LLM endpoints it gates (Claude Code, `*.apache.org`, local Ollama / vLLM, opt-in third-party) are configured, not prerequisites of the tool itself.

--- a/tools/probe-templates/README.md
+++ b/tools/probe-templates/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Probe templates](#probe-templates)
+  - [Prerequisites](#prerequisites)
   - [Layout](#layout)
   - [What a probe template looks like](#what-a-probe-template-looks-like)
   - [Contributing a runtime](#contributing-a-runtime)
@@ -26,6 +27,13 @@ The probe pattern, contract, and recording schema are in the
 skill's [`probe-templates.md`](../../skills/issue-reproducer/probe-templates.md)
 companion. This directory holds runtime-specific reference
 implementations.
+
+## Prerequisites
+
+- **Runtime:** None of its own — this directory holds per-runtime probe template files (today `groovy/`). Running a probe needs the matching language runtime (e.g. a Groovy interpreter for the `groovy/` templates).
+- **CLIs:** Whatever runs the target runtime's scripts; nothing else.
+- **Credentials / auth:** None.
+- **Network:** Runs fully offline/local.
 
 ## Layout
 

--- a/tools/sandbox-lint/README.md
+++ b/tools/sandbox-lint/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [`sandbox-lint`](#sandbox-lint)
+  - [Prerequisites](#prerequisites)
   - [What it checks](#what-it-checks)
   - [How to use](#how-to-use)
   - [CI wiring](#ci-wiring)
@@ -24,6 +25,13 @@ invariants documented in `docs/security/threat-model.md`
 (mitigation **M.29**). The threat-model document lands in a
 companion PR; the lint stands on its own and runs immediately on
 merge.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv` (stdlib only, no third-party deps).
+- **CLIs:** None beyond the runtime.
+- **Credentials / auth:** None.
+- **Network:** Runs fully offline/local — it only reads local JSON files.
 
 ## What it checks
 

--- a/tools/scan-format/README.md
+++ b/tools/scan-format/README.md
@@ -2,6 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [tools/scan-format/ — adapter contract](#toolsscan-format--adapter-contract)
+  - [Prerequisites](#prerequisites)
   - [What "a scan" means](#what-a-scan-means)
   - [Today's adapters](#todays-adapters)
   - [Interface](#interface)
@@ -29,6 +30,13 @@ scanner-agnostic; everything format-specific — how to recognise a scan
 folder, how to enumerate findings, how to pull a finding's evidence, and
 how to normalise the fields — lives behind this contract so the triage
 flow is identical across scanners.
+
+## Prerequisites
+
+- **Runtime:** None — this directory is a documented adapter *contract* (specification), not executable code; an adapter is implemented as documented behaviour inside the consuming skill.
+- **CLIs:** None.
+- **Credentials / auth:** None.
+- **Network:** None — the contract reaches no hosts; locating scan folders and issues is the consuming skill's job.
 
 ## What "a scan" means
 

--- a/tools/skill-and-tool-validator/README.md
+++ b/tools/skill-and-tool-validator/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [skill-and-tool-validator](#skill-and-tool-validator)
+  - [Prerequisites](#prerequisites)
   - [What it checks](#what-it-checks)
     - [Hard rules (failure)](#hard-rules-failure)
     - [SOFT advisories (warning, do not fail)](#soft-advisories-warning-do-not-fail)
@@ -20,6 +21,16 @@
 
 Validate framework skill definitions — YAML frontmatter, internal
 link integrity, and placeholder conventions.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv`; stdlib-only (no third-party
+  runtime dependencies). The `dev` group pulls `pytest`, `ruff`, `mypy`.
+- **CLIs:** None beyond the runtime. `git` is used only for the optional
+  trigger-phrase-preservation check and is silently skipped when git or
+  the base ref is unavailable.
+- **Credentials / auth:** None.
+- **Network:** Runs fully offline against local skill files.
 
 ## What it checks
 

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -88,14 +88,20 @@ DOCS_DIR = Path("docs")
 SKILL_EVALS_DIR = Path("tools/skill-evals/evals")
 PROJECTS_TEMPLATE_DIR = Path("projects/_template")
 
-# Categories for the tool-validator block. Both HARD by default — every
-# tool must have a README that declares its capability.
+# Categories for the tool-validator block. All HARD by default — every
+# tool must have a README that declares its capability and its prerequisites.
 TOOL_README_CATEGORY = "tool-readme"
 TOOL_CAPABILITY_CATEGORY = "tool-capability"
+TOOL_PREREQUISITES_CATEGORY = "tool-prerequisites"
 
 # Matches `**Capability:** capability:NAME` (and multi-value
 # `capability:NAME + capability:NAME + …`) on a single line.
 TOOL_CAPABILITY_RE = re.compile(r"^\*\*Capability:\*\*[ \t]+(.+)$", re.MULTILINE)
+
+# Matches a level-2 `## Prerequisites` heading. Every tool README must carry
+# one so the tool's runtime / CLI / credential / network requirements are
+# stated up front rather than discovered at first run.
+TOOL_PREREQUISITES_RE = re.compile(r"^##[ \t]+Prerequisites[ \t]*$", re.MULTILINE)
 
 # Capability-sync check: keeps docs/labels-and-capabilities.md tables aligned
 # with live skill frontmatter + tool README declarations.
@@ -287,6 +293,7 @@ HARD_CATEGORIES: frozenset[str] = frozenset(
     {
         TOOL_README_CATEGORY,
         TOOL_CAPABILITY_CATEGORY,
+        TOOL_PREREQUISITES_CATEGORY,
         CAPABILITY_SYNC_CATEGORY,
         INJECTION_GUARD_CATEGORY,
         NAME_CONVENTION_CATEGORY,
@@ -1309,10 +1316,14 @@ def validate_tools(root: Path | None = None) -> Iterable[Violation]:
     2. The README to contain a ``**Capability:** capability:NAME`` line,
        with NAME drawn from ``ALLOWED_CAPABILITIES``. Multi-value form is
        ``**Capability:** capability:NAME + capability:NAME``.
+    3. The README to contain a ``## Prerequisites`` section so the tool's
+       runtime / CLI / credential / network requirements are stated up
+       front.
 
-    Both are HARD checks — every tool must declare its capabilities so
-    the per-tool map in ``docs/labels-and-capabilities.md`` stays
-    authoritative.
+    All are HARD checks — every tool must declare its capabilities and
+    its prerequisites so the per-tool map in
+    ``docs/labels-and-capabilities.md`` stays authoritative and an adopter
+    can tell what a tool needs before running it.
     """
     for tool_dir in collect_tool_dirs(root):
         readme = tool_dir / "README.md"
@@ -1332,6 +1343,16 @@ def validate_tools(root: Path | None = None) -> Iterable[Violation]:
         except OSError as exc:
             yield Violation(readme, None, f"cannot read README.md: {exc}")
             continue
+
+        if TOOL_PREREQUISITES_RE.search(text) is None:
+            yield Violation(
+                readme,
+                1,
+                f"tool '{tool_dir.name}' README missing a '## Prerequisites' section — "
+                f"state the tool's runtime, required CLIs, credentials, and network "
+                f"access up front (see tools/AGENTS.md)",
+                category=TOOL_PREREQUISITES_CATEGORY,
+            )
 
         match = TOOL_CAPABILITY_RE.search(text)
         if match is None:

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -2347,7 +2347,10 @@ class TestValidateTools:
         root = _make_tools_root(tmp_path)
         tool = root / "tools" / "foo"
         tool.mkdir()
-        (tool / "README.md").write_text("# tools/foo\n\n**Capability:** capability:setup\n\nFoo tool.\n")
+        (tool / "README.md").write_text(
+            "# tools/foo\n\n**Capability:** capability:setup\n\nFoo tool.\n\n"
+            "## Prerequisites\n\n- Python 3.11+ via uv.\n"
+        )
         violations = list(validate_tools(root))
         assert violations == []
 
@@ -2363,7 +2366,9 @@ class TestValidateTools:
         root = _make_tools_root(tmp_path)
         tool = root / "tools" / "bare"
         tool.mkdir()
-        (tool / "README.md").write_text("# bare\n\nDescription only, no capability line.\n")
+        (tool / "README.md").write_text(
+            "# bare\n\nDescription only, no capability line.\n\n## Prerequisites\n\n- None.\n"
+        )
         violations = list(validate_tools(root))
         assert len(violations) == 1
         assert "missing '**Capability:**" in violations[0].message
@@ -2381,7 +2386,9 @@ class TestValidateTools:
         root = _make_tools_root(tmp_path)
         tool = root / "tools" / "dual"
         tool.mkdir()
-        (tool / "README.md").write_text("# dual\n\n**Capability:** capability:setup + capability:intake\n")
+        (tool / "README.md").write_text(
+            "# dual\n\n**Capability:** capability:setup + capability:intake\n\n## Prerequisites\n\n- None.\n"
+        )
         violations = list(validate_tools(root))
         assert violations == []
 
@@ -2395,10 +2402,29 @@ class TestValidateTools:
         (tool / "README.md").write_text(
             "# tools/with-prose\n\n"
             "**Capability:** capability:setup\n\n"
-            "Some prose that follows the capability line and should NOT be parsed as part of it.\n"
+            "Some prose that follows the capability line and should NOT be parsed as part of it.\n\n"
+            "## Prerequisites\n\n- None.\n"
         )
         violations = list(validate_tools(root))
         assert violations == []
+
+    def test_tool_missing_prerequisites(self, tmp_path: Path) -> None:
+        root = _make_tools_root(tmp_path)
+        tool = root / "tools" / "no-prereq"
+        tool.mkdir()
+        (tool / "README.md").write_text("# no-prereq\n\n**Capability:** capability:setup\n\nA tool.\n")
+        violations = list(validate_tools(root))
+        assert len(violations) == 1
+        assert "'## Prerequisites'" in violations[0].message
+        assert violations[0].category == "tool-prerequisites"
+
+    def test_tool_missing_both_capability_and_prerequisites(self, tmp_path: Path) -> None:
+        root = _make_tools_root(tmp_path)
+        tool = root / "tools" / "bare-both"
+        tool.mkdir()
+        (tool / "README.md").write_text("# bare-both\n\nDescription only.\n")
+        cats = {v.category for v in validate_tools(root)}
+        assert cats == {"tool-prerequisites", "tool-capability"}
 
 
 # ---------------------------------------------------------------------------

--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -36,6 +36,22 @@ Suites are currently implemented for:
 - **setup-status** — 14 cases across 4 steps (step-0-preflight, step-1-command, step-2-present, step-3-adjust-decision)
 - **non-asf-profile-smoke** — 6 cases across 2 steps (step-1-fetch-pool, step-3-classify); drives `issue-stale-sweep` through the `projects/non-asf-example/` fixture to verify non-ASF config resolves without skill-body edits
 
+## Prerequisites
+
+- **Runtime:** Python 3.11+ (stdlib only) — the runner is pure standard
+  library with no third-party deps and no build step; run it directly
+  with `python3` and `PYTHONPATH=tools/skill-evals/src`.
+- **CLIs:** None for the default print mode. Automated mode (`--cli`)
+  needs an LLM CLI that reads a prompt on stdin and writes the response
+  to stdout (e.g. `claude -p`, `llm`, `ollama run …`). Field-aware
+  grading adds a judge CLI (default `claude -p --model haiku`).
+- **Credentials / auth:** None in print mode; in `--cli` mode whatever
+  the chosen model CLI requires (e.g. a Claude / API key, or a local
+  Ollama install).
+- **Network:** Evals mock all external tool calls, so the harness itself
+  makes no network calls; any network use comes from the model CLI you
+  point `--cli` / `--grader-cli` at.
+
 ## Run
 
 The runner is pure Python standard library — no third-party dependencies and no

--- a/tools/spec-loop/README.md
+++ b/tools/spec-loop/README.md
@@ -12,6 +12,19 @@ human-in-the-loop posture. The full write-up is in
 [`docs/spec-driven-development.md`](../../docs/spec-driven-development.md);
 this is the operator quickstart.
 
+## Prerequisites
+
+- **Runtime:** Bash + coreutils (`loop.sh` is the runner); the
+  spec-side helper tools it drives are Python 3.11+ run via `uv`.
+- **CLIs:** `git` (required — must run inside a git checkout), `gh`
+  (for open-PR duplicate-work checks), and a Claude-compatible agent
+  CLI (`SPEC_LOOP_AGENT`, default `claude`).
+- **Credentials / auth:** `gh` must be authenticated for the PR checks;
+  the loop is designed to run with **no** push/write credentials in the
+  environment (it hard-denies `git push` and `gh` writes).
+- **Network:** Reaches GitHub (via `gh`) and the agent/model backend; the
+  agent itself performs the model calls.
+
 ## The pieces
 
 | File | Role |

--- a/tools/spec-status-index/README.md
+++ b/tools/spec-status-index/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [spec-status-index](#spec-status-index)
+  - [Prerequisites](#prerequisites)
   - [Usage](#usage)
   - [Statuses](#statuses)
   - [Run tests](#run-tests)
@@ -19,6 +20,15 @@
 A deterministic `uv` tool that reads spec-loop specs from
 `tools/spec-loop/specs/` and prints them grouped by status, so build
 iterations can choose the next work item mechanically.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv`; stdlib-only (no runtime
+  dependencies). The `dev` group pulls `pytest`.
+- **CLIs:** None beyond the runtime.
+- **Credentials / auth:** None.
+- **Network:** Runs fully offline; reads spec files from
+  `tools/spec-loop/specs/` on the local filesystem.
 
 ## Usage
 

--- a/tools/spec-validator/README.md
+++ b/tools/spec-validator/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [spec-validator](#spec-validator)
+  - [Prerequisites](#prerequisites)
   - [What it checks](#what-it-checks)
   - [Usage](#usage)
 
@@ -17,6 +18,14 @@
 
 Validates spec files in `tools/spec-loop/specs/` — the counterpart to
 `tools/skill-and-tool-validator/` for the spec side of the framework.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv`; stdlib-only (no runtime
+  dependencies). The `dev` group pulls `pytest`, `ruff`.
+- **CLIs:** None beyond the runtime.
+- **Credentials / auth:** None.
+- **Network:** Runs fully offline against local spec files.
 
 ## What it checks
 

--- a/tools/vcs/README.md
+++ b/tools/vcs/README.md
@@ -2,6 +2,7 @@
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 - [`magpie-vcs`](#magpie-vcs)
+  - [Prerequisites](#prerequisites)
   - [Why](#why)
   - [The abstraction](#the-abstraction)
   - [Backends](#backends)
@@ -34,6 +35,18 @@ uv run --project tools/vcs magpie-vcs -C <upstream> log --grep ISSUE-123
 The active backend is **detected** from the working copy (or forced
 with `--backend` / `$MAGPIE_VCS`), so the same command works whatever
 VCS the project enables under *Tools enabled → Source control*.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ run via `uv`; stdlib-only (no runtime
+  dependencies). The `dev` group pulls `pytest`, `ruff`, `mypy`.
+- **CLIs:** Depends on the active backend — the tool shells out to the
+  underlying VCS binary. `git` for the complete backend; `hg` / `svn` are
+  detected but their bindings are not yet implemented.
+- **Credentials / auth:** None of its own; write operations (`fetch`,
+  `push`) inherit whatever auth the underlying VCS/remote needs.
+- **Network:** Local for read and local-write operations; `fetch` / `push`
+  reach the project's remote (e.g. GitHub) over the network.
 
 ## Why
 


### PR DESCRIPTION
## What

Makes the tool inventory self-describing and keeps the vendor-neutrality
explainer honest. Four parts:

1. **Validator** — a new HARD `tool-prerequisites` check in
   `skill-and-tool-validator` requires every `tools/<name>/README.md` to
   carry a `## Prerequisites` section, alongside the existing
   `**Capability:**` requirement. New tests cover present / missing /
   both-missing; pre-existing fixtures updated.
2. **Every tool README** now declares its prerequisites — runtime,
   required CLIs, credentials/auth, network reach, optional deps —
   derived from each tool's actual `pyproject`/scripts, not guessed.
   Pure interface-spec tools (adapter contracts with no code) say so and
   defer to their adapters.
3. **`tools/AGENTS.md`** (new) — conventions for the `tools/` tree: the
   two HARD README requirements, plus the maintenance rule to refresh
   the Capability-to-tool map (validator-enforced) and the
   hand-maintained extension-point list in `docs/vendor-neutrality.md`
   whenever a tool or its tracking issues change.
4. **`docs/vendor-neutrality.md` refresh** — adds a sixth axis
   (Communication channels) with the mail/chat extension-point issues,
   links the VCS issues (#601-#605, #608) and security/CNA backends
   (OSV #311), and **corrects the Bitbucket reference (#606, not #306**;
   #306 is Mailman 3 — a regression that landed via #614).

## Verification

- `skill-and-tool-validate` passes (all 32 tools carry capability +
  prerequisites); doctoc, markdownlint, lychee, ruff check/format,
  placeholder check all green.
- mypy + pytest verified green via `uv run` for the validator project.
  The `workspace-mypy` / `workspace-pytest` pre-commit hooks were skipped
  at commit only because their binaries can't spawn in my environment —
  CI will run them normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)