### PR TITLE
chore(agent-isolation): bump pinned claude-code 2.1.196 -> 2.1.197

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -158,7 +158,7 @@ The same flow, condensed to commands you run yourself:
 #    section: "Required tools (pinned versions)" below.
 sudo apt-get install --no-install-recommends \
     bubblewrap=0.11.2-* socat=1.8.1.1-*
-npm install -g --no-save @anthropic-ai/claude-code@2.1.196
+npm install -g --no-save @anthropic-ai/claude-code@2.1.197
 
 # 2. Project-scope `.claude/settings.json`. Copy the framework's
 #    sandbox / permissions.deny / permissions.ask / allowedDomains
@@ -266,7 +266,7 @@ version, no pin enforced — Homebrew rolls forward, so the
 
 ```bash
 # npm distribution (the only stable channel today)
-npm install -g --no-save @anthropic-ai/claude-code@2.1.196
+npm install -g --no-save @anthropic-ai/claude-code@2.1.197
 ```
 
 ### Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble

--- a/tools/agent-isolation/pinned-versions.toml
+++ b/tools/agent-isolation/pinned-versions.toml
@@ -91,8 +91,8 @@ install.dnf = "dnf install socat-1.8.1.1"
 install.from_source = "http://www.dest-unreach.org/socat/download/socat-1.8.1.1.tar.gz"
 
 [tools.claude-code]
-version = "2.1.196"
-released = "2026-06-29"
+version = "2.1.197"
+released = "2026-06-30"
 # Override the framework-wide 7-day default. Claude Code releases
 # cadence is high (multiple releases per week) and any regression
 # that affects the framework's permission-rule semantics, sandbox
@@ -118,5 +118,5 @@ upstream_releases = "https://api.github.com/repos/anthropics/claude-code/release
 # Claude Code is distributed via npm; use `--no-save` so the global
 # install doesn't drift the local lockfile of any project the user
 # installs from.
-install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.196"
-install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.196 (when available)"
+install.npm = "npm install -g --no-save @anthropic-ai/claude-code@2.1.197"
+install.brew = "# brew tap anthropics/claude-code; brew install claude-code@2.1.197 (when available)"


### PR DESCRIPTION
## What

Bumps the pinned `claude-code` in the secure-agent-setup manifest from **2.1.196 → 2.1.197**.

- `tools/agent-isolation/pinned-versions.toml`: `version`, `released`, and the `install.npm` / `install.brew` command strings.
- `docs/setup/secure-agent-setup.md`: both `@anthropic-ai/claude-code@` pins.

`pinned_at` was already today's date (2026-07-01).

## Why / changelog review

2.1.197's only change is making **Claude Sonnet 5** the default model (native 1M-token context, promo pricing through Aug 31). Reviewed against the framework's security surface — **no** changes to permission-rule semantics, sandbox/network isolation, hooks/PreToolUse, prompt-injection mitigations, `settings.json` schema, or credential handling. Clean for the secure setup. Eligible per policy (past the 1-day cooldown; released 2026-06-30).

## Verification

- `check-tool-updates.sh` now reports `claude-code ✓ up to date`.
- No remaining `2.1.196` references in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
