### PR TITLE
fix(setup): remove stray in-source skill symlinks

### DIFF
--- a/skills/contributor-to-committer/magpie-contributor-to-committer
+++ b/skills/contributor-to-committer/magpie-contributor-to-committer
@@ -1,1 +1,0 @@
-../../.agents/skills/magpie-contributor-to-committer

--- a/skills/good-first-issue-sweep/good-first-issue-sweep
+++ b/skills/good-first-issue-sweep/good-first-issue-sweep
@@ -1,1 +1,0 @@
-../../skills/good-first-issue-sweep

--- a/skills/workflow-security-audit/workflow-security-audit
+++ b/skills/workflow-security-audit/workflow-security-audit
@@ -1,1 +1,0 @@
-../../skills/workflow-security-audit


### PR DESCRIPTION
## Summary

Remove three stray, self-referential symlinks committed inside skill source
dirs. Each resolves back to its own directory, forming a filesystem cycle; the
canonical `.agents/skills/magpie-<skill>` links already provide discovery, so
these in-source links are redundant — the same self-adoption-drift class fixed
in #516 and #599.

- `skills/good-first-issue-sweep/good-first-issue-sweep` → `../../skills/good-first-issue-sweep`
- `skills/workflow-security-audit/workflow-security-audit` → `../../skills/workflow-security-audit`
- `skills/contributor-to-committer/magpie-contributor-to-committer` → `../../.agents/skills/magpie-contributor-to-committer`

## Context / how found

While bringing up **OpenCode** and **Kiro CLI** as runtime targets for the
vendor-neutrality runtime-adapter effort (#320), OpenCode's skill loader globs
`**/SKILL.md` *following symlinks* and walked these cycles into looped paths
(`skills/x/x/x/.../SKILL.md`). Discovery still succeeded (it dedupes by name and
the glob has a depth cap), but the cycle is fragile and unnecessary.

## Type of change

- [x] CI / dev loop — `setup` self-adoption wiring (no skill content changed)

## Test plan

- [x] `find skills -type l` → 0 (no symlinks remain in the source tree)
- [x] `opencode debug skill` resolves all three skills via clean, single-segment paths; total skill count unchanged
- [x] `skill-and-tool-validate` passes
- [x] No `SKILL.md` content altered — pure symlink removal

---
*Gen-AI disclosure: authored with Kiro CLI (Opus 4.8); commit carries a `Generated-by:` trailer per AGENTS.md.*
