### PR TITLE
docs(mentoring): sync README to reflect contributor-to-committer shipped

### DIFF
--- a/docs/mentoring/README.md
+++ b/docs/mentoring/README.md
@@ -17,9 +17,9 @@
 # Mentoring skill family
 
 Maintainer-facing skills that join contributor threads in a teaching
-register, author newcomer-ready issues, and orient first-time contributors.
-Three skills shipped at `experimental`; a fourth (`contributor-to-committer`)
-is in-flight.
+register, author newcomer-ready issues, orient first-time contributors, and
+track a contributor's readiness path to committer nomination.
+Four skills shipped at `experimental`.
 
 MISSION names Mentoring as the highest-value project-side mode and the one
 off-the-shelf agent tooling skips. The framework lands the spec — tone guide,
@@ -34,8 +34,9 @@ behaviour and can be evolved without editing the skill body.
 | [`pr-management-mentor`](../../skills/pr-management-mentor/SKILL.md) | Draft a teaching-register comment on a single GitHub issue or PR thread; waits for maintainer confirmation before posting. | experimental |
 | [`good-first-issue-author`](../../skills/good-first-issue-author/SKILL.md) | Draft one net-new good first issue from a supplied gap or small task; a suitability gate and R1–R9 readiness checklist gate the draft; waits for maintainer confirmation before filing via `gh`. | experimental |
 | [`mentoring-welcome`](../../skills/mentoring-welcome/SKILL.md) | Draft a first-contact orientation comment for a first-time contributor on a newly opened issue or PR; detects first-time authorship via the GitHub `author_association` field; skips repeat contributors. | experimental |
+| [`contributor-to-committer`](../../skills/contributor-to-committer/SKILL.md) | Read-only readiness tracker that maps a contributor's GitHub activity against the adopter's declared committer/PMC thresholds; surfaces a traffic-light brief (Not yet / Approaching / Ready to nominate) plus the specific evidence gaps that remain. | experimental |
 
-All three skills are read-only on tracker state or draft-then-confirm: no
+All four skills are read-only on tracker state or draft-then-confirm: no
 skill posts, labels, closes, or files anything without explicit maintainer
 confirmation in-session.
 
@@ -58,6 +59,13 @@ confirmation in-session.
   orientation comment (contributing-guide link, community-norm pointers,
   expected next steps). Skips silently for repeat contributors and
   security-sensitive threads.
+- **`contributor-to-committer`** — the readiness-tracking skill. Takes a
+  GitHub handle, fetches their public activity on `<upstream>`, and maps it
+  against the adopter's declared committer or PMC thresholds from
+  `committer-readiness.md`. Returns a traffic-light verdict (Not yet /
+  Approaching / Ready to nominate) plus a gap table showing exactly what
+  evidence the contributor still needs. Read-only; never opens a nomination
+  thread, sends a message, or modifies any record.
 
 ## Adopter contract
 
@@ -69,19 +77,16 @@ The skills resolve project-specific content from these files in the adopter's
 | [`mentoring-config.md`](../../projects/_template/mentoring-config.md) | `pr-management-mentor` (tone knobs, hand-off team, footer, `max_agent_turns`) |
 | [`good-first-issue-config.md`](../../projects/_template/good-first-issue-config.md) | `good-first-issue-author` (candidate-scope rules, R1–R9 threshold, filing target) |
 | [`mentoring-welcome-config.md`](../../projects/_template/mentoring-welcome-config.md) | `mentoring-welcome` (welcome-comment bodies, detection rules, contributing-guide URL) |
+| [`committer-readiness.md`](../../projects/_template/committer-readiness.md) | `contributor-to-committer` (committer/PMC threshold declarations: PR count, review count, issue participation, tenure window) |
 
 See the spec's [Adopter contract section](spec.md#adopter-contract) for the
 required key documentation.
 
 ## Status
 
-**Experimental.** Three skills shipped. No adopter has run the full
+**Experimental.** Four skills shipped. No adopter has run the full
 contributor-to-committer interaction path under evaluation conditions yet;
 shape may change between framework versions.
-
-An in-flight fourth skill — `contributor-to-committer` — assembles readiness
-evidence for a contributor approaching committer nomination and surfaces the
-signals `contributor-nomination` already gathers. It is not yet on `main`.
 
 ## Cross-references
 

--- a/tools/spec-loop/specs/mentoring-mode.md
+++ b/tools/spec-loop/specs/mentoring-mode.md
@@ -123,10 +123,11 @@ uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/mentoring-
 - **The family now covers the newcomer journey end to end.**
   `pr-management-mentor`, `good-first-issue-author`, `mentoring-welcome`
   (first-contribution welcome / orientation), and `contributor-to-committer`
-  (readiness path tracker) all ship. The two newcomer-facing capabilities
-  this spec previously flagged as undesigned are both built; the open
-  item that remains is the backlog-curation counterpart noted above
-  (relabeling the existing backlog as good-first-issue candidates).
+  (readiness path tracker) all ship. `docs/mentoring/README.md` reflects all
+  four shipped skills. The two newcomer-facing capabilities this spec
+  previously flagged as undesigned are both built; the open item that remains
+  is the backlog-curation counterpart noted above (relabeling the existing
+  backlog as good-first-issue candidates).
 - **`experimental` — no adopter pilot has run.** All four shipped skills
   (`pr-management-mentor`, `good-first-issue-author`, `mentoring-welcome`)
   and `contributor-to-committer` may change shape as adopter pilots and


### PR DESCRIPTION
## Summary

docs/mentoring/README.md described contributor-to-committer as an in-flight skill "not yet on main", but it has been on main since it landed. This sync adds the skill to the table and descriptions, updates the skill count from three to four, adds committer-readiness.md to the adopter-contract table, and removes the stale in-flight note.

Clears the stale text that would mislead adopters and future agents reading this doc. Mirrors the pattern established by the issue-management README sync.

Generated-by: Claude (Opus 4.7)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
