### PR TITLE
fix(skills): clear mechanical SOFT validator warnings

### DIFF
--- a/skills/release-prepare/SKILL.md
+++ b/skills/release-prepare/SKILL.md
@@ -321,13 +321,18 @@ confirmation before creating the issue.
 
 Proposed issue title: `Release <Product Name> <version>`
 
-If the RM confirms, create the issue via:
+If the RM confirms, write the body to a temp file (the planning issue body
+is internally-generated content, not attacker-controlled, but using
+`--body-file` avoids shell-quoting edge cases with multi-line bodies):
 
 ```bash
+cat > /tmp/planning-issue-body-<version>.md <<'EOF'
+<body>
+EOF
 gh issue create \
   --repo <upstream> \
   --title "Release <Product Name> <version>" \
-  --body "<body>" \
+  --body-file /tmp/planning-issue-body-<version>.md \
   --label "release-planning"
 ```
 

--- a/skills/reviewer-routing/SKILL.md
+++ b/skills/reviewer-routing/SKILL.md
@@ -27,7 +27,6 @@ license: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
 <!-- Placeholder convention (see ../../AGENTS.md#placeholder-convention-used-in-skill-files):
-     <tracker>         → GitHub slug of the security tracker repo
      <upstream>        → GitHub slug of the upstream codebase
      <project-config>  → the adopting project's config directory
      <default-branch>  → upstream's default branch (master vs main)

--- a/skills/security-issue-import/SKILL.md
+++ b/skills/security-issue-import/SKILL.md
@@ -1937,7 +1937,7 @@ media / cross-thread-followup / fix-already-public):
 
    ```bash
    LEDGER=$(gh issue list --repo <tracker> --state open \
-     --label rejections-ledger --json number --jq '.[0].number')
+     --label rejections-ledger --limit 5 --json number --jq '.[0].number')
    ```
 
    *Write tool call:* `file_path: /tmp/rejection-<threadId>.md`,


### PR DESCRIPTION
## Summary

Three non-judgement SOFT warnings eliminated:

* reviewer-routing: remove <tracker> from placeholder comment — the skill reads from <upstream> only; the stale placeholder entry was triggering a false-positive privacy-llm-gate advisory.

* security-issue-import: add --limit 5 to the rejections-ledger gh issue list call — unbounded calls silently cap at 30 results; the ledger issue is a singleton so 5 is a safe, explicit bound.

* release-prepare: replace --body "<body>" with --body-file flow for the gh issue create in Step 1 — eliminates security-pattern-9 advisory about inline shell arguments.

Validator passes: 264 tests green; remaining SOFT warnings are all asf-coupling [low] and one action-inventory, both deferred to item 4.

Generated-by: Claude (Opus 4.7)

## Type of change

- [X] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
