### PR TITLE
feat(validator): add project-template drift check 

### DIFF
--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -95,6 +95,14 @@ skills/:
     attempt to weaken the framework's safety / confidentiality / privacy /
     external-content-as-data baseline.  Advisory only — prose explanations
     of what NOT to do can false-positive here.
+16. Project-template drift (SOFT) — compares ``projects/_template/``
+    with ``projects/non-asf-example/`` for structural drift: files
+    referenced in the example README must exist on disk, every config
+    file in the example must be documented in its README, and config
+    files present in both profiles must have the same h2 section
+    headings (``project.md`` and ``README.md`` are excluded from the
+    h2 comparison because their structures intentionally differ by
+    organization profile). Advisory only.
 
 SOFT categories surface as advisory warnings (stderr) without
 failing the run unless ``--strict`` is passed.
@@ -123,6 +131,7 @@ TOOLS_DIR = Path("tools")
 DOCS_DIR = Path("docs")
 SKILL_EVALS_DIR = Path("tools/skill-evals/evals")
 PROJECTS_TEMPLATE_DIR = Path("projects/_template")
+PROJECTS_NON_ASF_EXAMPLE_DIR = Path("projects/non-asf-example")
 MODES_DOC_PATH = Path("docs/modes.md")
 OVERRIDES_DIR = Path(".apache-magpie-overrides")
 
@@ -429,6 +438,9 @@ MODES_DOC_CATEGORY = "modes-doc-consistency"
 # SOFT advisory: override files in .apache-magpie-overrides/ must not weaken the
 # framework's safety / confidentiality / privacy / data-not-instructions baseline.
 OVERRIDE_CONTRACT_CATEGORY = "override-contract"
+# SOFT advisory: structural drift between projects/_template/ and
+# projects/non-asf-example/ — missing files, undocumented files, or h2 mismatches.
+TEMPLATE_DRIFT_CATEGORY = "template-drift"
 
 # The `magpie-` namespace prefix every installed framework skill carries.
 SKILL_NAME_PREFIX = "magpie-"
@@ -447,6 +459,7 @@ SOFT_CATEGORIES: frozenset[str] = frozenset(
         MODES_DOC_CATEGORY,
         MULTI_CAPABILITY_CATEGORY,
         OVERRIDE_CONTRACT_CATEGORY,
+        TEMPLATE_DRIFT_CATEGORY,
     }
 )
 HARD_CATEGORIES: frozenset[str] = frozenset(
@@ -2634,6 +2647,172 @@ def validate_eval_coverage(root: Path | None = None) -> Iterable[Violation]:
             )
 
 
+# ---------------------------------------------------------------------------
+# Project-template drift check (check #15, SOFT advisory)
+# ---------------------------------------------------------------------------
+
+# DocToc-generated TOC block — strip before comparing headings so that
+# section titles in the generated table of contents do not double-count as h2s.
+_DOCTOC_BLOCK_RE = re.compile(
+    r"<!-- START doctoc.*?<!-- END doctoc[^\n]*\n",
+    re.DOTALL,
+)
+
+# Markdown link where the link text is a backtick-quoted filename, e.g.:
+#   [`issue-tracker-config.md`](issue-tracker-config.md)
+# Group 1: the file name (inside backticks); Group 2: the link target (href).
+_PROJECT_FILE_LINK_RE = re.compile(r"\[`([^`]+)`\]\(([^)#\s]+)\)")
+
+# Files excluded from the h2 heading comparison.  project.md and README.md
+# have intentionally different structures depending on organization profile
+# (project.md has org-inherited blocks the example omits; README.md is a
+# narrative file not a config template).
+_TEMPLATE_DRIFT_H2_SKIP: frozenset[str] = frozenset({"project.md", "README.md"})
+
+
+def _strip_doctoc(text: str) -> str:
+    """Remove the DocToc-generated TOC block so its headings are not counted."""
+    return _DOCTOC_BLOCK_RE.sub("", text)
+
+
+def _extract_h2_headings(text: str) -> list[str]:
+    """Return the text of every h2 heading, in order, after stripping DocToc."""
+    clean = _strip_doctoc(text)
+    return [m.group(1).strip() for m in re.finditer(r"^## (.+)$", clean, re.MULTILINE)]
+
+
+def validate_project_template_drift(root: Path | None = None) -> Iterable[Violation]:
+    """SOFT advisory: detect structural drift between _template and non-asf-example.
+
+    Three checks (all SOFT — advisory, never fails the run unless --strict):
+
+    1. **README file-list coherence**: every file linked in the '## Files'
+       section of non-asf-example/README.md must exist on disk.
+
+    2. **Undocumented files**: every ``.md`` file in non-asf-example/
+       (other than README.md itself) must be mentioned somewhere in
+       non-asf-example/README.md.
+
+    3. **Shared-file h2 alignment**: for each file present in both
+       ``projects/_template/`` and ``projects/non-asf-example/`` (excluding
+       README.md and project.md, whose structures differ intentionally by
+       organization profile), the h2 section headings are compared.  A
+       heading present in the template but absent in the example suggests
+       the example may be missing a section; the reverse suggests the
+       template doc needs updating.  Both are advisory.
+
+    Silently skipped when either directory does not exist — avoids noise
+    on forks that omit the non-ASF example profile.
+    """
+    repo_root = root or find_repo_root()
+    template_dir = repo_root / PROJECTS_TEMPLATE_DIR
+    example_dir = repo_root / PROJECTS_NON_ASF_EXAMPLE_DIR
+
+    if not template_dir.is_dir() or not example_dir.is_dir():
+        return
+
+    example_readme = example_dir / "README.md"
+    if not example_readme.exists():
+        yield Violation(
+            example_readme,
+            None,
+            "template-drift [readme-missing]: non-asf-example/README.md is missing — "
+            "the example profile must document its files and explain what differs from "
+            "the _template/ profile",
+            category=TEMPLATE_DRIFT_CATEGORY,
+        )
+        return
+
+    try:
+        example_readme_text = example_readme.read_text(encoding="utf-8")
+    except OSError:
+        return
+
+    # -------------------------------------------------------------------
+    # Check 1: README file-list coherence (non-asf-example)
+    # -------------------------------------------------------------------
+    # Locate the "## Files" section and inspect every backtick-linked filename.
+    files_section = ""
+    if "## Files" in example_readme_text:
+        after_header = example_readme_text.split("## Files", 1)[1]
+        next_h2 = after_header.find("\n## ")
+        files_section = after_header[:next_h2] if next_h2 > 0 else after_header
+
+    for m in _PROJECT_FILE_LINK_RE.finditer(files_section):
+        href = m.group(2).strip()
+        # Only check local same-directory links (no ../ traversal, no URLs).
+        if href.startswith(("http://", "https://", "#", "..", "/")):
+            continue
+        target = example_dir / href
+        if not target.exists():
+            yield Violation(
+                example_readme,
+                None,
+                f"template-drift [readme-dead-link]: non-asf-example/README.md "
+                f"'## Files' links to '{href}' but the file does not exist — "
+                f"add the file or remove it from the README",
+                category=TEMPLATE_DRIFT_CATEGORY,
+            )
+
+    # -------------------------------------------------------------------
+    # Check 2: Undocumented files in non-asf-example
+    # -------------------------------------------------------------------
+    for child in sorted(example_dir.iterdir()):
+        if not child.is_file() or child.suffix != ".md" or child.name == "README.md":
+            continue
+        if child.name not in example_readme_text:
+            yield Violation(
+                child,
+                None,
+                f"template-drift [undocumented-file]: non-asf-example/{child.name} "
+                f"exists but is not mentioned in non-asf-example/README.md — "
+                f"add it to the '## Files' section or explain its purpose",
+                category=TEMPLATE_DRIFT_CATEGORY,
+            )
+
+    # -------------------------------------------------------------------
+    # Check 3: Shared-file h2 alignment (excluding project.md and README.md)
+    # -------------------------------------------------------------------
+    template_files = {p.name for p in template_dir.iterdir() if p.is_file() and p.suffix == ".md"}
+    example_files = {p.name for p in example_dir.iterdir() if p.is_file() and p.suffix == ".md"}
+    shared = (template_files & example_files) - _TEMPLATE_DRIFT_H2_SKIP
+
+    for filename in sorted(shared):
+        try:
+            tmpl_text = (template_dir / filename).read_text(encoding="utf-8")
+            ex_text = (example_dir / filename).read_text(encoding="utf-8")
+        except OSError:
+            continue
+
+        tmpl_h2s = set(_extract_h2_headings(tmpl_text))
+        ex_h2s = set(_extract_h2_headings(ex_text))
+
+        missing_from_example = tmpl_h2s - ex_h2s
+        extra_in_example = ex_h2s - tmpl_h2s
+
+        if missing_from_example:
+            yield Violation(
+                example_dir / filename,
+                None,
+                f"template-drift [h2-missing-from-example]: "
+                f"non-asf-example/{filename} is missing h2 section(s) present in "
+                f"_template/{filename}: {sorted(missing_from_example)!r} — "
+                f"add the section(s) or document the intentional omission in the README",
+                category=TEMPLATE_DRIFT_CATEGORY,
+            )
+
+        if extra_in_example:
+            yield Violation(
+                template_dir / filename,
+                None,
+                f"template-drift [h2-extra-in-example]: "
+                f"non-asf-example/{filename} has h2 section(s) not present in "
+                f"_template/{filename}: {sorted(extra_in_example)!r} — "
+                f"add the section(s) to the template so adopters know about them",
+                category=TEMPLATE_DRIFT_CATEGORY,
+            )
+
+
 def run_validation(root: Path | None = None) -> list[Violation]:
     """Run the full validation suite and return all violations."""
     repo_root = root or find_repo_root()
@@ -2693,6 +2872,9 @@ def run_validation(root: Path | None = None) -> list[Violation]:
 
     # Override-file contract check: .apache-magpie-overrides/*.md must not weaken baseline.
     violations.extend(validate_override_contract(repo_root))
+
+    # Project-template drift check: _template/ and non-asf-example/ stay comparable.
+    violations.extend(validate_project_template_drift(repo_root))
 
     return violations
 
@@ -2770,6 +2952,7 @@ _SOFT_RULE_PREFIXES: tuple[str, ...] = (
     "override-contract",
     "override-weakening",
     "parenthetical rationale",
+    "template-drift",
     "trigger phrase",
     "injection-guard TODO",
     "security-pattern-1",

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -53,6 +53,7 @@ from skill_and_tool_validator import (
     SECURITY_PATTERN_CATEGORY,
     SOFT_CATEGORIES,
     STATUS_CATEGORY,
+    TEMPLATE_DRIFT_CATEGORY,
     TRIGGER_PRESERVATION_CATEGORY,
     _parse_modes_doc,
     _read_mode_table,
@@ -88,6 +89,7 @@ from skill_and_tool_validator import (
     validate_placeholders,
     validate_principle_compliance,
     validate_privacy_patterns,
+    validate_project_template_drift,
     validate_security_patterns,
     validate_tools,
     validate_trigger_preservation,
@@ -3695,3 +3697,244 @@ class TestValidateOverrideContract:
         # No skill bodies are read; the check only scans the override directory.
         violations = list(validate_override_contract(tmp_path))
         assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Project-template drift check
+# ---------------------------------------------------------------------------
+
+
+def _make_profile_dirs(
+    tmp_path: Path,
+    template_files: dict[str, str] | None = None,
+    example_files: dict[str, str] | None = None,
+    example_readme: str | None = None,
+) -> Path:
+    """Create minimal projects/_template/ and projects/non-asf-example/ trees.
+
+    *template_files* and *example_files* are {filename: content} dicts.
+    *example_readme* overrides the auto-generated README.md for the example.
+    Returns the repo root (tmp_path itself).
+    """
+    tmpl_dir = tmp_path / "projects" / "_template"
+    ex_dir = tmp_path / "projects" / "non-asf-example"
+    tmpl_dir.mkdir(parents=True)
+    ex_dir.mkdir(parents=True)
+
+    for name, content in (template_files or {}).items():
+        (tmpl_dir / name).write_text(content, encoding="utf-8")
+
+    for name, content in (example_files or {}).items():
+        (ex_dir / name).write_text(content, encoding="utf-8")
+
+    if example_readme is not None:
+        (ex_dir / "README.md").write_text(example_readme, encoding="utf-8")
+    elif "README.md" not in (example_files or {}):
+        # Default README that lists any config files provided.
+        listed = "\n".join(
+            f"- [`{n}`]({n}) — fixture" for n in sorted((example_files or {}).keys()) if n != "README.md"
+        )
+        (ex_dir / "README.md").write_text(
+            f"# Example\n\n## Files\n\n{listed}\n",
+            encoding="utf-8",
+        )
+
+    return tmp_path
+
+
+class TestProjectTemplateDrift:
+    # --- Category membership ---
+
+    def test_category_is_soft(self) -> None:
+        assert TEMPLATE_DRIFT_CATEGORY in SOFT_CATEGORIES
+        assert TEMPLATE_DRIFT_CATEGORY not in HARD_CATEGORIES
+
+    def test_category_in_all_categories(self) -> None:
+        assert TEMPLATE_DRIFT_CATEGORY in ALL_CATEGORIES
+
+    # --- Silent when directories absent ---
+
+    def test_silent_when_template_dir_missing(self, tmp_path: Path) -> None:
+        ex_dir = tmp_path / "projects" / "non-asf-example"
+        ex_dir.mkdir(parents=True)
+        (ex_dir / "README.md").write_text("# Example\n")
+        violations = list(validate_project_template_drift(tmp_path))
+        assert violations == []
+
+    def test_silent_when_example_dir_missing(self, tmp_path: Path) -> None:
+        tmpl_dir = tmp_path / "projects" / "_template"
+        tmpl_dir.mkdir(parents=True)
+        (tmpl_dir / "project.md").write_text("# Template\n")
+        violations = list(validate_project_template_drift(tmp_path))
+        assert violations == []
+
+    # --- Clean state: no violations ---
+
+    def test_clean_dirs_produce_no_violations(self, tmp_path: Path) -> None:
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"stale-sweep-config.md": "## Thresholds\n\ncontent\n"},
+            example_files={"stale-sweep-config.md": "## Thresholds\n\ncontent\n"},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert violations == []
+
+    def test_no_violations_on_live_repo(self) -> None:
+        root = find_repo_root()
+        violations = list(validate_project_template_drift(root))
+        drift = [v for v in violations if v.category == TEMPLATE_DRIFT_CATEGORY]
+        assert drift == [], "Unexpected template-drift violations on live repo:\n" + "\n".join(
+            str(v) for v in drift
+        )
+
+    # --- Check 1: README file-list coherence ---
+
+    def test_readme_dead_link_fires(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n- [`ghost.md`](ghost.md) — does not exist\n"
+        _make_profile_dirs(tmp_path, example_readme=readme)
+        violations = list(validate_project_template_drift(tmp_path))
+        assert any("readme-dead-link" in v.message for v in violations)
+        assert any(v.category == TEMPLATE_DRIFT_CATEGORY for v in violations)
+
+    def test_readme_dead_link_violation_names_the_missing_file(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n- [`missing.md`](missing.md) — gone\n"
+        _make_profile_dirs(tmp_path, example_readme=readme)
+        violations = list(validate_project_template_drift(tmp_path))
+        dead = [v for v in violations if "readme-dead-link" in v.message]
+        assert any("missing.md" in v.message for v in dead)
+
+    def test_existing_file_does_not_trigger_dead_link(self, tmp_path: Path) -> None:
+        _make_profile_dirs(
+            tmp_path,
+            example_files={"config.md": "# Config\n"},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("readme-dead-link" in v.message for v in violations)
+
+    def test_external_url_in_files_section_not_checked(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n- [external](https://example.com/foo.md) — external\n"
+        _make_profile_dirs(tmp_path, example_readme=readme)
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("readme-dead-link" in v.message for v in violations)
+
+    def test_parent_traversal_in_files_section_not_checked(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n- [`org`](../../organizations/README.md) — parent\n"
+        _make_profile_dirs(tmp_path, example_readme=readme)
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("readme-dead-link" in v.message for v in violations)
+
+    # --- Check 2: Undocumented files ---
+
+    def test_undocumented_file_fires(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n(no files listed)\n"
+        _make_profile_dirs(
+            tmp_path,
+            example_files={"orphan.md": "# Orphan\n"},
+            example_readme=readme,
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert any("undocumented-file" in v.message for v in violations)
+
+    def test_undocumented_file_violation_names_the_file(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n(no files listed)\n"
+        _make_profile_dirs(
+            tmp_path,
+            example_files={"stale-sweep-config.md": "## Thresholds\n"},
+            example_readme=readme,
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        undoc = [v for v in violations if "undocumented-file" in v.message]
+        assert any("stale-sweep-config.md" in v.message for v in undoc)
+
+    def test_readme_md_itself_never_flagged_as_undocumented(self, tmp_path: Path) -> None:
+        _make_profile_dirs(tmp_path)
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("undocumented-file" in v.message and "README.md" in v.message for v in violations)
+
+    def test_documented_file_no_undocumented_violation(self, tmp_path: Path) -> None:
+        _make_profile_dirs(
+            tmp_path,
+            example_files={"config.md": "# Config\n"},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("undocumented-file" in v.message for v in violations)
+
+    # --- Check 3: Shared-file h2 alignment ---
+
+    def test_h2_missing_from_example_fires(self, tmp_path: Path) -> None:
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"config.md": "## Section A\n\ncontent\n\n## Section B\n\ncontent\n"},
+            example_files={"config.md": "## Section A\n\ncontent\n"},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert any("h2-missing-from-example" in v.message for v in violations)
+        assert any("Section B" in v.message for v in violations)
+
+    def test_h2_extra_in_example_fires(self, tmp_path: Path) -> None:
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"config.md": "## Section A\n\ncontent\n"},
+            example_files={"config.md": "## Section A\n\ncontent\n\n## Extra\n\ncontent\n"},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert any("h2-extra-in-example" in v.message for v in violations)
+        assert any("Extra" in v.message for v in violations)
+
+    def test_matching_h2s_produce_no_violation(self, tmp_path: Path) -> None:
+        content = "## Thresholds\n\n## Exclusion labels\n\n## Cross-references\n"
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"stale-sweep-config.md": content},
+            example_files={"stale-sweep-config.md": content},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("h2-" in v.message for v in violations)
+
+    def test_project_md_h2_differences_silent(self, tmp_path: Path) -> None:
+        # project.md is excluded from h2 comparison — org-inherited blocks
+        # intentionally differ between template and example.
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"project.md": "## Identity\n\n## Mail sources\n\ncontent\n"},
+            example_files={"project.md": "## Identity\n\ncontent\n"},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("h2-" in v.message and "project.md" in v.message for v in violations)
+
+    def test_readme_md_excluded_from_h2_comparison(self, tmp_path: Path) -> None:
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"README.md": "## What each file is for\n\ncontent\n"},
+            example_readme="## Files\n\ncontent\n",
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("h2-" in v.message and "README.md" in v.message for v in violations)
+
+    def test_doctoc_headings_not_counted(self, tmp_path: Path) -> None:
+        # DocToc repeats headings in a comment block; those should not be compared.
+        doctoc = (
+            "<!-- START doctoc generated TOC please keep comment here to allow auto update -->\n"
+            "<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->\n"
+            "**Table of Contents**\n\n"
+            "- [Section A](#section-a)\n"
+            "- [Section B](#section-b)\n\n"
+            "<!-- END doctoc generated TOC\n"
+            " -->\n"
+        )
+        tmpl = doctoc + "## Section A\n\ncontent\n\n## Section B\n\ncontent\n"
+        ex = doctoc + "## Section A\n\ncontent\n\n## Section B\n\ncontent\n"
+        _make_profile_dirs(
+            tmp_path,
+            template_files={"config.md": tmpl},
+            example_files={"config.md": ex},
+        )
+        violations = list(validate_project_template_drift(tmp_path))
+        assert not any("h2-" in v.message for v in violations)
+
+    def test_all_violations_are_soft_category(self, tmp_path: Path) -> None:
+        readme = "# Example\n\n## Files\n\n- [`ghost.md`](ghost.md) — missing\n"
+        _make_profile_dirs(tmp_path, example_readme=readme)
+        violations = list(validate_project_template_drift(tmp_path))
+        for v in violations:
+            assert v.category == TEMPLATE_DRIFT_CATEGORY

--- a/tools/spec-loop/specs/project-agnosticism.md
+++ b/tools/spec-loop/specs/project-agnosticism.md
@@ -183,8 +183,11 @@ uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-valid
   catalogue (bare `PMC`, `ICLA`, `announce@apache.org`) is surfaced by the
   advisory lint (check #10 in `skill-and-tool-validator`) for human
   judgement.
-- **Template/profile drift is not mechanically checked.** The non-ASF
-  example is now a real smoke fixture, but no validator compares its file
-  and key surface against `projects/_template/`. A drift check should
-  catch missing required files, stale documented keys, and hidden
-  organization-default assumptions.
+- **Template/profile drift is now mechanically checked.** Check #15 in
+  `tools/skill-and-tool-validator` (`template-drift` category, SOFT)
+  compares `projects/_template/` and `projects/non-asf-example/`: files
+  linked in the example README must exist on disk, every config file in the
+  example must be documented in its README, and shared config files (all
+  except `project.md` and `README.md`, which differ by design) must have
+  the same h2 section headings. The live tree produces no `template-drift`
+  violations.


### PR DESCRIPTION
## Summary

Add validate_project_template_drift (check #15) to
tools/skill-and-tool-validator to mechanically compare
projects/_template/ with projects/non-asf-example/ for structural
drift, closing the Known gap in specs/project-agnosticism.md.

Three SOFT advisory checks under the new template-drift category:

1. README file-list coherence: every file linked in the ## Files
section of non-asf-example/README.md must exist on disk.
2. Undocumented files: every .md file in non-asf-example/ (other
than README.md) must be mentioned somewhere in its README.
3. Shared-file h2 alignment: for each .md file present in both
profiles, h2 section headings are compared. project.md and
README.md are excluded since they differ intentionally by
organization profile (org-inherited blocks, narrative structure).

22 new tests in TestProjectTemplateDrift cover all checks, the
live-repo clean-state assertion, DocToc-stripping, exclusion of
parent-traversal and external URLs, and the project.md/README.md
exemptions. The live tree produces zero template-drift violations.

Updates specs/project-agnosticism.md Known gaps to document the
new check and its scope.

Generated-by: Claude (Opus 4.7)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [] Tool / bridge contract (`tools/<system>/*.md`)
- [X] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [X] Other: manually tested
