### PR TITLE
docs: point .asf.yaml homepage at https://magpie.apache.org/

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -19,7 +19,7 @@
 ---
 github:
   description: "Agent-assisted maintainership and development framework for Apache projects — Triage and Drafting (agent-authored fixes with human review); Mentoring, Pairing (developer-side dev-cycle), and Auto-merge on the roadmap."
-  homepage: "https://github.com/apache/magpie"
+  homepage: "https://magpie.apache.org/"
   labels:
     # Note that GitHub only supports <=20 labels/topics per repo! Pipeline
     # will fail if you add more.


### PR DESCRIPTION
Update the `github.homepage` field in `.asf.yaml` to the ASF site URL.