### PR TITLE
feat(organizations): organization membership for skills/families/tools + identity/logo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -511,6 +511,14 @@ Read that page once; treat it as the source of truth.
 - **New docs** link to the taxonomy doc and name their capability in the
   first paragraph if capability-specific; cross-cutting docs need no
   marker.
+- **Organization membership (optional).** A skill, skill family, tool, or
+  tool adapter that *belongs to* a specific organization declares it:
+  skills via an `organization:` frontmatter key, families via the
+  `organization:` scope banner in `docs/<family>/README.md`, and tools
+  via an `**Organization:** <org>` line in the README. The value must
+  name an organization under [`organizations/`](organizations/); omit it
+  for organization-agnostic entities. The validator fails on an unknown
+  organization value.
 
 The taxonomy applies to *this framework repository*. Skills that create
 issues or PRs on an **adopter's tracker** (e.g. `security-issue-import`,

--- a/docs/contributor-growth/README.md
+++ b/docs/contributor-growth/README.md
@@ -17,7 +17,7 @@
 
 # Contributor-growth skill family
 
-> **Scope — `asf: true` · 🪶 ASF-specific.** This family encodes Apache Software
+> **Scope — `organization: ASF` · 🪶 ASF-specific.** This family encodes Apache Software
 > Foundation processes (the contributor-to-committer path) and assumes an ASF
 > adopter profile by default. Non-ASF projects can still adopt it through the
 > adapter/config layer, but it carries ASF assumptions the generic families do not.

--- a/docs/issue-management/README.md
+++ b/docs/issue-management/README.md
@@ -16,7 +16,7 @@
 
 # Issue management skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Maintainer-facing skills for projects with a general-issue tracker

--- a/docs/mentoring/README.md
+++ b/docs/mentoring/README.md
@@ -16,7 +16,7 @@
 
 # Agentic Mentoring skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Maintainer-facing skills that join contributor threads in a teaching

--- a/docs/pairing/README.md
+++ b/docs/pairing/README.md
@@ -17,7 +17,7 @@
 
 # Agentic Pairing skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Developer-side pre-flight review skills that run in the maintainer's or

--- a/docs/pr-management/README.md
+++ b/docs/pr-management/README.md
@@ -14,7 +14,7 @@
 
 # PR management skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Maintainer-facing PR-queue management for projects with a public

--- a/docs/release-management/README.md
+++ b/docs/release-management/README.md
@@ -17,7 +17,7 @@
 
 # Release-management skill family
 
-> **Scope — `asf: true` · 🪶 ASF-specific.** This family encodes Apache Software
+> **Scope — `organization: ASF` · 🪶 ASF-specific.** This family encodes Apache Software
 > Foundation processes (the 14-step release lifecycle) and assumes an ASF adopter
 > profile by default. Non-ASF projects can still adopt it through the
 > adapter/config layer, but it carries ASF assumptions the generic families do not.

--- a/docs/repo-health/README.md
+++ b/docs/repo-health/README.md
@@ -19,7 +19,7 @@
 
 # Repo-health audits — family overview
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Read-only agent-assisted audits that surface repository maintenance signals

--- a/docs/security/README.md
+++ b/docs/security/README.md
@@ -17,7 +17,7 @@
 
 # Security workflow skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not. The ASF intake
+> **Scope.** Works on any project, ASF or not. The ASF intake
 > path (`security@`, Vulnogram CVE flow) is the default profile; non-ASF
 > adopters swap it for GitHub Security Advisories / a MITRE CNA through the
 > adapter/config layer.

--- a/docs/setup/README.md
+++ b/docs/setup/README.md
@@ -15,7 +15,7 @@
 
 # Setup skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 The **setup** skill family is the prerequisite for running any

--- a/docs/utilities/README.md
+++ b/docs/utilities/README.md
@@ -16,7 +16,7 @@
 
 # Utilities skill family
 
-> **Scope — `asf: false`.** Works on any project, ASF or not — no
+> **Scope.** Works on any project, ASF or not — no
 > Apache-Software-Foundation-specific assumptions baked in.
 
 Framework meta-skills — the tools you use to **build and maintain skills

--- a/organizations/ASF/organization.md
+++ b/organizations/ASF/organization.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Apache Software Foundation — organization](#apache-software-foundation--organization)
+  - [Organization identity](#organization-identity)
   - [Governance vocabulary](#governance-vocabulary)
   - [CVE authority](#cve-authority)
   - [Governance gate](#governance-gate)
@@ -45,6 +46,20 @@ backends are [`tools/cve-tool-vulnogram/`](../../tools/cve-tool-vulnogram/),
 [`tools/apache-projects/`](../../tools/apache-projects/), and the
 ASF-security forwarder shape in
 [`tools/gmail/asf-relay.md`](../../tools/gmail/asf-relay.md).
+
+## Organization identity
+
+Brand / display metadata, surfaced by the website (and any skill that
+shows which organization a project belongs to). `logo` is the asset the
+site renders for projects under this organization.
+
+```yaml
+organization_identity:
+  id: ASF                              # matches the organizations/<id>/ dir name
+  name: "Apache Software Foundation"   # full name, longer than the id; shown on the website
+  url: https://www.apache.org/
+  logo: https://www.apache.org/foundation/press/kit/asf_logo.svg
+```
 
 ## Governance vocabulary
 

--- a/organizations/README.md
+++ b/organizations/README.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Organizations](#organizations)
+  - [Membership — what can belong to an organization](#membership--what-can-belong-to-an-organization)
   - [Why this exists](#why-this-exists)
   - [Resolution order](#resolution-order)
   - [What ships here](#what-ships-here)
@@ -19,8 +20,10 @@ An **organization** in Magpie groups everything a governing body — a
 foundation, a company, or an informal maintainer collective — makes
 *default* for the projects that belong to it:
 
+- its **identity** (`organization_identity`: `id`, full `name`, `url`,
+  and `logo`) — the brand the website renders for projects under it;
 - its **governance vocabulary** (what the governing body is called, how
-  contributors are admitted, the project-lifecycle stages), and
+  contributors are admitted, the project-lifecycle stages); and
 - its **default backend selections + infrastructure values** — which
   tool [adapter](../docs/vendor-neutrality.md#tool-adapters) fulfils each
   capability (CVE authority, mail archive, project metadata, …) and the
@@ -31,6 +34,24 @@ It is the layer between a single project's
 defaults. A project names its organization once
 (`organization: <org>` in `<project-config>/project.md`) and inherits
 the rest.
+
+## Membership — what can belong to an organization
+
+Beyond a *project*, four framework entities can declare that they
+**belong to** an organization (and so assume its stack); the value names
+a directory here, and absence means organization-agnostic:
+
+| Entity | How it declares membership |
+|---|---|
+| **Skill** | `organization:` key in the `SKILL.md` frontmatter |
+| **Skill family** | `organization:` scope banner in `docs/<family>/README.md` |
+| **Tool** | `**Organization:** <org>` line in the tool `README.md` |
+| **Tool adapter** | same as a tool — the adapter directory's README |
+
+For example the ASF release-management and contributor-growth families,
+their skills, and the `cve-tool-vulnogram` / `ponymail` /
+`apache-projects` tools all declare `organization: ASF`. The validator
+rejects a declared organization that has no directory here.
 
 ## Why this exists
 

--- a/organizations/_template/organization.md
+++ b/organizations/_template/organization.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [TODO: `<Organization Name>` — organization](#todo-organization-name--organization)
+  - [Organization identity](#organization-identity)
   - [Governance vocabulary](#governance-vocabulary)
   - [Capability-to-backend bundle](#capability-to-backend-bundle)
 
@@ -25,6 +26,19 @@ Any key you omit falls through to the framework default. Start from
 (the generic baseline) and change only what your organization mandates;
 [`organizations/ASF/organization.md`](../ASF/organization.md) is a fully
 worked example.
+
+## Organization identity
+
+Brand / display metadata used by the website. `logo` is the asset the
+site renders for projects under this organization.
+
+```yaml
+organization_identity:
+  id: <org>                            # must match this directory's name
+  name: "<Organization full name>"     # longer than the id; shown on the website
+  url: <homepage URL>
+  logo: <URL or path to the organization's logo, shown on the website>
+```
 
 ## Governance vocabulary
 

--- a/organizations/independent/organization.md
+++ b/organizations/independent/organization.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Independent — organization (no formal governing body)](#independent--organization-no-formal-governing-body)
+  - [Organization identity](#organization-identity)
   - [Governance vocabulary](#governance-vocabulary)
   - [CVE authority](#cve-authority)
   - [Governance gate](#governance-gate)
@@ -28,6 +29,16 @@ inherits from.
 Everything here is the *generic* path — no mailing lists, no forwarder
 relay, no foundation CNA, no project-metadata service. A project may
 still override any key.
+
+## Organization identity
+
+```yaml
+organization_identity:
+  id: independent
+  name: "Independent (no formal organization)"
+  url: null
+  logo: null   # no organization logo; the website falls back to the project's own
+```
 
 ## Governance vocabulary
 

--- a/skills/committer-onboarding/SKILL.md
+++ b/skills/committer-onboarding/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-committer-onboarding
+organization: ASF
 description: |
   Post-vote committer and PMC onboarding for Apache projects.
   Walks the nominator through every step from ICLA check to

--- a/skills/contributor-activity-sweep/SKILL.md
+++ b/skills/contributor-activity-sweep/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-contributor-activity-sweep
+organization: ASF
 mode: Triage
 description: |
   Read-only GitHub activity card for a named contributor on <upstream>.

--- a/skills/contributor-nomination/SKILL.md
+++ b/skills/contributor-nomination/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-contributor-nomination
+organization: ASF
 mode: Triage
 description: |
   Read-only nomination brief for a named GitHub contributor on

--- a/skills/contributor-to-committer/SKILL.md
+++ b/skills/contributor-to-committer/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-contributor-to-committer
+organization: ASF
 mode: Mentoring
 description: |
   Read-only readiness tracker that maps a contributor's GitHub activity

--- a/skills/release-announce-draft/SKILL.md
+++ b/skills/release-announce-draft/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-announce-draft
+organization: ASF
 mode: Drafting
 description: |
   Draft the `[ANNOUNCE]` email body and open (not merge) the site-bump PR

--- a/skills/release-archive-sweep/SKILL.md
+++ b/skills/release-archive-sweep/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-archive-sweep
+organization: ASF
 mode: Triage
 description: |
   Scan `dist/release/<project>/` (or the configured distribution location),

--- a/skills/release-audit-report/SKILL.md
+++ b/skills/release-audit-report/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-audit-report
+organization: ASF
 mode: Triage
 description: |
   Assemble a per-release audit record from the planning issue, vote thread,

--- a/skills/release-keys-sync/SKILL.md
+++ b/skills/release-keys-sync/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-keys-sync
+organization: ASF
 mode: Drafting
 description: |
   Draft the diff that adds the Release Manager's public key to the

--- a/skills/release-prepare/SKILL.md
+++ b/skills/release-prepare/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-prepare
+organization: ASF
 mode: Drafting
 description: |
   Draft the release planning issue (Step 1), the prep PR with version

--- a/skills/release-promote/SKILL.md
+++ b/skills/release-promote/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-promote
+organization: ASF
 mode: Drafting
 description: |
   Emit the backend-shaped promotion command set for a release that has

--- a/skills/release-rc-cut/SKILL.md
+++ b/skills/release-rc-cut/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-rc-cut
+organization: ASF
 mode: Drafting
 description: |
   Emit the paste-ready command sequence to tag an RC, build artefacts,

--- a/skills/release-verify-rc/SKILL.md
+++ b/skills/release-verify-rc/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-verify-rc
+organization: ASF
 mode: Triage
 description: |
   Read-only pre-flight verification of a staged release candidate (RC)

--- a/skills/release-vote-draft/SKILL.md
+++ b/skills/release-vote-draft/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-vote-draft
+organization: ASF
 mode: Drafting
 description: |
   Draft the `[VOTE]` email body and planning-issue comment for an

--- a/skills/release-vote-tally/SKILL.md
+++ b/skills/release-vote-tally/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: magpie-release-vote-tally
+organization: ASF
 mode: Triage
 description: |
   After the approval window closes, fetch the approval signal for an RC

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -62,11 +62,29 @@ declares, up front:
    A pure interface-spec tool (an adapter *contract* with no executable
    code) says so and defers concrete prerequisites to its adapters.
 
-Both are **HARD** checks in
+3. **(Optional) its organization** — when a tool *belongs to* a specific
+   organization (it is the backend/adapter for that org's stack, e.g.
+   the ASF Vulnogram / PonyMail / apache-projects tools), add a line of
+   the exact form
+
+   ```markdown
+   **Organization:** ASF
+   ```
+
+   The value must name an organization under
+   [`organizations/`](../organizations/) (e.g. `ASF`). Omit the line for
+   organization-agnostic tools — absence means "belongs to no specific
+   organization". Skills declare the same membership with an
+   `organization:` frontmatter key; skill families with an
+   `organization:` scope banner in `docs/<family>/README.md`.
+
+The capability and prerequisites are **HARD** checks in
 [`tools/skill-and-tool-validator`](skill-and-tool-validator/) — a tool
 README missing either the `**Capability:**` line or the
 `## Prerequisites` section fails `skill-and-tool-validate` (and the
-`prek` / pre-commit hook that runs it).
+`prek` / pre-commit hook that runs it). The optional `**Organization:**`
+line, when present, must name a known organization or the validator
+fails the run.
 
 ## Refresh the cross-references when tools change
 

--- a/tools/apache-projects/README.md
+++ b/tools/apache-projects/README.md
@@ -14,6 +14,8 @@
 
 **Capability:** capability:stats + capability:intake
 
+**Organization:** ASF
+
 ASF project-metadata substrate. Read-only, unauthenticated client
 for the official `apache/comdev` `apache-projects-mcp` server, which
 wraps the public `projects.apache.org/json` feeds (committee /

--- a/tools/cve-tool-vulnogram/README.md
+++ b/tools/cve-tool-vulnogram/README.md
@@ -14,6 +14,8 @@
 
 **Capability:** capability:resolve
 
+**Organization:** ASF
+
 ASF Vulnogram CVE-allocation client. OAuth-authenticated API that allocates a CVE ID through the ASF's Vulnogram instance and publishes the CVE record. Consumed by `security-cve-allocate`. See [`allocation.md`](allocation.md), [`record.md`](record.md), and [`bot-credits-policy.md`](bot-credits-policy.md) for the protocol.
 
 ## Prerequisites

--- a/tools/ponymail/README.md
+++ b/tools/ponymail/README.md
@@ -14,6 +14,8 @@
 
 **Capability:** capability:setup + capability:intake
 
+**Organization:** ASF
+
 PonyMail archive substrate. Read-only ASF mailing-list archive client; complements `gmail` for threads not present in the inbox. Used by security-issue-import + sync to cross-reference public mailing-list discussions. See [`tool.md`](tool.md) for the operation catalogue and [`operations.md`](operations.md) for usage.
 
 ## Prerequisites

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -103,6 +103,17 @@ TOOL_CAPABILITY_RE = re.compile(r"^\*\*Capability:\*\*[ \t]+(.+)$", re.MULTILINE
 # stated up front rather than discovered at first run.
 TOOL_PREREQUISITES_RE = re.compile(r"^##[ \t]+Prerequisites[ \t]*$", re.MULTILINE)
 
+# Optional `**Organization:** <org>` line in a tool README — declares that
+# the tool belongs to / is the adapter for a specific organization (e.g.
+# the ASF backends cve-tool-vulnogram, ponymail, apache-projects). Absent =
+# organization-agnostic. Skills declare the same via an `organization:`
+# frontmatter key; skill families via a banner in docs/<family>/README.md.
+TOOL_ORGANIZATION_RE = re.compile(r"^\*\*Organization:\*\*[ \t]+(.+)$", re.MULTILINE)
+ORGANIZATION_CATEGORY = "organization"
+# Directory of organization adapters; an entity's declared `organization`
+# must match one of these (minus the authoring template).
+ORGANIZATIONS_DIR = Path("organizations")
+
 # Capability-sync check: keeps docs/labels-and-capabilities.md tables aligned
 # with live skill frontmatter + tool README declarations.
 DOCS_LABELS_AND_CAPABILITIES = Path("docs/labels-and-capabilities.md")
@@ -122,7 +133,7 @@ _CAPABILITY_TOKEN_RE = re.compile(r"`?(capability:[a-z]+)`?")
 _ITALIC_PARENS_RE = re.compile(r"\*\(.*?\)\*")
 
 REQUIRED_FRONTMATTER_KEYS = {"name", "description", "license", "capability"}
-OPTIONAL_FRONTMATTER_KEYS = {"when_to_use", "mode"}
+OPTIONAL_FRONTMATTER_KEYS = {"when_to_use", "mode", "organization"}
 ALLOWED_LICENSES = {"Apache-2.0"}
 
 # Canonical capability taxonomy — docs/labels-and-capabilities.md is authoritative.
@@ -297,6 +308,7 @@ HARD_CATEGORIES: frozenset[str] = frozenset(
         TOOL_README_CATEGORY,
         TOOL_CAPABILITY_CATEGORY,
         TOOL_PREREQUISITES_CATEGORY,
+        ORGANIZATION_CATEGORY,
         CAPABILITY_SYNC_CATEGORY,
         INJECTION_GUARD_CATEGORY,
         NAME_CONVENTION_CATEGORY,
@@ -533,12 +545,33 @@ def parse_frontmatter(text: str) -> dict[str, str] | None:
     return result
 
 
-def validate_frontmatter(path: Path, text: str) -> Iterable[Violation]:
+def known_organizations(root: Path | None = None) -> set[str]:
+    """Return the set of declared organization adapters (dir names under
+    ``organizations/``), excluding the authoring template. An entity that
+    declares ``organization: <name>`` must name one of these."""
+    base = (root or find_repo_root()) / ORGANIZATIONS_DIR
+    if not base.exists():
+        return set()
+    return {d.name for d in base.iterdir() if d.is_dir() and d.name != "_template"}
+
+
+def validate_frontmatter(path: Path, text: str, root: Path | None = None) -> Iterable[Violation]:
     """Validate the YAML frontmatter of a SKILL.md file."""
     fm = parse_frontmatter(text)
     if fm is None:
         yield Violation(path, 1, "missing YAML frontmatter block (expected '---' at start)")
         return
+
+    if fm.get("organization"):
+        orgs = known_organizations(root)
+        if orgs and fm["organization"] not in orgs:
+            yield Violation(
+                path,
+                1,
+                f"frontmatter organization '{fm['organization']}' is not a known organization "
+                f"{sorted(orgs)} — add organizations/{fm['organization']}/ or fix the value",
+                category=ORGANIZATION_CATEGORY,
+            )
 
     missing = REQUIRED_FRONTMATTER_KEYS - set(fm.keys())
     for key in sorted(missing):
@@ -1356,6 +1389,19 @@ def validate_tools(root: Path | None = None) -> Iterable[Violation]:
                 f"access up front (see tools/AGENTS.md)",
                 category=TOOL_PREREQUISITES_CATEGORY,
             )
+
+        org_match = TOOL_ORGANIZATION_RE.search(text)
+        if org_match is not None:
+            org = org_match.group(1).strip()
+            orgs = known_organizations(root)
+            if orgs and org not in orgs:
+                yield Violation(
+                    readme,
+                    text[: org_match.start()].count("\n") + 1,
+                    f"tool '{tool_dir.name}' '**Organization:** {org}' is not a known "
+                    f"organization {sorted(orgs)} — add organizations/{org}/ or fix the value",
+                    category=ORGANIZATION_CATEGORY,
+                )
 
         match = TOOL_CAPABILITY_RE.search(text)
         if match is None:

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -56,6 +56,7 @@ from skill_and_tool_validator import (
     find_repo_root,
     is_path_allowlisted,
     is_placeholder_url,
+    known_organizations,
     line_has_inline_allow_marker,
     main,
     parse_frontmatter,
@@ -2425,6 +2426,64 @@ class TestValidateTools:
         (tool / "README.md").write_text("# bare-both\n\nDescription only.\n")
         cats = {v.category for v in validate_tools(root)}
         assert cats == {"tool-prerequisites", "tool-capability"}
+
+    def test_tool_organization_known(self, tmp_path: Path) -> None:
+        root = _make_tools_root(tmp_path)
+        (root / "organizations" / "ASF").mkdir(parents=True)
+        tool = root / "tools" / "asf-backend"
+        tool.mkdir()
+        (tool / "README.md").write_text(
+            "# asf-backend\n\n**Capability:** capability:setup\n\n"
+            "**Organization:** ASF\n\nAn ASF backend.\n\n## Prerequisites\n\n- None.\n"
+        )
+        violations = list(validate_tools(root))
+        assert violations == []
+
+    def test_tool_organization_unknown(self, tmp_path: Path) -> None:
+        root = _make_tools_root(tmp_path)
+        (root / "organizations" / "ASF").mkdir(parents=True)
+        tool = root / "tools" / "bogus-org"
+        tool.mkdir()
+        (tool / "README.md").write_text(
+            "# bogus-org\n\n**Capability:** capability:setup\n\n"
+            "**Organization:** Nope\n\nA tool.\n\n## Prerequisites\n\n- None.\n"
+        )
+        violations = [v for v in validate_tools(root) if v.category == "organization"]
+        assert len(violations) == 1
+        assert "'**Organization:** Nope'" in violations[0].message
+
+
+class TestOrganizationMembership:
+    def test_known_organizations_excludes_template(self, tmp_path: Path) -> None:
+        for name in ("ASF", "independent", "_template"):
+            (tmp_path / "organizations" / name).mkdir(parents=True)
+        assert known_organizations(tmp_path) == {"ASF", "independent"}
+
+    def test_frontmatter_organization_known(self, tmp_path: Path) -> None:
+        (tmp_path / "organizations" / "ASF").mkdir(parents=True)
+        text = (
+            "---\nname: magpie-x\ndescription: d\nlicense: Apache-2.0\n"
+            "capability: capability:setup\norganization: ASF\n---\n\nBody.\n"
+        )
+        violations = [
+            v
+            for v in validate_frontmatter(tmp_path / "SKILL.md", text, root=tmp_path)
+            if v.category == "organization"
+        ]
+        assert violations == []
+
+    def test_frontmatter_organization_unknown(self, tmp_path: Path) -> None:
+        (tmp_path / "organizations" / "ASF").mkdir(parents=True)
+        text = (
+            "---\nname: magpie-x\ndescription: d\nlicense: Apache-2.0\n"
+            "capability: capability:setup\norganization: Nope\n---\n\nBody.\n"
+        )
+        violations = [
+            v
+            for v in validate_frontmatter(tmp_path / "SKILL.md", text, root=tmp_path)
+            if v.category == "organization"
+        ]
+        assert len(violations) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tools/spec-loop/specs/project-agnosticism.md
+++ b/tools/spec-loop/specs/project-agnosticism.md
@@ -59,27 +59,33 @@ The three mechanisms, in order of preference:
   `projects/_template/`.
 - The backend-flag precedent: `docs/release-management/README.md`
   (§ adopter backends) and `projects/_template/release-management-config.md`.
-- The per-family **`asf:` metadata flag** (`asf: true` / `asf: false`),
-  declared in each family's scope banner at the top of
-  `docs/<family>/README.md` and surfaced in the **Scope** column of the
-  family tables in [`README.md`](../../../README.md#skill-families) and
-  [`docs/index.md`](../../../docs/index.md#need-help-with-one-of-these-adopt-a-family-of-skills).
-  Only **release-management** and **contributor-growth** carry `asf: true`:
-  their *core purpose* is an ASF Foundation process (the release lifecycle,
-  the contributor-to-committer path). This is a narrower lens than the
-  residual-coupling audit list below — a family can be `asf: false`
-  (generic core, runs anywhere) and still carry ASF-flavoured defaults that
-  the coupling audit tracks (security is the clearest case).
+- The per-family **`organization:` scope** (formerly the binary
+  `asf: true` / `asf: false` flag), declared in each family's scope banner
+  at the top of `docs/<family>/README.md` and surfaced in the **Scope**
+  column of the family tables in [`README.md`](../../../README.md#skill-families)
+  and [`docs/index.md`](../../../docs/index.md#need-help-with-one-of-these-adopt-a-family-of-skills).
+  An organization-scoped family declares `organization: <org>` (naming a
+  directory under [`organizations/`](../../../organizations/)); an
+  organization-agnostic family declares no scope key at all. Only
+  **release-management** and **contributor-growth** carry
+  `organization: ASF`: their *core purpose* is an ASF Foundation process
+  (the release lifecycle, the contributor-to-committer path). This is a
+  narrower lens than the residual-coupling audit list below — a family can
+  be agnostic (no `organization:`, runs anywhere) and still carry
+  ASF-flavoured *defaults* that the coupling audit tracks (security is the
+  clearest case; those defaults now live in `organizations/ASF/`).
+  Skills, tools, and tool adapters declare the same membership — see
+  [`organizations/README.md` § Membership](../../../organizations/README.md#membership--what-can-belong-to-an-organization).
 - The skills carrying residual ASF coupling to audit, by family:
-  - **security** (`asf: false`): generic at its core, but ships an
+  - **security** (agnostic): generic at its core, but ships an
     ASF-flavoured default profile — `security@`-style intake and the ASF
     security-team relay (`security-issue-import-via-forwarder`), CVE
     allocation assuming an ASF CNA (`security-cve-allocate`), Vulnogram as
     the CVE tool — all swappable for GHSA / MITRE-CNA via the config layer.
-  - **contributor / committer growth** (`asf: true`): `committer-onboarding`
-    (ICLA gate, PMC vote semantics, `dev@` announce),
+  - **contributor / committer growth** (`organization: ASF`):
+    `committer-onboarding` (ICLA gate, PMC vote semantics, `dev@` announce),
     `contributor-nomination` (committer-vs-PMC roster framing).
-  - **release-management** (`asf: true`, proposed): the whole ASF release
+  - **release-management** (`organization: ASF`): the whole ASF release
     ritual, already designed with backend flags; the audit confirms the
     non-ASF paths stay first-class as the skills land.
   - any skill whose prose names `apache.org` lists, `svn` dist trees,


### PR DESCRIPTION
## What

Two additions on top of the organization layer (#622/#623):

### 1. Organization membership for every entity type
Any framework entity can now declare that it **belongs to** an
organization (and so assumes its stack). The value must name a directory
under `organizations/`; absence = organization-agnostic. The validator
rejects an unknown value.

| Entity | Declares membership via |
|---|---|
| Skill | `organization:` frontmatter key |
| Skill family | `organization:` scope banner in `docs/<family>/README.md` (**replaces** the binary `asf: true/false` flag — agnostic families now carry no scope key at all) |
| Tool | `**Organization:** <org>` line in the README |
| Tool adapter | same — the adapter directory's README |

Applied `organization: ASF` to the **release-management** +
**contributor-growth** families and their **14 skills**, and to the ASF
backend tools **cve-tool-vulnogram / ponymail / apache-projects**.

### 2. Organization identity (for the website)
Each `organizations/<org>/organization.md` gains an
`organization_identity` block — `id`, full `name` (longer than the id),
`url`, and **`logo`**. The website renders the logo/name for projects
under the organization. ASF → the Apache feather; `independent` → no
logo (site falls back to the project's own).

## Supporting
- Validator: new `organization` HARD category + `known_organizations()`
  helper + tests (skill frontmatter + tool README).
- Docs: `AGENTS.md` labeling, `tools/AGENTS.md`, `organizations/README.md`
  (new Membership table + identity), and the `project-agnosticism` spec.

## Verification
`skill-and-tool-validate` EXIT 0 (no organization violations); validator
mypy + pytest green via `uv run`; doctoc / markdownlint / lychee /
placeholder / spec-validate all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)