### PR TITLE
feat(security-issue-sync): honor disclosure_governance flags from security-intake-config

### DIFF
--- a/skills/security-issue-sync/SKILL.md
+++ b/skills/security-issue-sync/SKILL.md
@@ -330,6 +330,26 @@ Before reading any tracker state, verify:
    when (and only when) the rendered draft references a
    third-party identifier.
 
+6. **Disclosure governance flags from `<project-config>/security-intake-config.md`.**
+   If the file exists, read the `disclosure_governance` block and load these
+   three keys into the observed-state bag for use in Steps 1 and 2b:
+
+   - `window_days` — integer; the CVD window in calendar days from first
+     receipt to public disclosure.  Used in Step 1a to flag trackers past
+     their disclosure deadline.
+   - `grace_period_days` — integer; the additional days granted after a fix
+     ships before the team is expected to publish the advisory.  Used in
+     Step 1a to determine whether the grace period has also lapsed.
+   - `pre_announce_distributors` — boolean; when `true` the team maintains
+     a distributor embargo list and the skill proposes a pre-announcement
+     draft once the fix is in a pending release.  Used in Step 2b.
+
+   If the file does not exist or the `disclosure_governance` block is absent,
+   silently default to `window_days: 90`, `grace_period_days: 14`, and
+   `pre_announce_distributors: false`.  A missing file is **not** a stop
+   condition — adopters who have not yet created this config receive the same
+   ASF defaults the skill has always applied.
+
 If any check fails (other than PonyMail, which degrades quietly),
 stop and surface what is missing. Do **not** proceed to Step 1 on a
 partial setup — half the observations would be wrong and the

--- a/skills/security-issue-sync/gather.md
+++ b/skills/security-issue-sync/gather.md
@@ -38,6 +38,26 @@ Record:
   - link to the fixing PR(s);
 - the discussion so far (comments), paying attention to the most recent activity
   and any stalled-for-30-days state.
+- **Disclosure deadline check.** Compute `issue_age_days` as the number of
+  calendar days between `createdAt` and today's date.  Compare against the
+  `window_days` and `grace_period_days` values loaded in Step 0.6 and set the
+  following flags in the observed-state bag:
+  - `overdue_for_disclosure: true` — when `issue_age_days > window_days` **and**
+    the `announced` label is absent (the advisory has not yet been sent).
+  - `approaching_window_end: true` — when `issue_age_days > window_days * 0.8`
+    (≥ 80 % of the window elapsed) and the issue is not yet `announced` — a
+    yellow-flag caution surfaced in the observed-state dump but no proposal item
+    is added.
+  - `grace_period_expired: true` — when the issue carries `pr merged` or
+    `fix released` **and** `issue_age_days > window_days + grace_period_days` and
+    the `announced` label is absent.
+  - `distributor_notify_pending: true` — when `pre_announce_distributors: true`
+    (from Step 0.6) **and** the issue carries `pr merged` or `fix released` and
+    the `announced` label is absent.  Signals that Step 2b should propose a
+    pre-announcement draft for the distributor embargo list.
+  These flags are informational observations only; they do not stop the sync.
+  A missing `announced` label on a tracker whose `announced` date is populated
+  in the body is treated as missing-label (propose adding it, not as overdue).
 
 Also read the tracker's **project-board status** on the "Security
 issues" board — the board is the primary overview surface for the

--- a/skills/security-issue-sync/signals-to-actions.md
+++ b/skills/security-issue-sync/signals-to-actions.md
@@ -1065,6 +1065,54 @@ will change and *why*. Group them by category:
   **Apply mechanic** — same as the hand-off comment: a fresh
   `gh issue comment`, surfaced in the recap.
 
+- **Overdue-for-disclosure escalation** — when `overdue_for_disclosure: true`
+  (Step 1a) the tracker has passed its CVD window without the advisory being
+  sent.  Propose appending a rollup entry that:
+
+  1. Notes the elapsed time and the configured `window_days` ceiling (e.g.
+     *"Tracker is {issue_age_days} days old; the project's CVD window is
+     {window_days} days — disclosure is overdue."*).
+  2. Recommends one of:
+     - Notifying the reporter of an extended timeline on the mail thread
+       (propose a Gmail draft if the acknowledgement model is `manual`); or
+     - Proceeding to disclosure with a partial or advisory-only fix if a
+       coordinated full fix cannot ship in the near term.
+  3. Does **not** override or silence any other proposal — the overdue flag
+     is additive context, not a shortcut past the normal lifecycle steps.
+
+  When `grace_period_expired: true` (fix shipped but grace period has also
+  lapsed), promote the rollup entry to a **separate first-class comment** (not
+  a `<details>` entry) so it is immediately visible to the release manager and
+  the security team without expanding the rollup.  Use the same idempotency
+  check as the RM hand-off comment — scan for the marker
+  ```html
+  <!-- apache-magpie: disclosure-overdue v1 -->
+  ```
+  before proposing; if it already exists, update it in-place via PATCH rather
+  than posting a duplicate.
+
+- **Distributor pre-announcement draft** — when `distributor_notify_pending: true`
+  (Step 1a) the project maintains an embargo distributor list and the fix is
+  about to ship.  Propose a Gmail draft pre-announcement to the distributor
+  list declared in `<project-config>/distributor-list.md` (if that file exists;
+  if absent, surface a one-line note that the adopter should create it and
+  document the list URL there before this proposal can be executed).  The draft:
+
+  - Names the CVE ID and the affected product/versions from the tracker body.
+  - States the expected public disclosure date as
+    `createdAt + window_days + grace_period_days` (or earlier if the team
+    decides to disclose sooner) — do not commit to a specific calendar date
+    unless the advisory send date has already been confirmed by the team.
+  - Omits any detail beyond what is in the advisory's *Short public summary
+    for publish* body field — the pre-announcement is not the advisory itself.
+  - Is marked **DRAFT, NEVER SEND** until the team confirms the wording, the
+    recipient list, and the timing.
+
+  Trigger condition: `distributor_notify_pending: true` AND the `announced`
+  label is absent AND no pre-announcement draft already exists in Gmail for
+  this tracker's thread (check via the existing Gmail draft-scan the skill
+  performs in Step 1e before proposing a new draft).
+
 - **Draft email to reporter (other reasons)** — whenever the ball is in our
   court on the email thread for any other reason (a question from the
   reporter, a follow-up needed for triage, communicating a negative

--- a/tools/skill-evals/evals/security-issue-sync/step-1f-process-step/fixtures/step-config.json
+++ b/tools/skill-evals/evals/security-issue-sync/step-1f-process-step/fixtures/step-config.json
@@ -1,4 +1,4 @@
 {
-  "skill_md": "skills/security-issue-sync/SKILL.md",
+  "skill_md": "skills/security-issue-sync/gather.md",
   "step_heading": "### 1f. Locate the process step"
 }

--- a/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-4-overdue-disclosure-window/expected.json
+++ b/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-4-overdue-disclosure-window/expected.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "number": 1,
+      "category": "status_comment",
+      "action": "Append disclosure-overdue rollup entry noting tracker is 60 days old against a 45-day CVD window and recommending either notifying the reporter of an extended timeline or proceeding to advisory-only disclosure",
+      "reason": "overdue_for_disclosure is true — issue_age_days (60) exceeds window_days (45) and the announced label is absent."
+    }
+  ],
+  "labels_to_add": [],
+  "labels_to_remove": [],
+  "milestone_create_needed": false,
+  "assignee_proposed": null,
+  "has_bare_issue_numbers": false,
+  "overdue_for_disclosure_proposed": true
+}

--- a/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-4-overdue-disclosure-window/report.md
+++ b/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-4-overdue-disclosure-window/report.md
@@ -1,0 +1,27 @@
+## Observed tracker state
+
+**Tracker:** myproject-s/myproject-s#88
+**Current labels:** security issue, cve allocated
+**Current milestone:** (none)
+**Current assignee:** (none)
+
+## Disclosure governance flags (Step 0.6)
+
+Loaded from `projects/myproject/security-intake-config.md`:
+- `window_days: 45`
+- `grace_period_days: 14`
+- `pre_announce_distributors: false`
+
+## Gathered state from Step 1
+
+**PR with the fix:** (none — no fix PR opened yet)
+**Process step:** 7 (cve allocated, pending fix)
+
+**Disclosure deadline check (Step 1a):**
+- `issue_age_days: 60` (issue created 2026-04-30; today 2026-06-29)
+- `overdue_for_disclosure: true` (60 > 45; `announced` label absent)
+- `approaching_window_end: false` (window already exceeded)
+- `grace_period_expired: false` (no fix shipped yet)
+- `distributor_notify_pending: false`
+
+Produce the numbered proposal for this tracker.

--- a/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-5-pre-announce-distributors/expected.json
+++ b/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-5-pre-announce-distributors/expected.json
@@ -1,0 +1,16 @@
+{
+  "items": [
+    {
+      "number": 1,
+      "category": "status_comment",
+      "action": "Draft distributor pre-announcement email to the embargo list declared in projects/airflow/distributor-list.md, noting the pending Airflow 3.2.3 release carrying the fix for this tracker",
+      "reason": "distributor_notify_pending is true — pre_announce_distributors is set and the pr merged label is present with the announced label absent."
+    }
+  ],
+  "labels_to_add": [],
+  "labels_to_remove": [],
+  "milestone_create_needed": false,
+  "assignee_proposed": null,
+  "has_bare_issue_numbers": false,
+  "distributor_notify_proposed": true
+}

--- a/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-5-pre-announce-distributors/report.md
+++ b/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/case-5-pre-announce-distributors/report.md
@@ -1,0 +1,30 @@
+## Observed tracker state
+
+**Tracker:** airflow-s/airflow-s#401
+**Current labels:** security issue, cve allocated, pr merged
+**Current milestone:** Airflow 3.2.3 (exists on tracker)
+**Current assignee:** mik-laj (collaborator)
+
+## Disclosure governance flags (Step 0.6)
+
+Loaded from `projects/airflow/security-intake-config.md`:
+- `window_days: 90`
+- `grace_period_days: 14`
+- `pre_announce_distributors: true`
+
+## Gathered state from Step 1
+
+**PR with the fix:** apache/airflow#67241
+**PR state:** MERGED (merged 2026-06-20)
+**PR milestone:** Airflow 3.2.3 (pending release — not yet tagged)
+
+**Process step:** 11 (pr merged — fix in main, awaiting release)
+
+**Disclosure deadline check (Step 1a):**
+- `issue_age_days: 58` (within 90-day window)
+- `overdue_for_disclosure: false`
+- `approaching_window_end: false`
+- `grace_period_expired: false`
+- `distributor_notify_pending: true` (pre_announce_distributors true; pr merged label present; announced label absent)
+
+Produce the numbered proposal for this tracker.

--- a/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/security-issue-sync/step-2b-proposed-changes/fixtures/output-spec.md
@@ -28,3 +28,5 @@ Field rules:
 - `milestone_create_needed`: `true` when the required milestone does not yet exist on the tracker and a `gh api` create call is included in the proposal.
 - `assignee_proposed`: the GitHub handle proposed for assignee, or `null`. Only propose a security-team collaborator, never an external reporter.
 - `has_bare_issue_numbers`: `true` if any item contains a bare `#NNN` without a full URL — should be `false`.
+- `overdue_for_disclosure_proposed`: `true` when `items` contains an escalation item due to the CVD window expiring. Optional field — omit (or set `false`) when the tracker is not overdue.
+- `distributor_notify_proposed`: `true` when `items` contains a distributor pre-announcement draft proposal. Optional field — omit (or set `false`) when `pre_announce_distributors` is `false` or the fix is not yet in a pending release.


### PR DESCRIPTION
## Summary

Read window_days, grace_period_days, and pre_announce_distributors from the project's security-intake-config.md at Step 0 startup (sub-step 6), default to 90/14/false when the file is absent.  Step 1a computes four new flags in the observed-state bag: overdue_for_disclosure, approaching_window_end, grace_period_expired, and distributor_notify_pending.  Signals-to-actions maps them to two new proposal types: a disclosure-overdue rollup entry (promoted to a first-class comment when grace_period_expired) and a distributor pre-announcement draft.

Add eval cases 4-5 in step-2b-proposed-changes covering each new signal, and extend the output-spec with the two corresponding assertion booleans.  Also fix a pre-existing misconfiguration: step-1f step-config.json was pointing at SKILL.md; the heading lives in gather.md.

Generated-by: Claude (Opus 4.7)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
