### PR TITLE
feat(tools/symlink-lint): lint cyclic and misdirected skill symlinks

### DIFF
--- a/.claude/skills/magpie-issue-backlog-stats
+++ b/.claude/skills/magpie-issue-backlog-stats
@@ -1,1 +1,1 @@
-../../skills/issue-backlog-stats
+../../.agents/skills/magpie-issue-backlog-stats

--- a/.claude/skills/magpie-issue-deduplicate
+++ b/.claude/skills/magpie-issue-deduplicate
@@ -1,1 +1,1 @@
-../../skills/issue-deduplicate
+../../.agents/skills/magpie-issue-deduplicate

--- a/.claude/skills/magpie-release-announce-draft
+++ b/.claude/skills/magpie-release-announce-draft
@@ -1,1 +1,1 @@
-../../skills/release-announce-draft
+../../.agents/skills/magpie-release-announce-draft

--- a/.claude/skills/magpie-release-audit-report
+++ b/.claude/skills/magpie-release-audit-report
@@ -1,1 +1,1 @@
-../../skills/release-audit-report
+../../.agents/skills/magpie-release-audit-report

--- a/.claude/skills/magpie-release-rc-cut
+++ b/.claude/skills/magpie-release-rc-cut
@@ -1,1 +1,1 @@
-../../skills/release-rc-cut
+../../.agents/skills/magpie-release-rc-cut

--- a/.claude/skills/magpie-release-vote-tally
+++ b/.claude/skills/magpie-release-vote-tally
@@ -1,1 +1,1 @@
-../../skills/release-vote-tally
+../../.agents/skills/magpie-release-vote-tally

--- a/.claude/skills/magpie-workflow-security-audit
+++ b/.claude/skills/magpie-workflow-security-audit
@@ -1,1 +1,1 @@
-../../skills/workflow-security-audit
+../../.agents/skills/magpie-workflow-security-audit

--- a/.github/skills/magpie-contributor-to-committer
+++ b/.github/skills/magpie-contributor-to-committer
@@ -1,1 +1,1 @@
-../../skills/contributor-to-committer
+../../.agents/skills/magpie-contributor-to-committer

--- a/.github/skills/magpie-release-rc-cut
+++ b/.github/skills/magpie-release-rc-cut
@@ -1,1 +1,1 @@
-../../skills/release-rc-cut
+../../.agents/skills/magpie-release-rc-cut

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,6 +146,18 @@ repos:
         entry: tools/dev/check-placeholders.sh
         files: ^(skills/.*|tools/.*)\.(md|sh|py|yaml|yml|toml)$
         pass_filenames: false
+  # Self-adoption symlink hygiene: reject cyclic symlinks and misdirected
+  # skill relays. `types: [symlink]` fires it on any staged symlink (always
+  # on `prek run --all-files`). Rules, rationale, and the pytest suite live
+  # in tools/symlink-lint (README + tests).
+  - repo: local
+    hooks:
+      - id: symlink-lint
+        name: symlink-lint
+        language: system
+        entry: python3 tools/symlink-lint/src/symlink_lint/__init__.py
+        types: [symlink]
+        pass_filenames: false
   # Workspace-membership guard. The single source of truth for
   # which Python projects get pre-commit hooks + the CI pytest
   # matrix is the `[tool.uv.workspace] members` array in the root

--- a/docs/labels-and-capabilities.md
+++ b/docs/labels-and-capabilities.md
@@ -258,6 +258,7 @@ it implements multiple contracts (e.g. `tools/gmail` provides both
 | [`tools/skill-and-tool-validator`](../tools/skill-and-tool-validator/) | `substrate:framework-dev` | Skill-frontmatter and convention validator |
 | [`tools/spec-status-index`](../tools/spec-status-index/) | `substrate:framework-dev` + `substrate:analytics` | Index of spec / RFC implementation status — framework-dev substrate that also doubles as a governance/stats view (`analytics`) |
 | [`tools/spec-validator`](../tools/spec-validator/) | `substrate:framework-dev` | Spec-frontmatter and body-section validator — counterpart to `skill-and-tool-validator` for `tools/spec-loop/specs/` |
+| [`tools/symlink-lint`](../tools/symlink-lint/) | `substrate:framework-dev` | Self-adoption symlink hygiene — rejects cyclic symlinks and misdirected skill relays (canonical/relay target-correctness) |
 | [`tools/pilot-report-validator`](../tools/pilot-report-validator/) | `substrate:framework-dev` | Adopter pilot-report validator — required frontmatter keys, no unfilled placeholders, valid profile, and required body sections; counterpart to `spec-validator` for `docs/pilot-report-template.md` |
 | [`tools/vcs`](../tools/vcs/) | `contract:source-control` | Backend-dispatching implementation of the source-control (VCS) capability ([`tools/github/source-control.md`](../tools/github/source-control.md)); complete Git backend plus detected extension points for non-Git VCS bridges (#601 Hg, #602 SVN) |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,5 +112,6 @@ members = [
   "tools/pilot-report-validator",
   "tools/spec-status-index",
   "tools/spec-validator",
+  "tools/symlink-lint",
   "tools/vcs",
 ]

--- a/tools/spec-loop/specs/meta-and-quality-tooling.md
+++ b/tools/spec-loop/specs/meta-and-quality-tooling.md
@@ -37,6 +37,9 @@ trustworthy as it grows.
   (soft check: warns when a skill has no eval suite). CLI: `skill-and-tool-validate`.
 - `tools/skill-evals/` — harness for measuring skill behaviour.
 - `tools/sandbox-lint/` — lints the sandbox/permissions configuration.
+- `tools/symlink-lint/` — lints the framework's self-adoption skill
+  symlinks: rejects cyclic symlinks and misdirected relays (canonical/
+  relay target-correctness).
 - `tools/dashboard-generator/` — read-only HTML dashboards over campaign
   artefacts.
 - `tools/probe-templates/` — reusable probes.
@@ -60,8 +63,8 @@ trustworthy as it grows.
 - **Generated, never cached.** `list-skills` reads the live
   `.claude/skills/*/SKILL.md` frontmatter on every run, so the index never
   goes stale.
-- **Deterministic checks.** `skill-and-tool-validator` and `sandbox-lint` are
-  heuristic/text tools with no model calls — reproducible in CI.
+- **Deterministic checks.** `skill-and-tool-validator`, `sandbox-lint`, and
+  `symlink-lint` are heuristic/text tools with no model calls — reproducible in CI.
 - **Hard vs soft rules.** The validator fails on missing frontmatter or
   broken links; advisories are warnings unless `--strict`.
 - **Schema-backed metadata.** Skill frontmatter, tool README capability

--- a/tools/symlink-lint/README.md
+++ b/tools/symlink-lint/README.md
@@ -1,0 +1,78 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+
+- [`symlink-lint`](#symlink-lint)
+  - [Rules](#rules)
+  - [Prerequisites](#prerequisites)
+  - [How to use](#how-to-use)
+  - [Wiring](#wiring)
+  - [Tests](#tests)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# `symlink-lint`
+
+**Capability:** substrate:framework-dev
+
+Lints the framework's **self-adoption skill symlinks** — the canonical
+`.agents/skills/` links and their relays — against two invariants. This is
+the single place the rationale lives; the module, the prek hook, and the
+error output all point back here.
+
+The framework's wiring is **one-directional** (see
+[`skills/setup/agents.md`](../../skills/setup/agents.md)): the canonical
+link lives under `.agents/skills/` and points *into* the source tree, and
+every other agent dir (`.claude/`, `.github/`, `.windsurf/`, `.goose/`,
+`.kiro/`, …) carries a thin relay that points at the canonical entry.
+
+## Rules
+
+1. **No cycles.** A symlink must not resolve to its own directory or an
+   ancestor of it. Such a link makes a recursive `**/SKILL.md` scanner that
+   follows symlinks (opencode's skill loader does) re-enter the directory
+   until an internal depth cap, yielding looped paths like
+   `skills/x/x/x/.../SKILL.md`. This rule is convention-agnostic — it names
+   no agent dir, so a new one needs no change here.
+2. **Relay correctness.** For a `magpie-<skill>` link under an
+   `<agent>/skills/` directory: the canonical entry under `.agents/skills/`
+   must point at `../../skills/<skill>`, and every other agent dir's relay
+   must point at `../../.agents/skills/magpie-<skill>` (through the
+   canonical, not straight at source). Catches relays that bypass
+   `.agents/` — acyclic, so rule 1 alone would miss them.
+
+**Dangling / unresolvable links are skipped**, never flagged: an adopter's
+canonical links legitimately dangle until the gitignored `.apache-magpie/`
+snapshot is installed. Broken-target detection is `setup verify`'s job.
+
+## Prerequisites
+
+- **Runtime:** Python 3.11+ (stdlib only) — no third-party dependencies; run it directly with `python3`, or as the console script `symlink-lint`.
+- **CLIs:** `git` (optional) — locates the repo root via `git rev-parse --show-toplevel`; falls back to the current working directory.
+- **Credentials / auth:** None.
+- **Network:** None.
+
+## How to use
+
+```bash
+python3 tools/symlink-lint/src/symlink_lint/__init__.py
+# or, once the workspace is synced:
+uv run --project tools/symlink-lint symlink-lint
+```
+
+Exit `0` if clean; `1` otherwise, with each offender printed to stderr.
+
+## Wiring
+
+Runs as the `symlink-lint` [prek](https://github.com/j178/prek) hook
+(`.pre-commit-config.yaml`), fired on any staged symlink and always on
+`prek run --all-files` (CI). Behaviour is locked by the pytest suite under
+[`tests/`](tests/), run by the workspace `pytest` hook + CI matrix.
+
+## Tests
+
+```bash
+uv run --project tools/symlink-lint pytest
+```

--- a/tools/symlink-lint/pyproject.toml
+++ b/tools/symlink-lint/pyproject.toml
@@ -1,0 +1,81 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "symlink-lint"
+version = "0.1.0"
+description = "Detect self-referential / cyclic symlinks (a symlink resolving to its own directory or an ancestor), which break recursive SKILL.md scanners."
+readme = "README.md"
+requires-python = ">=3.11"
+license = { text = "Apache-2.0" }
+# stdlib-only — os.walk + pathlib resolve every path we need.
+dependencies = []
+
+[project.scripts]
+symlink-lint = "symlink_lint:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/symlink_lint"]
+
+[tool.ruff]
+line-length = 110
+target-version = "py311"
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = [
+  "E",     # pycodestyle errors
+  "W",     # pycodestyle warnings
+  "F",     # pyflakes
+  "I",     # isort
+  "B",     # flake8-bugbear
+  "UP",    # pyupgrade
+  "SIM",   # flake8-simplify
+  "C4",    # flake8-comprehensions
+  "RUF",   # ruff-specific
+]
+ignore = [
+  "E501",  # line-too-long — the 110-char limit above is already generous
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = ["B", "SIM"]
+
+[tool.mypy]
+python_version = "3.11"
+files = ["src", "tests"]
+warn_unused_ignores = true
+warn_redundant_casts = true
+warn_unreachable = true
+check_untyped_defs = true
+no_implicit_optional = true
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+
+[[tool.mypy.overrides]]
+module = "tests.*"
+disallow_untyped_defs = false
+disallow_incomplete_defs = false
+
+[tool.pytest.ini_options]
+minversion = "8.0"
+addopts = "-ra -q"
+testpaths = ["tests"]

--- a/tools/symlink-lint/src/symlink_lint/__init__.py
+++ b/tools/symlink-lint/src/symlink_lint/__init__.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Lint the framework's self-adoption skill symlinks. Two rules:
+
+1. **No cycles** — a symlink must not resolve to its own directory or an
+   ancestor (that traps recursive `**/SKILL.md` scanners in looped paths).
+2. **Relay correctness** — a `magpie-<skill>` link under `.agents/skills/`
+   (canonical) points into `../../skills/`; the same link under any other
+   agent dir relays through `../../.agents/skills/magpie-<skill>`.
+
+Dangling links are skipped. Full rationale + examples: `README.md`.
+
+Run as the `symlink-lint` prek hook, or directly:
+`python3 tools/symlink-lint/src/symlink_lint/__init__.py`. Exit 0 if clean,
+1 otherwise (offenders on stderr).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+# Directories pruned from the scan (VCS metadata, virtualenvs, vendored
+# deps, build/test caches, gitignored snapshot).
+PRUNE_DIR_NAMES = frozenset(
+    {
+        ".git",
+        ".venv",
+        "node_modules",
+        ".apache-magpie",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".hatch",
+    }
+)
+
+
+def repo_root() -> Path:
+    """The repo root — `git rev-parse --show-toplevel`, else CWD."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        return Path.cwd()
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip())
+    return Path.cwd()
+
+
+def find_cyclic_symlinks(root: Path, prune: frozenset[str] = PRUNE_DIR_NAMES) -> list[tuple[Path, Path]]:
+    """Return `(link, resolved_target)` for every symlink under `root` that
+    resolves to its own directory or an ancestor. Dangling / unresolvable
+    links are skipped; directories in `prune` are not descended into."""
+    violations: list[tuple[Path, Path]] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in prune]
+        # os.walk never follows a symlink (followlinks=False), so a cyclic
+        # link cannot trap the walk; symlinks show up in dirnames + filenames.
+        for name in (*dirnames, *filenames):
+            link = Path(dirpath) / name
+            if not link.is_symlink():
+                continue
+            try:
+                target = link.resolve(strict=True)
+            except (OSError, RuntimeError):
+                continue  # dangling / unresolvable -> out of scope
+            link_dir = link.parent.resolve()
+            if target == link_dir or target in link_dir.parents:
+                violations.append((link, target))
+    return sorted(violations)
+
+
+def find_misdirected_relays(
+    root: Path, prune: frozenset[str] = PRUNE_DIR_NAMES
+) -> list[tuple[Path, str, str]]:
+    """Return `(link, actual_target, expected_target)` for every
+    `magpie-<skill>` symlink under an `<agent>/skills/` directory whose
+    one-hop target breaks the one-directional convention: canonical links
+    under `.agents/skills/` point into `../../skills/`; every other agent
+    dir's relay points at `../../.agents/skills/magpie-<skill>`."""
+    problems: list[tuple[Path, str, str]] = []
+    for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+        dirnames[:] = [d for d in dirnames if d not in prune]
+        if os.path.basename(dirpath) != "skills":
+            continue
+        agent = os.path.basename(os.path.dirname(dirpath))
+        for name in (*dirnames, *filenames):
+            if not name.startswith("magpie-"):
+                continue
+            link = Path(dirpath) / name
+            if not link.is_symlink():
+                continue
+            if agent == ".agents":
+                expected = f"../../skills/{name.removeprefix('magpie-')}"
+            else:
+                expected = f"../../.agents/skills/{name}"
+            actual = os.readlink(link)
+            if actual != expected:
+                problems.append((link, actual, expected))
+    return sorted(problems)
+
+
+def _rel(link: Path, root: Path) -> Path:
+    try:
+        return link.relative_to(root)
+    except ValueError:
+        return link
+
+
+def main() -> int:
+    root = repo_root()
+    cycles = find_cyclic_symlinks(root)
+    relays = find_misdirected_relays(root)
+    if not cycles and not relays:
+        return 0
+
+    out = sys.stderr.write
+    if cycles:
+        out("error: self-referential / cyclic symlink(s):\n")
+        for link, target in cycles:
+            out(f"  {_rel(link, root)} -> {os.readlink(link)}  (resolves to {target})\n")
+    if relays:
+        out("error: misdirected skill relay symlink(s):\n")
+        for link, actual, expected in relays:
+            out(f"  {_rel(link, root)} -> {actual}  (expected {expected})\n")
+    out("\nSee tools/symlink-lint/README.md and skills/setup/agents.md.\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/symlink-lint/tests/test_symlink_lint.py
+++ b/tools/symlink-lint/tests/test_symlink_lint.py
@@ -1,0 +1,155 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""Behavioural fixtures for symlink-lint's two rules.
+
+Rule 1 (cycles): parity with the earlier bash draft — cyclic -> flagged,
+dangling -> skipped, canonical+relay -> allowed, plus pruned / symlink-to-
+file / whitespace-name edges.
+
+Rule 2 (relay correctness): canonical links point into ../../skills/;
+relays point at ../../.agents/skills/magpie-<skill>.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import symlink_lint
+
+
+def _symlink(root: Path, path: str, target: str) -> None:
+    """Create a symlink at ``root/<path>`` pointing at ``target``, making
+    any missing parent directories first."""
+    link = root / path
+    link.parent.mkdir(parents=True, exist_ok=True)
+    os.symlink(target, link)
+
+
+def offending_paths(violations: Iterable[tuple[Any, ...]], root: Path) -> set[str]:
+    """Root-relative paths of the flagged links — works for either rule's
+    return shape (the link is always the first tuple element)."""
+    return {str(link.relative_to(root)) for link, *_ in violations}
+
+
+def _wire_skill(root: Path, relay_target: str) -> None:
+    """Build skills/x + a canonical .agents link + a .claude relay pointing
+    at ``relay_target``."""
+    (root / "skills" / "x").mkdir(parents=True)
+    (root / "skills" / "x" / "SKILL.md").write_text("x\n")
+    _symlink(root, ".agents/skills/magpie-x", "../../skills/x")
+    _symlink(root, ".claude/skills/magpie-x", relay_target)
+
+
+# ---- Rule 1: cycles -------------------------------------------------------
+
+
+def test_self_referential_cycle_detected(tmp_path: Path) -> None:
+    _symlink(tmp_path, "skills/foo/loop", target=".")  # loop -> its own dir
+    assert offending_paths(symlink_lint.find_cyclic_symlinks(tmp_path), tmp_path) == {"skills/foo/loop"}
+
+
+def test_indirect_cycle_through_relay_detected(tmp_path: Path) -> None:
+    (tmp_path / "skills" / "ctc").mkdir(parents=True)
+    _symlink(tmp_path, ".agents/skills/magpie-ctc", "../../skills/ctc")
+    # stray in-source relay -> canonical -> back into skills/ctc: a cycle
+    _symlink(tmp_path, "skills/ctc/magpie-ctc", "../../.agents/skills/magpie-ctc")
+    assert offending_paths(symlink_lint.find_cyclic_symlinks(tmp_path), tmp_path) == {"skills/ctc/magpie-ctc"}
+
+
+def test_dangling_link_skipped(tmp_path: Path) -> None:
+    _symlink(tmp_path, "x/dangling", "../../no-such-dir/skills/thing")
+    assert symlink_lint.find_cyclic_symlinks(tmp_path) == []
+
+
+def test_symlink_to_regular_file_not_flagged(tmp_path: Path) -> None:
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "real.txt").write_text("x\n")
+    _symlink(tmp_path, "a/link.txt", target="real.txt")
+    assert symlink_lint.find_cyclic_symlinks(tmp_path) == []
+
+
+def test_pruned_directory_ignored(tmp_path: Path) -> None:
+    _symlink(tmp_path, ".git/loop", target=".")
+    assert symlink_lint.find_cyclic_symlinks(tmp_path) == []
+
+
+def test_symlink_name_with_spaces_detected(tmp_path: Path) -> None:
+    _symlink(tmp_path, "weird dir/loop with space", target=".")
+    assert offending_paths(symlink_lint.find_cyclic_symlinks(tmp_path), tmp_path) == {
+        "weird dir/loop with space"
+    }
+
+
+# ---- Rule 2: relay correctness -------------------------------------------
+
+
+def test_correct_canonical_and_relay_not_flagged(tmp_path: Path) -> None:
+    _wire_skill(tmp_path, relay_target="../../.agents/skills/magpie-x")
+    assert symlink_lint.find_cyclic_symlinks(tmp_path) == []
+    assert symlink_lint.find_misdirected_relays(tmp_path) == []
+
+
+def test_relay_pointing_at_source_flagged(tmp_path: Path) -> None:
+    # The workflow-security-audit divergence: a .claude relay pointing
+    # straight into source instead of through the canonical .agents entry.
+    _wire_skill(tmp_path, relay_target="../../skills/x")
+    assert offending_paths(symlink_lint.find_misdirected_relays(tmp_path), tmp_path) == {
+        ".claude/skills/magpie-x"
+    }
+    # It is acyclic, so rule 1 does NOT catch it — rule 2 must.
+    assert symlink_lint.find_cyclic_symlinks(tmp_path) == []
+
+
+def test_canonical_pointing_outside_source_flagged(tmp_path: Path) -> None:
+    (tmp_path / "skills" / "x").mkdir(parents=True)
+    # Canonical should point at ../../skills/x, not at another skill.
+    _symlink(tmp_path, ".agents/skills/magpie-x", "../../skills/wrong")
+    assert offending_paths(symlink_lint.find_misdirected_relays(tmp_path), tmp_path) == {
+        ".agents/skills/magpie-x"
+    }
+
+
+def test_non_magpie_symlink_ignored_by_relay_rule(tmp_path: Path) -> None:
+    (tmp_path / "other").mkdir()
+    _symlink(tmp_path, ".claude/skills/not-magpie", "../../other")
+    assert symlink_lint.find_misdirected_relays(tmp_path) == []
+
+
+# ---- main() ---------------------------------------------------------------
+
+
+def test_main_returns_zero_when_clean(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_skill(tmp_path, relay_target="../../.agents/skills/magpie-x")
+    monkeypatch.setattr(symlink_lint, "repo_root", lambda: tmp_path)
+    assert symlink_lint.main() == 0
+
+
+def test_main_returns_one_on_cycle(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _symlink(tmp_path, "skills/foo/loop", target=".")
+    monkeypatch.setattr(symlink_lint, "repo_root", lambda: tmp_path)
+    assert symlink_lint.main() == 1
+
+
+def test_main_returns_one_on_misdirected_relay(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _wire_skill(tmp_path, relay_target="../../skills/x")
+    monkeypatch.setattr(symlink_lint, "repo_root", lambda: tmp_path)
+    assert symlink_lint.main() == 1

--- a/uv.lock
+++ b/uv.lock
@@ -34,6 +34,7 @@ members = [
     "skill-evals",
     "spec-status-index",
     "spec-validator",
+    "symlink-lint",
     "vulnogram-api",
 ]
 
@@ -841,8 +842,8 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.11" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.18" },
 ]
 
@@ -874,6 +875,11 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "ruff", specifier = ">=0.15.18" },
 ]
+
+[[package]]
+name = "symlink-lint"
+version = "0.1.0"
+source = { editable = "tools/symlink-lint" }
 
 [[package]]
 name = "typing-extensions"


### PR DESCRIPTION
## Summary

- Add `tools/symlink-lint`, a stdlib-Python `prek` hook guarding the framework's
  self-adoption skill symlinks against two failure modes: **cycles** (a symlink
  resolving to its own dir/ancestor — traps recursive `**/SKILL.md` scanners in
  looped paths) and **misdirected relays** (an agent-dir relay pointing straight
  at source instead of through the canonical `.agents/skills/` entry — acyclic,
  so a cycle check alone misses it).
- Guard companion to #648: #648 removed the three cyclic in-source symlinks;
  this keeps those — and misdirected relays — from returning.
- Dangling links are skipped: an adopter's canonical links legitimately dangle
  until the `.apache-magpie/` snapshot is installed (`setup verify`'s job).

## Context / how found

Rule 2 (relay-correctness) directly addresses the
`.claude/skills/magpie-workflow-security-audit` divergence flagged in #648
review — and surfaced it wasn't a one-off: **9** committed relays under
`.claude/` and `.github/` pointed at `../../skills/<skill>` instead of
`../../.agents/skills/magpie-<skill>`. They're repointed here because the new
hook would otherwise fail on `main` — the guard and the tree it guards must land
together. Each is a one-line target repoint; no source moves.

Supersedes this PR's original bash implementation, per review — rewritten to
stdlib Python to fix portability (`pathlib.resolve()`), filename-safety
(`os.walk`), and testability (a `pytest` suite) at the root.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)
- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] `prek run --all-files` passes
- [x] `uv run pytest` / `ruff check` / `mypy` pass (13-case suite: both rules +
      dangling / pruned / symlink-to-file / whitespace edges + `main()` exit codes)
- [x] `meta-and-quality-tooling.md` spec updated to list the tool; no skill loads
      `symlink-lint`, so no skill-eval / `mode-economics` update applies

---
*Gen-AI disclosure: authored with Kiro CLI (Opus 4.8); commit carries a `Generated-by:` trailer per AGENTS.md.*
