### PR TITLE
feat(setup): seed agent-guard into each worktree; gitignore the hook script

### DIFF
--- a/docs/setup/install-recipes.md
+++ b/docs/setup/install-recipes.md
@@ -119,6 +119,14 @@ cat >> .gitignore <<'GITIGNORE'
 __pycache__/
 *.pyc
 
+# Deterministic agent-guard PreToolUse hook — framework code synced
+# from the snapshot by /magpie-setup (and seeded into each worktree),
+# not an adopter artefact. The committed .claude/settings.json wires
+# it; the script itself stays gitignored. Force-add your own guards
+# under guards.d/ with `git add -f` if you want them tracked.
+/.claude/hooks/agent-guard.py
+/.claude/hooks/guards.d/
+
 # Framework-skill symlinks created by /magpie-setup. One uniform
 # block per skills dir you use: the `magpie-*` glob ignores them
 # all (their targets are the gitignored snapshot, so they would

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -503,6 +503,8 @@ idempotent — re-add them if they're missing.
 /.apache-magpie/
 /.apache-magpie.local.lock
 /.claude/settings.local.json
+/.claude/hooks/agent-guard.py
+/.claude/hooks/guards.d/
 __pycache__/
 *.pyc
 ```
@@ -513,6 +515,24 @@ scripts emit when run from the adopter checkout (e.g.
 [`setup-status/scripts/collect_status.py`](../setup-status/scripts/collect_status.py))
 out of the tree. Most adopters already carry these from a stock
 Python `.gitignore`; the adopt flow adds them if missing.
+
+The `/.claude/hooks/agent-guard.py` and `/.claude/hooks/guards.d/`
+lines keep the deterministic `PreToolUse` guard **gitignored** —
+it is framework code synced from the snapshot
+([Step 12 pass 1](#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)),
+not an adopter artefact, so it is regenerated on `/magpie-setup`
+rather than committed (the same rule that keeps the snapshot and
+the framework-skill symlinks out of git — the only committed
+framework artefact is `magpie-setup`). The committed
+`.claude/settings.json` still references it; the **wiring** is
+committed, the **script** is not. Because the script is gitignored,
+**no** worktree inherits it via git — every worktree is seeded from
+the main checkout by the post-checkout hook
+([Step 10](#step-10--worktree-aware-post-checkout-hook-fresh-only))
+or by [`worktree-init` Step 1d](worktree-init.md#step-1d--seed-the-worktrees-agent-guard-pretooluse-hook).
+An adopter who keeps their own non-framework guards under
+`.claude/hooks/guards.d/` and wants them tracked should commit them
+with `git add -f` (the directory is ignored by default).
 
 **Symlink entries — one uniform block per active target
 ([`agents.md`](agents.md)), no per-layout variation.** Every
@@ -902,15 +922,36 @@ are handled — both are read-only and scoped.
 
 ## Step 10 — Worktree-aware post-checkout hook (FRESH only)
 
-Install `<repo-root>/.git/hooks/post-checkout` that chains into
-the sandbox-allowlist helper installed by
-`setup-isolated-setup-install`, so the new worktree's working
-directory is added to the worktree's own
-`.claude/settings.local.json`'s `sandbox.filesystem.allowRead` /
-`allowWrite` (defensive against
-[issue #197](https://github.com/apache/magpie/issues/197)
-— see
-[`setup-isolated-setup-install/SKILL.md` → Step P](../setup-isolated-setup-install/SKILL.md#step-p--project-root-coverage-in-the-sandbox-allowlists)).
+Install `<repo-root>/.git/hooks/post-checkout` — a best-effort
+per-worktree reconciler that fires on `git checkout` and on
+`git worktree add`. It carries **two** responsibilities, each
+guarded independently so neither can gate the git operation:
+
+1. **Sandbox allowlist.** Chain into the sandbox-allowlist helper
+   installed by `setup-isolated-setup-install`, so the new
+   worktree's working directory is added to the worktree's own
+   `.claude/settings.local.json`'s `sandbox.filesystem.allowRead` /
+   `allowWrite` (defensive against
+   [issue #197](https://github.com/apache/magpie/issues/197)
+   — see
+   [`setup-isolated-setup-install/SKILL.md` → Step P](../setup-isolated-setup-install/SKILL.md#step-p--project-root-coverage-in-the-sandbox-allowlists)).
+
+2. **agent-guard seeding.** The committed `.claude/settings.json`
+   wires the deterministic `PreToolUse` guard
+   ([`tools/agent-guard`](../../tools/agent-guard/README.md)) at
+   `$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py` — a
+   **per-worktree** path. The script + its `guards.d/` are
+   adopter-installed local files synced into the **main** checkout
+   by [Step 12 pass 1](#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
+   and **gitignored** ([Step 7](#step-7--gitignore-entries-fresh-only)).
+   Because they are gitignored, **no** worktree inherits them via
+   `git worktree add` — every freshly-created worktree starts
+   without the script and would run with the guard **silently
+   inactive**. The hook seeds them from the main checkout's
+   already-synced copy when — and only when — this worktree has
+   none, so the guard is live in every worktree from its first
+   checkout. It never overwrites a copy the worktree already
+   carries (which may hold worktree-local guards).
 
 The hook is a small shell script. Surface the exact content to
 the user before writing:
@@ -918,27 +959,54 @@ the user before writing:
 ```bash
 #!/usr/bin/env bash
 # apache-magpie post-checkout hook (installed by /magpie-setup adopt).
-# Add the current worktree's working dir to the worktree's own
-# .claude/settings.local.json sandbox allowlists (per issue #197).
-# Chains into the helper if installed by /magpie-setup-isolated-setup-install;
-# no-op when the helper is absent.
+# Best-effort per-worktree reconciliation on checkout / `git worktree add`.
+# Every action is individually guarded and the hook always exits 0 — it
+# never gates the surrounding git operation.
 set -u
+
+# (a) Sandbox allowlist (issue #197): add the current worktree's working
+#     dir to the worktree's own .claude/settings.local.json. No-op when the
+#     helper from /magpie-setup-isolated-setup-install is absent.
 if [ -x "$HOME/.claude/scripts/sandbox-add-project-root.sh" ]; then
   "$HOME/.claude/scripts/sandbox-add-project-root.sh" || true
 fi
+
+# (b) agent-guard PreToolUse guard: .claude/settings.json resolves it at
+#     $CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py (per-worktree). Seed
+#     this worktree from the main checkout's already-synced copy when it has
+#     none — never overwrite a copy the worktree already carries.
+wt="$(git rev-parse --show-toplevel 2>/dev/null)" || wt=""
+main="$(dirname "$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)")"
+if [ -n "$wt" ] && [ "$main" != "$wt" ] \
+   && [ -f "$main/.claude/hooks/agent-guard.py" ] \
+   && [ ! -f "$wt/.claude/hooks/agent-guard.py" ]; then
+  mkdir -p "$wt/.claude/hooks/guards.d"
+  cp "$main/.claude/hooks/agent-guard.py" "$wt/.claude/hooks/agent-guard.py" || true
+  [ -d "$main/.claude/hooks/guards.d" ] &&
+    cp "$main/.claude/hooks/guards.d/"*.py "$wt/.claude/hooks/guards.d/" 2>/dev/null || true
+fi
+
 exit 0
 ```
 
-The `|| true` guard keeps the hook from failing the surrounding
-git operation (`git checkout`, `git worktree add`) — the hook is
-best-effort reconciliation, not a gate.
+The `|| true` guards (and the trailing `exit 0`) keep the hook
+from failing the surrounding git operation (`git checkout`,
+`git worktree add`) — the hook is best-effort reconciliation, not
+a gate.
 
 If the operator has not yet run `/magpie-setup-isolated-setup-install`,
-the helper-script line is a no-op (the `-x` test fails). When
+the helper-script line (a) is a no-op (the `-x` test fails). When
 they later install the secure setup, no hook re-write is needed:
-the next `post-checkout` fires the helper automatically.
+the next `post-checkout` fires the helper automatically. Likewise
+(b) is a no-op when the main checkout has no agent-guard yet (the
+`-f "$main/.claude/hooks/agent-guard.py"` test fails) or when the
+worktree already carries its own copy.
 
-**Why no framework-skill symlink reconciliation here.** Earlier
+**Why agent-guard seeding is shell-safe but symlink
+reconciliation is not.** Seeding agent-guard is a plain
+`cp` of files that already exist in the main checkout — a pure
+shell operation with no dependency on the agent harness. Recreating
+the gitignored framework-skill symlinks is **not**: earlier
 template versions of this hook also called
 `/magpie-setup verify --auto-fix-symlinks` to recreate
 gitignored symlinks after a checkout. That line printed a spurious
@@ -1247,7 +1315,8 @@ A summary of what was written:
 ✓ Locks:    .apache-magpie.lock (committed) + .apache-magpie.local.lock (gitignored)
 ✓ Symlinks: <list of created symlinks>
 ✓ Overrides scaffold: .apache-magpie-overrides/ (committed)
-✓ post-checkout hook installed
+✓ post-checkout hook installed (seeds sandbox allowlist + agent-guard per worktree)
+✓ agent-guard PreToolUse hook synced (.claude/hooks/agent-guard.py + guards.d/ — gitignored)
 ✓ <repo>/README.md updated with adoption note
 
 Committed (you'll see in `git status`):
@@ -1262,6 +1331,9 @@ Committed (you'll see in `git status`):
 Gitignored (do NOT commit):
   .apache-magpie/
   .apache-magpie.local.lock
+  .claude/settings.local.json   # per-machine, per-worktree sandbox allowlist (issue #197)
+  .claude/hooks/agent-guard.py  # framework code synced from the snapshot; seeded into each worktree
+  .claude/hooks/guards.d/       # bundled + skill-owned guards; re-collected on /magpie-setup
   __pycache__/ + *.pyc       # byte-compiled artefacts from skill scripts; added to .gitignore if missing
   .agents/skills/magpie-*   (except magpie-setup, committed above)  # canonical links into the snapshot: opt-in + always-on families
   .claude/skills/magpie-*   (except magpie-setup, committed above)  # relays → ../../.agents/skills/magpie-*

--- a/skills/setup/unadopt.md
+++ b/skills/setup/unadopt.md
@@ -9,9 +9,12 @@ committed lock, gitignored local lock, framework-skill
 symlinks **in every active target dir** ([`agents.md`](agents.md)
 — `.agents/skills/`, `.claude/skills/`, `.github/skills/`, plus
 any present holdout), the matching `.gitignore` blocks,
-post-checkout hook, the adoption sections in `README.md` /
-`AGENTS.md` / `CONTRIBUTING.md`, and the committed `setup`
-skill itself.
+post-checkout hook, the gitignored agent-guard hook
+(`.claude/hooks/agent-guard.py` + `guards.d/`), the adoption
+sections in `README.md` / `AGENTS.md` / `CONTRIBUTING.md`, and the
+committed `setup` skill itself. (The committed
+`.claude/settings.json` `hooks.PreToolUse` wiring is adopter-owned
+and agent-edit-denied — surfaced for manual removal, never edited.)
 
 > **Critical — tear down *all* target dirs.** Removing only the
 > `.claude/skills/` + `.github/skills/` pair would **orphan** the
@@ -101,7 +104,8 @@ every artefact).
 | Committed lock | `<committed-lock>` | exists |
 | `.gitignore` entries | `<repo-root>/.gitignore` | which of the entries from [`adopt.md` Step 7](adopt.md) are present |
 | Framework-skill symlinks | **Every active target dir** ([`agents.md`](agents.md)): the canonical `.agents/skills/` (always present), the `.claude/skills/` + `.github/skills/` relay pair, and any present holdout (`.windsurf/skills/`, `.goose/skills/`) | each `magpie-*` symlink — canonical entries resolving into `<snapshot-dir>/skills/`, relays resolving into `.agents/skills/magpie-*` — in **each** target dir |
-| Post-checkout hook | `<repo-root>/.git/hooks/post-checkout` | exists + invokes `~/.claude/scripts/sandbox-add-project-root.sh` |
+| Post-checkout hook | `<repo-root>/.git/hooks/post-checkout` | exists + invokes `~/.claude/scripts/sandbox-add-project-root.sh` and/or seeds `.claude/hooks/agent-guard.py` |
+| agent-guard hook | `<repo-root>/.claude/hooks/agent-guard.py` + `<repo-root>/.claude/hooks/guards.d/` | exist (gitignored framework code). The committed `.claude/settings.json` `hooks.PreToolUse` wiring is **adopter-owned** — surface it for the user to remove by hand (settings.json is agent-edit-denied); do not edit it. |
 | Doc section: `README.md` | `<repo-root>/README.md` | contains the `## Agent-assisted contribution (apache-magpie)` heading |
 | Doc section: `AGENTS.md` | `<repo-root>/AGENTS.md` | contains the `## apache-magpie framework` heading |
 | Doc section: `CONTRIBUTING.md` | `<repo-root>/CONTRIBUTING.md` | contains the adoption section (fallback layout) |
@@ -133,6 +137,8 @@ The following will be REMOVED:
     .github/skills/magpie-<skill-1>      → ../../.agents/skills/magpie-<skill-1>   (relay)
     <holdout>/skills/magpie-<skill-1>    → ../../.agents/skills/magpie-<skill-1>   (relay; e.g. .windsurf/skills/, .goose/skills/ — only if present)
     .git/hooks/post-checkout              (if it contains the magpie recipe)
+    .claude/hooks/agent-guard.py          (gitignored framework code)
+    .claude/hooks/guards.d/               (gitignored; bundled + skill-owned guards)
     # Target dirs (per agents.md): canonical .agents/skills/, the
     #   .claude/skills/ + .github/skills/ relay pair, plus any present
     #   holdout — each carries one magpie-<n> entry per linked skill.
@@ -231,20 +237,33 @@ pointing at a deleted snapshot.
    Never touch a non-symlink at the same path.
 2. **Post-checkout hook.** Remove only if its content matches
    the magpie recipe verbatim (i.e. the hook the adopt flow
-   wrote — a single
-   `~/.claude/scripts/sandbox-add-project-root.sh` invocation
-   guarded by the `-x` test; see
+   wrote — the two-part body that chains
+   `~/.claude/scripts/sandbox-add-project-root.sh` (guarded by
+   the `-x` test) **and** seeds `.claude/hooks/agent-guard.py`
+   from the main checkout; see
    [`adopt.md` Step 10](adopt.md#step-10--worktree-aware-post-checkout-hook-fresh-only)
    for the exact text). If the hook contains additional adopter
    logic, surface that, leave the hook in place, and tell the
-   user which line to delete by hand. Hooks that still contain
+   user which lines to delete by hand. Hooks that still contain
    the obsolete `/magpie-setup verify --auto-fix-symlinks` line
    (a Claude Code slash command that does not work from a shell
    hook — removed in a later framework release) should be
    replaced with the current Step 10 template.
-3. **Snapshot directory.** `rm -rf <snapshot-dir>/`.
-4. **Local lock.** `rm <local-lock>`.
-5. **`.gitignore` entries.** Read `<repo-root>/.gitignore`,
+3. **agent-guard hook files.** `rm -f
+   <repo-root>/.claude/hooks/agent-guard.py` and `rm -rf
+   <repo-root>/.claude/hooks/guards.d/` — gitignored framework
+   code, no `git rm` needed. If the adopter force-added their own
+   guards under `guards.d/` (tracked via `git add -f`), surface
+   them and `git rm` only those by name; do not delete an
+   adopter-authored tracked guard silently. Leave the
+   `.claude/hooks/` directory itself if it holds non-framework
+   hooks. The committed `.claude/settings.json` `hooks.PreToolUse`
+   wiring is **adopter-owned and agent-edit-denied** — surface the
+   exact entry for the user to delete by hand; do not edit
+   `settings.json`.
+4. **Snapshot directory.** `rm -rf <snapshot-dir>/`.
+5. **Local lock.** `rm <local-lock>`.
+6. **`.gitignore` entries.** Read `<repo-root>/.gitignore`,
    remove exactly the lines from
    [`adopt.md` Step 7](adopt.md) that are present, and leave
    any adopter-added entries (e.g. unrelated rules near the
@@ -256,7 +275,7 @@ pointing at a deleted snapshot.
    them if they sit unambiguously inside the magpie-managed
    block (under the same comment header the adopt flow wrote)
    and the repo has no other Python sources.
-6. **Doc sections.** For each of `README.md`, `AGENTS.md`,
+7. **Doc sections.** For each of `README.md`, `AGENTS.md`,
    `CONTRIBUTING.md` that contains an adoption section,
    remove the section. The boundaries are the section
    heading (e.g. `## Agent-assisted contribution (apache-
@@ -264,10 +283,10 @@ pointing at a deleted snapshot.
    Surface the proposed diff (`git diff` form) to the user
    before writing; one batched confirmation for the whole
    doc set, not per file.
-7. **Committed lock.** `git rm <committed-lock>`.
-8. **Overrides directory** *(only if `--purge-overrides`)*.
+8. **Committed lock.** `git rm <committed-lock>`.
+9. **Overrides directory** *(only if `--purge-overrides`)*.
    `git rm -r .apache-magpie-overrides/`.
-9. **`setup` skill itself.** `git rm -r` the canonical copy
+10. **`setup` skill itself.** `git rm -r` the canonical copy
    `.agents/skills/magpie-setup/` and its relay symlinks
    `.claude/skills/magpie-setup` and `.github/skills/magpie-setup`.
    After this step the running skill has deleted its own committed
@@ -293,6 +312,10 @@ After the deletions, verify the post-state:
   the removed `<snapshot-dir>/` nor relays into the now-empty
   `.agents/skills/`.
 - `.gitignore` no longer contains the magpie entries.
+- `.claude/hooks/agent-guard.py` and `.claude/hooks/guards.d/`
+  do not exist (save any adopter-authored guards the user chose
+  to keep); the `.claude/settings.json` `hooks.PreToolUse` entry
+  was surfaced for manual removal.
 - The doc sections are gone from the affected files.
 - `.agents/skills/magpie-setup/` and its `.claude`/`.github`
   relays do not exist.

--- a/skills/setup/upgrade.md
+++ b/skills/setup/upgrade.md
@@ -414,7 +414,13 @@ The framework ships hooks and config files an adopter
 rather than pulls in via symlink. Examples:
 
 - `<repo-root>/.git/hooks/post-checkout` (the worktree-aware
-  hook installed during adoption).
+  hook installed during adoption). Its expected content is the
+  [`adopt.md` Step 10](adopt.md#step-10--worktree-aware-post-checkout-hook-fresh-only)
+  template — which now both chains the sandbox-allowlist helper
+  **and** seeds a new worktree's agent-guard from the main
+  checkout. An adopter on an older hook (sandbox-only, or the
+  long-removed `--auto-fix-symlinks` line) is re-installed to the
+  current template by this drift sync.
 - `<repo-root>/.claude/hooks/agent-guard.py` and the
   `<repo-root>/.claude/hooks/guards.d/` directory (the
   deterministic `PreToolUse` guard dispatcher and its guards — see

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -284,12 +284,18 @@ snapshot's `.apache-magpie/skills/setup/`.
 Two sub-checks on `<repo-root>/.git/hooks/post-checkout`:
 
 1. **Presence + executable.** File exists, is executable,
-   and contains the
-   `/magpie-setup verify --auto-fix-symlinks` recipe.
-   - ⚠ if missing — strictly optional, but worktrees off
-     this repo will need a manual
-     `/magpie-setup verify --auto-fix-symlinks` after
-     checkout. Print the install recipe.
+   and carries the current hook body — the sandbox-allowlist
+   helper chain **and** the agent-guard seeding block (see
+   [`adopt.md` Step 10](adopt.md#step-10--worktree-aware-post-checkout-hook-fresh-only)).
+   It must **not** contain the long-removed
+   `/magpie-setup verify --auto-fix-symlinks` line (a slash
+   command is not shell-callable; it printed a spurious error on
+   every checkout).
+   - ⚠ if missing — strictly optional, but worktrees off this
+     repo will then not get their sandbox allowlist or
+     agent-guard seeded automatically on `git worktree add`
+     (they fall back to `/magpie-setup worktree-init`). Print
+     the install recipe.
 
 2. **Content drift vs the framework's expected.** Diff the
    installed hook against the framework's expected hook
@@ -333,6 +339,20 @@ Three sub-checks for the deterministic guard
      the one-time wiring snippet (see
      [`adopt.md` Step 12](adopt.md#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check))
      for the maintainer to apply (settings.json is agent-edit-denied).
+
+The script + `guards.d` are **gitignored** framework code
+([`adopt.md` Step 7](adopt.md#step-7--gitignore-entries-fresh-only)),
+synced from the snapshot rather than committed — so a *missing*
+script is the expected state of a fresh checkout, not a defect, and
+the fix is always a re-sync (never `git add`). When this check runs
+**inside a worktree**, the script + `guards.d` are per-worktree
+files (the `settings.json` wiring resolves
+`$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py` against the
+worktree root). The remediation for a *missing* script in a worktree
+is not the main-checkout sync but
+[`worktree-init.md` Step 1d](worktree-init.md#step-1d--seed-the-worktrees-agent-guard-pretooluse-hook)
+(or the post-checkout hook on the next `git worktree add`), which
+seeds it from the main checkout's already-synced copy.
 
 ### 8b. Sandbox-allowlist coverage of the current worktree
 

--- a/skills/setup/worktree-init.md
+++ b/skills/setup/worktree-init.md
@@ -173,6 +173,53 @@ one-line recap row for the Step 2 summary:
 `worktree-init` does **not** fail when the helper is absent;
 secure-agent isolation is independent of framework adoption.
 
+## Step 1d — Seed the worktree's agent-guard PreToolUse hook
+
+The committed `.claude/settings.json` wires the deterministic
+guard ([`tools/agent-guard`](../../tools/agent-guard/README.md))
+at `$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py` — a
+**per-worktree** path. The script + its `guards.d/` are
+adopter-installed local files synced into the **main** checkout by
+[`adopt.md` Step 12 pass 1](adopt.md#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
+/ [`upgrade.md` Step 6b](upgrade.md#step-6b--sync-locally-installed-hooks-and-configuration)
+and **gitignored** ([`adopt.md` Step 7](adopt.md#step-7--gitignore-entries-fresh-only)).
+Because they are gitignored, no worktree inherits them via git —
+every worktree starts without the script and would run with the
+guard **silently inactive** until seeded.
+
+This is the agent-driven counterpart of the
+[post-checkout hook's agent-guard seeding](adopt.md#step-10--worktree-aware-post-checkout-hook-fresh-only):
+the git hook covers `git worktree add`, this step covers worktrees
+that pre-date the hook or where its best-effort copy did not run.
+
+Seed from the main checkout's already-synced copy — a plain file
+copy, the same `<main>` resolved in Step 0:
+
+```bash
+# Only when the main has a guard and this worktree has none — never
+# overwrite a copy the worktree already carries (worktree-local guards).
+if [ -f "<main>/.claude/hooks/agent-guard.py" ] &&
+   [ ! -f "<worktree>/.claude/hooks/agent-guard.py" ]; then
+  mkdir -p "<worktree>/.claude/hooks/guards.d"
+  cp "<main>/.claude/hooks/agent-guard.py" "<worktree>/.claude/hooks/agent-guard.py"
+  cp "<main>/.claude/hooks/guards.d/"*.py "<worktree>/.claude/hooks/guards.d/" 2>/dev/null || true
+fi
+```
+
+Idempotent: a no-op when the worktree already has the script, and
+a no-op when the main has no agent-guard yet (an adopter who has
+not run the Step 12 / Step 6b sync). Surface a one-line recap row
+for Step 2:
+
+- ✓ already present, OR
+- + seeded from `<main>` (script + N guards), OR
+- ⚠ main has no agent-guard yet — run `/magpie-setup` (or
+  `/magpie-setup upgrade`) from the main checkout to sync it.
+
+`worktree-init` does **not** fail when the main carries no
+agent-guard; the guard is an opt-in adopter-side file, and the
+worktree's framework-skill symlinks are usable without it.
+
 ## Step 2 — Recap
 
 Print a short summary:
@@ -185,6 +232,9 @@ Print a short summary:
   active target dir (`.agents/skills/`, the `.claude/`/`.github/`
   pair, any present holdout), split into *opt-in* and
   *always-on*, with per-skill ✓ / + / ↻ counts.
+- The sandbox-allowlist recap row from Step 1c.
+- The agent-guard recap row from Step 1d (✓ already present /
+  + seeded / ⚠ main has no agent-guard yet).
 - A reminder: `upgrade` from the main, not from the worktree.
 
 ## Inputs


### PR DESCRIPTION
## What

The agent-guard `PreToolUse` hook is wired in committed
`.claude/settings.json` to a **per-worktree** path
(`$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py`), but the script +
`guards.d/` were only synced into the **main** checkout. A freshly-created
worktree without them ran with the guard **silently inactive**.

This PR:

1. **Wires agent-guard seeding into the `post-checkout` git hook** (Step 10),
   which fires on `git worktree add`. Alongside the existing sandbox-allowlist
   chaining, it copies `agent-guard.py` + `guards.d/*.py` from the main
   checkout into a new worktree **when, and only when, it has none** (never
   overwrites a worktree's own copy). Unlike the symlink reconciliation
   deliberately removed earlier (slash commands aren't shell-callable),
   seeding is a plain file copy, so it's shell-safe.

2. **Gitignores the script** (`.claude/hooks/agent-guard.py` + `guards.d/`).
   It's framework code synced from the snapshot, not an adopter artefact —
   the same rule that keeps the snapshot and skill symlinks out of git. The
   committed `settings.json` still references it: the **wiring** is committed,
   the **script** is not. This makes per-worktree seeding the *primary*
   delivery path, since no worktree inherits the script via git.

3. Adds the agent-driven counterpart (`worktree-init` Step 1d) so worktrees
   that pre-date the hook are reconciled too.

## Files

- `adopt.md` — Step 7 gitignore entries; Step 10 two-part post-checkout hook; Step 12 output block.
- `worktree-init.md` — new Step 1d (agent-driven seeding) + recap row.
- `verify.md` — fix stale check 8 (dropped the long-removed `--auto-fix-symlinks` expectation); note gitignored status in 8a.
- `upgrade.md` — hook drift-sync re-installs the current template.
- `unadopt.md` — remove the gitignored agent-guard files; surface the adopter-owned `settings.json` wiring for manual removal.
- `install-recipes.md` — bootstrap `.gitignore` emits the agent-guard lines.

## Boundary

The committed `.claude/settings.json` `hooks.PreToolUse` **wiring** stays
committed and agent-edit-denied — surfaced for the maintainer to apply/remove
by hand, never auto-edited. Only the script + guards are gitignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)