### PR TITLE
fix(skills): clear criteria-source and action-inventory advisories inrelease skills

### DIFF
--- a/skills/release-archive-sweep/SKILL.md
+++ b/skills/release-archive-sweep/SKILL.md
@@ -10,8 +10,8 @@ description: |
 when_to_use: |
   Invoke when a Release Manager says "run the archive sweep", "clean up old
   releases from dist", "archive past-retention releases for <project>", or
-  similar. Appropriate after Step 11 (`release-announce-draft`) confirms a
-  new release is promoted and announced. Safe to run periodically on any
+  similar. Appropriate after the announcement phase (`release-announce-draft`)
+  confirms a new release is promoted and announced. Safe to run periodically on any
   schedule; it is a no-op when nothing is past retention.
 argument-hint: "[--planning-issue <url>]"
 capability: capability:resolve

--- a/skills/release-audit-report/SKILL.md
+++ b/skills/release-audit-report/SKILL.md
@@ -2,16 +2,16 @@
 name: magpie-release-audit-report
 mode: Triage
 description: |
-  Assemble a per-release audit record from the planning issue, vote thread,
-  RC artefact list, promote revision, and announcement archive URL, then
-  propose a PR that appends the record to the project's audit log.
+  Assemble a per-release audit record from lifecycle artefacts (planning
+  issue, vote thread, artefact list, promote revision, and announcement
+  URL) and propose a PR appending it to the project's audit log.
   Read-only on every release surface; the only write is a PR the RM
   reviews and a committer merges.
 when_to_use: |
   Invoke when a Release Manager says "generate the audit report for
   <version>", "write the release audit log entry for <version>", "record
-  the lifecycle for <version>", or similar. Appropriate after Step 12
-  (`release-archive-sweep`) completes. Standalone: can also be run
+  the lifecycle for <version>", or similar. Appropriate after the archive
+  sweep (`release-archive-sweep`) completes. Standalone: can also be run
   periodically to refresh existing audit entries from updated source data.
 argument-hint: "<version> [--planning-issue <url>]"
 capability: capability:stats

--- a/skills/release-keys-sync/SKILL.md
+++ b/skills/release-keys-sync/SKILL.md
@@ -6,8 +6,8 @@ description: |
   project's KEYS file (`<keys-file-url>`), emit a paste-ready `svn`
   (or backend-equivalent) command sequence, remind the RM to upload to
   the configured keyserver, and validate the key meets the ASF strength
-  floor. Never commits, never holds or reads the private key. Step 3 of
-  the release-management lifecycle.
+  floor. Never commits, never holds or reads the private key. Runs during
+  release preparation, before RC signing begins.
 when_to_use: |
   Invoke when a Release Manager says "add my key to KEYS", "sync my
   signing key for the release", "run release-keys-sync", or any variation

--- a/skills/release-prepare/SKILL.md
+++ b/skills/release-prepare/SKILL.md
@@ -2,10 +2,10 @@
 name: magpie-release-prepare
 mode: Drafting
 description: |
-  Draft the release planning issue (Step 1), the prep PR with version
-  bump, changelog, NOTICE, and LICENSE updates (Step 2), or the
-  post-release development-version bump PR (Step 14) for `<upstream>`.
-  Reads release metadata from `<project-config>/release-trains.md` and
+  Draft release preparation artefacts for `<upstream>`: the planning
+  issue, the version-bump and changelog prep PR, or the post-release
+  development-version bump PR. Reads release metadata from
+  `<project-config>/release-trains.md` and
   `<project-config>/release-management-config.md`. Every output is a
   draft confirmed by the Release Manager before filing; the agent never
   marks a PR ready, never merges, and never closes any artefact.
@@ -13,12 +13,12 @@ when_to_use: |
   Invoke when a Release Manager says "prepare the <version> release",
   "draft the planning issue for <version>", "open the prep PR for
   <version>", "write the version bump for <version>", "draft the
-  post-release bump for <version>", or similar. Also invoked as
-  Steps 1, 2, and 14 of the release-management lifecycle
-  (`/release-prepare <version>` for Step 1, `/release-prepare prep
-  <version>` for Step 2, `/release-prepare post <version>` for
-  Step 14). Requires `<project-config>/release-management-config.md`
-  and `<project-config>/release-trains.md` to exist.
+  post-release bump for <version>", or similar. Covers three lifecycle
+  moments: planning-issue creation (`/release-prepare <version>`),
+  version-bump prep PR (`/release-prepare prep <version>`), and
+  post-release dev-version bump (`/release-prepare post <version>`).
+  Requires `<project-config>/release-management-config.md` and
+  `<project-config>/release-trains.md` to exist.
 argument-hint: "[prep | post] <version>"
 capability: capability:resolve
 license: Apache-2.0

--- a/skills/release-verify-rc/SKILL.md
+++ b/skills/release-verify-rc/SKILL.md
@@ -3,17 +3,17 @@ name: magpie-release-verify-rc
 mode: Triage
 description: |
   Read-only pre-flight verification of a staged release candidate (RC)
-  for `<upstream>`. Verifies GPG signatures, checksums, Apache RAT
-  license headers, NOTICE/LICENSE presence, prohibited-binary absence,
-  and version-string consistency across manifest files. Emits a
+  for `<upstream>`. Checks artefact integrity (GPG signatures and
+  checksums), Apache RAT licence headers, NOTICE/LICENSE completeness,
+  prohibited-binary absence, and version-string consistency. Emits a
   structured PASS / PASS-WITH-WARNINGS / FAIL report. Makes no state
   change; a `--post-to <planning-issue>` flag proposes a comment for
   explicit RM confirmation before any posting.
 when_to_use: |
   Invoke when a Release Manager or voter says "verify rc N for
   <version>", "run pre-flight on <version>-rcN", "check the RC
-  artefacts for <version>", or similar. Appropriate at Step 6 of the
-  release lifecycle — before the `[VOTE]` thread is opened (RM's
+  artefacts for <version>", or similar. Appropriate during the RC
+  pre-flight phase — before the `[VOTE]` thread is opened (RM's
   self-check) or during the vote window (any voter's dev loop). Can be
   run standalone with no other release-* skill in the session.
 argument-hint: "<version>-rcN [--post-to <planning-issue-url>]"


### PR DESCRIPTION
## Summary

Rephrase the `description` and `when_to_use` frontmatter fields across five release-management skills to clear 13 SOFT validator advisories:

- criteria-source (10): "Step N" references in frontmatter look like external-doc pointers the LLM router would need to open; replaced with self-contained lifecycle-phase descriptions.
- action-inventory (3): single-sentence enumerations with ≥5 commas in description fields; shortened to higher-level summaries.

No step logic, skill body, or adopter-facing behaviour is changed.

Generated-by: Claude (Opus 4.7)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
