### PR TITLE
chore(agent-isolation): bump pinned claude-code 2.1.193 -> 2.1.196

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -158,7 +158,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.2-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.193
+npm install -g --no-save @anthropic-ai/claude-code@2.1.196
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -266,7 +266,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.193
+npm install -g --no-save @anthropic-ai/claude-code@2.1.196
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -52,7 +52,7 @@
 
 # When this file was last touched. The check script uses this as the
 # minimum age the entries below claim to satisfy.
-pinned_at = "2026-06-27"
+pinned_at = "2026-07-01"
 
 [tools.bubblewrap]
 version = "0.11.2"
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.193"
-released = "2026-06-25"
+version = "2.1.196"
+released = "2026-06-29"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.193"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.193 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.196"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.196 (when available)"


### PR DESCRIPTION
## What

Bump the pinned `claude-code` from `2.1.193` to `2.1.196` in
`pinned-versions.toml` + the two install snippets in
`docs/setup/secure-agent-setup.md`.

## Why

`2.1.196` (released 2026-06-29, past the tool's 1-day cooldown) ships a
workspace-trust security fix: `claude mcp list`/`get` no longer spawn
`.mcp.json` servers that a repo self-approved via a committed
`.claude/settings.json`; untrusted workspaces show "Pending approval".
2.1.194-195 are voice/plugin/background-job fixes with no bearing on the
secure setup. No changes to sandbox flags, permission-rule semantics, or
hook behaviour.

Changelog: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
