### PR TITLE
docs(issue-management): sync family README to eight skills

### DIFF
--- a/docs/issue-management/README.md
+++ b/docs/issue-management/README.md
@@ -20,8 +20,9 @@
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Maintainer-facing skills for projects with a general-issue tracker
-(JIRA, GitHub Issues, Bugzilla, GitLab Issues). Six skills that
-cover per-issue work, pool-level sweeps, and read-only reporting:
+(JIRA, GitHub Issues, Bugzilla, GitLab Issues). Eight skills that
+cover per-issue work, pool-level sweeps, deduplication, and
+read-only reporting:
 
 1. **Agentic Triage** — sweep open issues in the configured candidate pool,
    classify against the project's criteria, propose a disposition
@@ -47,6 +48,14 @@ cover per-issue work, pool-level sweeps, and read-only reporting:
    files produced by reassess campaigns. Surfaces health rating,
    classification distribution, partial-fix surfaces, and per-component
    breakdowns.
+7. **Deduplicate** — identify two open issues sharing the same root
+   cause, draft a cross-link comment and a closing rationale, and
+   close the duplicate on maintainer confirmation; closures require a
+   second explicit confirmation step.
+8. **Backlog stats** — read-only dashboard over the open issue
+   backlog. Surfaces a health rating, prioritised recommendations,
+   age and staleness breakdowns, area pressure ranking, and a
+   triage-funnel summary without modifying any tracker state.
 
 ## Family boundary
 
@@ -76,9 +85,12 @@ configured with different trackers.
 | [`issue-fix-workflow`](../../skills/issue-fix-workflow/SKILL.md) | Agentic Drafting | Drafts a fix PR for a triaged issue |
 | [`issue-stale-sweep`](../../skills/issue-stale-sweep/SKILL.md) | Agentic Triage | Backlog hygiene: classifies dormant issues as `REQUEST-UPDATE` or `CLOSE-STALE`; posts one comment per issue on confirmation |
 | [`issue-reassess-stats`](../../skills/issue-reassess-stats/SKILL.md) | — | Read-only campaign dashboard |
+| [`issue-deduplicate`](../../skills/issue-deduplicate/SKILL.md) | Triage | Merge two open issues describing the same root cause; posts notices and closes the duplicate on explicit two-step confirmation |
+| [`issue-backlog-stats`](../../skills/issue-backlog-stats/SKILL.md) | Triage | Read-only dashboard over the open issue backlog: health rating, area pressure, age breakdown, triage funnel, and staleness candidates |
 
-Reproducer and stats sit outside the MISSION mode taxonomy; they
-are mechanical / read-only, not classificatory or mutating.
+`issue-reproducer` and `issue-reassess-stats` sit outside the MISSION
+mode taxonomy; they are mechanical / read-only, not classificatory or
+mutating.
 
 ## Adopter contract
 
@@ -89,13 +101,13 @@ adopter's `<project-config>/` directory:
 |---|---|
 | [`project.md`](../../projects/_template/project.md) | all `issue-*` skills (identifiers, `upstream_default_branch`) |
 | [`issue-tracker-config.md`](../../projects/_template/issue-tracker-config.md) | all `issue-*` skills (URL, project key, auth, default queries) |
-| [`scope-labels.md`](../../projects/_template/scope-labels.md) | `issue-triage`, `issue-reassess` (component / area routing) |
+| [`scope-labels.md`](../../projects/_template/scope-labels.md) | `issue-triage`, `issue-reassess`, `issue-backlog-stats` (component / area routing and area pressure ranking) |
 | [`release-trains.md`](../../projects/_template/release-trains.md) | `issue-triage` (`@`-mention routing) |
 | [`canned-responses.md`](../../projects/_template/canned-responses.md) | `issue-triage` (NEEDS-INFO templates) |
 | [`runtime-invocation.md`](../../projects/_template/runtime-invocation.md) | `issue-reproducer` (how to invoke the project's runtime on extracted code) |
 | [`reassess-pool-defaults.md`](../../projects/_template/reassess-pool-defaults.md) | `issue-reassess` (pool definitions extending the default queries in `issue-tracker-config.md`) |
 | [`reproducer-conventions.md`](../../projects/_template/reproducer-conventions.md) | `issue-reproducer` (evidence-package directory layout) |
-| [`stale-sweep-config.md`](../../projects/_template/stale-sweep-config.md) | `issue-stale-sweep` (warn / close / hard-close thresholds; omit to use framework defaults of 90 / 180 / 365 days) |
+| [`stale-sweep-config.md`](../../projects/_template/stale-sweep-config.md) | `issue-stale-sweep`, `issue-backlog-stats` (warn / close / hard-close thresholds; omit to use framework defaults of 90 / 180 / 365 days) |
 
 ## Status
 

--- a/tools/spec-loop/specs/issue-management-family.md
+++ b/tools/spec-loop/specs/issue-management-family.md
@@ -192,11 +192,6 @@ uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-valid
 
 ## Known gaps
 
-- **`docs/issue-management/README.md` is out of date.** The family README
-  on `main` lists six skills; `issue-backlog-stats` (#535) and
-  `issue-deduplicate` (#532) landed on `main` after the README was last
-  synced. A follow-on docs-sync item should add them to the skills table
-  and adopter-contract matrix.
 - **No adopter pilot has run the full family.** All eight skills are
   `experimental`; no maintainer has exercised the triage → reproduce →
   fix-draft → stale-sweep → deduplicate → dashboard pipeline end-to-end.


### PR DESCRIPTION
…sue-deduplicate

Both skills shipped in #532 and #535 but the family README still listed "six skills". This commit brings it to eight: adds both skills to the intro list and the Skills table, and updates the adopter-contract matrix to reflect that issue-backlog-stats also reads scope-labels.md and stale-sweep-config.md. Clears the corresponding Known Gap entries in the spec.

Generated-by: Claude (Opus 4.7)

## Summary

Brings the issue-management family README in line with the skills that
have actually shipped. The README still described "six skills" even
though `issue-backlog-stats` (#535) and `issue-deduplicate` (#532)
landed on `main`.

## Changes

- Update the intro from "Six skills" to "Eight skills" and add
  deduplication / read-only reporting to the coverage summary.
- Add entries 7 (**Deduplicate**) and 8 (**Backlog stats**) to the
  numbered skill list.
- Add both skills to the Skills table with their MISSION mode and
  one-line summaries.
- Fix the out-of-mode note to name `issue-reproducer` and
  `issue-reassess-stats` explicitly (the old "Reproducer and stats"
  phrasing was ambiguous now that backlog-stats exists).
- Update the adopter-contract matrix: `issue-backlog-stats` also reads
  `scope-labels.md` (area pressure ranking) and `stale-sweep-config.md`
  (staleness thresholds).
- Clear the two corresponding "Known gaps" entries in
  `tools/spec-loop/specs/issue-management-family.md`.
  
## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
