### PR TITLE
refactor(contract): rename contract:mail-draft → contract:mail-create

### DIFF
--- a/docs/labels-and-capabilities.md
+++ b/docs/labels-and-capabilities.md
@@ -102,7 +102,7 @@ framework substrate:
 | `contract:change-request` | contract | Proposed-change review + merge gate (pull request / merge request / Gerrit change). |
 | `contract:mail-archive` | contract | Mailing-list / forum archive reads. |
 | `contract:mail-source` | contract | Inbound-mail ingestion (mbox / IMAP / …). |
-| `contract:mail-draft` | contract | Outbound mail composition (draft, never send). |
+| `contract:mail-create` | contract | Outbound mail composition. Always produces an editable draft; sending is a separate human-approved step on that draft (draft mode = default and the only mode implemented today; send mode declared but unimplemented — no autonomous send). |
 | `contract:cve-authority` | contract | CVE allocation / record management / publication. |
 | `contract:report-relay` | contract | Inbound security-report relay detection. |
 | `contract:scan-format` | contract | Security-scanner report parsing. |
@@ -235,7 +235,7 @@ Capabilities for every skill currently in
 Tools under [`tools/`](../tools/). A tool's capability is the interface
 it provides; a tool may carry more than one value (separated by `+`) when
 it implements multiple contracts (e.g. `tools/gmail` provides both
-`mail-source` and `mail-draft`).
+`mail-source` and `mail-create`).
 
 | Tool | Capability / capabilities | Role |
 |---|---|---|
@@ -254,11 +254,11 @@ it implements multiple contracts (e.g. `tools/gmail` provides both
 | [`tools/github`](../tools/github/) | `contract:tracker` + `contract:source-control` + `contract:change-request` | GitHub REST / GraphQL tracker substrate (called by every lifecycle phase) plus the Git source-control binding documented in [`source-control.md`](../tools/github/source-control.md) (runnable backend in [`tools/vcs`](../tools/vcs/)) and the pull-request review/merge gate (`change-request`; the ASF default backend, alongside `tools/jira-patch/` and `tools/mail-patch/` for SVN-first projects) |
 | [`tools/github-body-field`](../tools/github-body-field/) | `contract:tracker` | Read or rewrite one `### Field` section of a GitHub issue body without bringing the body into agent context — substrate helper for the security-sync skills |
 | [`tools/github-rollup`](../tools/github-rollup/) | `contract:tracker` | Append to (or create) the status-rollup comment on a GitHub issue without bringing the rollup body into agent context — substrate helper for every status-update-emitting skill |
-| [`tools/gmail`](../tools/gmail/) | `contract:mail-source` + `contract:mail-draft` + `contract:mail-archive` | Gmail API substrate — inbound report intake (`mail-source`), thread / archive reads (`mail-archive`), plus outbound courtesy-reply drafting (`mail-draft`); read + draft only, never sends |
+| [`tools/gmail`](../tools/gmail/) | `contract:mail-source` + `contract:mail-create` + `contract:mail-archive` | Gmail API substrate — inbound report intake (`mail-source`), thread / archive reads (`mail-archive`), plus outbound courtesy-reply drafting (`mail-create`); read + draft only, never sends |
 | [`tools/jira`](../tools/jira/) | `contract:tracker` | JIRA REST substrate (read-only today; write subcommands tracked in [#301](https://github.com/apache/magpie/issues/301)) |
 | [`tools/jira-patch`](../tools/jira-patch/) | `contract:change-request` | JIRA-patch change-request backend: patches attached to JIRA issues as the proposal, reviewed via JIRA comments, landed via `contract:source-control` (`svn patch` + `svn commit`). Composes `tools/jira/` (REST) + `tools/asf-svn/` (land). Implements the `tools/change-request/` contract |
 | [`tools/mail-archive`](../tools/mail-archive/) | `contract:mail-archive` | Adapter contract for public mail-archive backends (PonyMail, Hyperkitty, Discourse, Google Groups, GitHub Discussions). Pure interface spec. |
-| [`tools/mail-patch`](../tools/mail-patch/) | `contract:change-request` | `[PATCH]`-mail change-request backend: a `[PATCH]` thread on `dev@` as the proposal, reviewed via drafted replies (`contract:mail-draft`), read via `contract:mail-archive`, landed via `contract:source-control` (`svn patch` + `svn commit`). Implements the `tools/change-request/` contract |
+| [`tools/mail-patch`](../tools/mail-patch/) | `contract:change-request` | `[PATCH]`-mail change-request backend: a `[PATCH]` thread on `dev@` as the proposal, reviewed via drafted replies (`contract:mail-create`), read via `contract:mail-archive`, landed via `contract:source-control` (`svn patch` + `svn commit`). Implements the `tools/change-request/` contract |
 | [`tools/mail-source`](../tools/mail-source/) | `contract:mail-source` | Mail-source backend abstraction (mbox / IMAP / Mailman 3) feeding a uniform inbound thread/message view to the intake pipeline |
 | [`tools/ponymail`](../tools/ponymail/) | `contract:mail-archive` + `contract:mail-source` | PonyMail public mail-archive substrate (ASF `lists.apache.org`); implements the `tools/mail-archive/` contract for archive reads and the `tools/mail-source/` contract for inbound list-traffic ingestion |
 | [`tools/scan-format`](../tools/scan-format/) | `contract:scan-format` | Adapter contract for security-scanner report formats (ASVS reference); reads a scan's finding index + per-finding evidence for the `security-issue-import-from-scan` pipeline. |
@@ -301,7 +301,7 @@ backend the adopter wired in. The framework consumes four:
 | MCP server | Tool prefix | Wrapped by | Capability provided | Organization |
 |---|---|---|---|---|
 | GitHub MCP | `mcp__github__*` | [`tools/github`](../tools/github/) | `contract:tracker` + `contract:source-control` + `contract:change-request` | — |
-| Gmail MCP (claude.ai) | `mcp__claude_ai_Gmail__*` | [`tools/gmail`](../tools/gmail/) | `contract:mail-source` + `contract:mail-draft` + `contract:mail-archive` | — |
+| Gmail MCP (claude.ai) | `mcp__claude_ai_Gmail__*` | [`tools/gmail`](../tools/gmail/) | `contract:mail-source` + `contract:mail-create` + `contract:mail-archive` | — |
 | PonyMail MCP (`apache/comdev`) | `mcp__ponymail__*` | [`tools/ponymail`](../tools/ponymail/) | `contract:mail-archive` + `contract:mail-source` | ASF |
 | apache-projects MCP (`apache/comdev`) | `mcp__apache-projects__*` | [`tools/apache-projects`](../tools/apache-projects/) | `contract:project-metadata` | ASF |
 

--- a/docs/rfcs/RFC-AI-0005.md
+++ b/docs/rfcs/RFC-AI-0005.md
@@ -133,7 +133,7 @@ small set of substrate kinds:
 | `source-control` | contract | branch / commit / diff / push (VCS) |
 | `mail-archive` | contract | public mailing-list / forum archive reads |
 | `mail-source` | contract | inbound-mail ingestion (mbox / IMAP / …) |
-| `mail-draft` | contract | outbound mail composition (draft, never send) |
+| `mail-create` | contract | outbound mail composition — always an editable draft; sending is a separate human-approved step (draft mode default and only mode implemented; send mode declared, unimplemented) |
 | `cve-authority` | contract | CVE allocation / record management / publication |
 | `report-relay` | contract | inbound security-report relay detection |
 | `scan-format` | contract | security-scanner report parsing |

--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -525,7 +525,7 @@ identity). The scorer reads them and applies one rule per contract
   is no vendor choice to make.
 
 The overall score is `green contracts / total contracts` — a hard,
-falsifiable number. Add a second outbound-mail backend and `mail-draft`
+falsifiable number. Add a second outbound-mail backend and `mail-create`
 flips to green on the next run; remove a backend and its contract flips
 back. The same rule then classifies every **skill**: *capability-pure*
 if it names no backend, *portable* if every backend it invokes has an
@@ -552,7 +552,7 @@ generated block below.
 | `contract:change-request` | ✅ | vendor-backed | Atlassian, GitHub, email | 3 backend vendors: Atlassian, GitHub, email |
 | `contract:mail-archive` | ✅ | vendor-backed | Google, PonyMail | 2 backend vendors: Google, PonyMail |
 | `contract:mail-source` | ✅ | vendor-backed | Google, PonyMail | 2 backend vendors: Google, PonyMail |
-| `contract:mail-draft` | ❌ | vendor-backed | Google | only 1 backend vendor (Google); needs 1 more |
+| `contract:mail-create` | ❌ | vendor-backed | Google | only 1 backend vendor (Google); needs 1 more |
 | `contract:cve-authority` | ✅ | vendor-backed | CVE.org, Vulnogram | 2 backend vendors: CVE.org, Vulnogram |
 | `contract:report-relay` | ✅ | agnostic | — | vendor-neutral by construction — one spec serves every backend |
 | `contract:scan-format` | ✅ | agnostic | — | vendor-neutral by construction — one spec serves every backend |
@@ -570,10 +570,10 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 49.
 
 Vendor-coupled skills (the only lock-ins today):
 
-- `security-issue-import` — `Google` → `contract:mail-draft`
-- `security-issue-import-via-forwarder` — `Google` → `contract:mail-draft`
-- `security-issue-invalidate` — `Google` → `contract:mail-draft`
-- `security-issue-sync` — `Google` → `contract:mail-draft`
+- `security-issue-import` — `Google` → `contract:mail-create`
+- `security-issue-import-via-forwarder` — `Google` → `contract:mail-create`
+- `security-issue-invalidate` — `Google` → `contract:mail-create`
+- `security-issue-sync` — `Google` → `contract:mail-create`
 
 **LLM / agent-integration neutrality**
 
@@ -623,9 +623,9 @@ Every other endpoint is **opt-in** — the adopting project's security team decl
 
 90% is not "90% done." It reads as: **nine of ten capabilities already
 work across more than one vendor, and the one that doesn't — outbound
-mail drafting (`mail-draft`) — is one adapter away.** The architecture
+mail composition (`mail-create`) — is one adapter away.** The architecture
 privileges no vendor on any of the ten axes; the single red cell is a
-missing *implementation* (a second `mail-draft` backend), tracked in the
+missing *implementation* (a second `mail-create` backend), tracked in the
 open — not a design that assumes Gmail.
 
 The `change-request` gate — the pull-request review/merge contract that

--- a/tools/change-request/README.md
+++ b/tools/change-request/README.md
@@ -201,7 +201,7 @@ Post a review verdict + body onto the proposal.
 - **Output.** `ok` sentinel (failure raises). On GitHub this is
   `gh pr review`; on `jira-patch` it is a JIRA comment (with the
   verdict encoded as a label transition); on `mail-patch` it is a
-  drafted reply through `contract:mail-draft` (never auto-sent).
+  drafted reply through `contract:mail-create` (never auto-sent).
 - **No-op case.** The `none` adapter raises `NotApplicable`; the
   skill falls back to surfacing the drafted review to the maintainer
   as copy-paste text.

--- a/tools/gmail/README.md
+++ b/tools/gmail/README.md
@@ -12,7 +12,7 @@
 
 # `tools/gmail/`
 
-**Capability:** contract:mail-source + contract:mail-draft + contract:mail-archive
+**Capability:** contract:mail-source + contract:mail-create + contract:mail-archive
 
 **Kind:** implementation
 
@@ -20,8 +20,11 @@
 
 Gmail API substrate. Read + draft-only — never sends. Provides two
 contracts: `mail-source` for inbound report intake (search / read a
-uniform thread/message view) and `mail-draft` for outbound courtesy-reply
-drafting. Used by the security-issue-import / sync / invalidate flows. See [`tool.md`](tool.md) for the operation catalogue and the per-area files for ASF relay routing, draft backends, threading, search queries.
+uniform thread/message view) and `mail-create` for outbound
+courtesy-reply composition. It implements only the `mail-create` **draft**
+mode: every message is created as an editable Gmail draft the user reviews,
+edits, and sends by hand — this backend never performs the `send` mode.
+Used by the security-issue-import / sync / invalidate flows. See [`tool.md`](tool.md) for the operation catalogue and the per-area files for ASF relay routing, draft backends, threading, search queries.
 
 ## Prerequisites
 

--- a/tools/mail-patch/README.md
+++ b/tools/mail-patch/README.md
@@ -42,7 +42,7 @@ framework already ships:
   (`tools/ponymail/` at the ASF) — thread search, thread fetch,
   participant extraction.
 - **Review replies** are drafted through
-  [`contract:mail-draft`](../gmail/) — the adapter never sends mail
+  [`contract:mail-create`](../gmail/) — the adapter never sends mail
   autonomously; `post_review` and `reject` produce a drafted reply the
   maintainer sends by hand.
 
@@ -54,12 +54,12 @@ reply on the thread.
 ## Prerequisites
 
 - **Runtime:** Bash — doc-only adapter; composes the `mail-archive`,
-  `mail-draft`, and `source-control` adapters, no local package.
+  `mail-create`, and `source-control` adapters, no local package.
 - **CLIs:** the mail-archive backend (PonyMail MCP at the ASF), the
-  mail-draft backend (Gmail draft API), and `svn` for the delegated
+  mail-create backend (Gmail draft API), and `svn` for the delegated
   `land`.
 - **Credentials / auth:** anonymous read for public `dev@` archives
-  (PonyMail); an authenticated mail-draft session to compose replies
+  (PonyMail); an authenticated mail-create session to compose replies
   (drafts only — never sends); and ASF committer credentials for the
   SVN commit that `land` delegates to `tools/asf-svn/`. As with
   `jira-patch`, the commit runs under the landing committer's identity
@@ -85,7 +85,7 @@ Each change-request verb resolves onto the mail surfaces as follows.
 | `list_open(filter)` | `mail-archive.list_recent_threads(dev-list, since)` filtered to `[PATCH]`-subject threads that have no terminal "applied"/"rejected" reply. One `proposal_summary` per open patch thread. |
 | `get(id)` | `mail-archive.fetch_thread_by_url(id)`; the `diff` is extracted from the first message's `[PATCH]` body or `.patch` attachment. `base` is the trunk from config; `commits` is `[]`; `mergeable` is `unknown` until an `svn patch --dry-run`. |
 | `get_discussion(id)` | The thread's reply chain, normalised to `{author, date, body, kind}`. A reply containing the configured approval token (`LGTM` / `+1`) maps to `kind: approval`. |
-| `post_review(id, verdict, body)` | **Drafts** a threaded reply via `contract:mail-draft` (`in-reply-to` the thread), never sends. The `verdict` shapes the reply's opening line (`+1`, `needs work`); the maintainer reviews and sends. |
+| `post_review(id, verdict, body)` | **Drafts** a threaded reply via `contract:mail-create` (`in-reply-to` the thread), never sends. The `verdict` shapes the reply's opening line (`+1`, `needs work`); the maintainer reviews and sends. |
 | `land(id, strategy)` | **Delegates to `contract:source-control`.** Extracts the patch via `get`, calls the source-control adapter's apply + commit (`svn patch <file>` then `svn commit` — see [`tools/asf-svn/source-control.md`](../asf-svn/source-control.md)), then drafts an "applied in rNNNNN, thanks!" reply on the thread. `strategy` is advisory — SVN lands a patch as one commit (`squash`). |
 | `reject(id, reason)` | Drafts a threaded reply carrying `reason`. **No commit** — the absence of a `land` is the rejection. Nothing is transitioned; the thread simply closes socially. |
 | `status(id)` | `checks: none` (a mail thread has no CI), `mergeable` from an `svn patch --dry-run`. Skills degrade the `checks` gate to advisory and fall back to a human-judgement prompt (the contract's `status` graceful-degradation path — this is the maximally-degraded backend). |
@@ -142,6 +142,6 @@ generic keys are the contract's.
 
 - Contract: [`tools/change-request/`](../change-request/)
 - Archive reads: [`tools/mail-archive/`](../mail-archive/) (ASF: [`tools/ponymail/`](../ponymail/))
-- Reply drafting: [`contract:mail-draft`](../gmail/)
+- Reply drafting: [`contract:mail-create`](../gmail/)
 - Delegated land: [`tools/asf-svn/source-control.md`](../asf-svn/source-control.md)
 - Issue: [#669](https://github.com/apache/magpie/issues/669)

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -278,7 +278,7 @@ TOOL_CAPABILITIES = {
     "contract:change-request",
     "contract:mail-archive",
     "contract:mail-source",
-    "contract:mail-draft",
+    "contract:mail-create",
     "contract:cve-authority",
     "contract:report-relay",
     "contract:scan-format",

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -2938,9 +2938,9 @@ class TestValidateAdapterAuthoring:
         root = _make_tools_root(tmp_path)
         tool = root / "tools" / "multi-cap"
         tool.mkdir()
-        # contract:mail-source + contract:mail-draft — should be checked
+        # contract:mail-source + contract:mail-create — should be checked
         (tool / "README.md").write_text(
-            "# multi-cap\n\n**Capability:** contract:mail-source + contract:mail-draft\n\n"
+            "# multi-cap\n\n**Capability:** contract:mail-source + contract:mail-create\n\n"
             "A dual-contract adapter.\n\n## Prerequisites\n\n- Something.\n"
         )
         violations = [v for v in validate_adapter_authoring(root) if v.category == ADAPTER_AUTHORING_CATEGORY]

--- a/tools/vendor-neutrality-score/src/vendor_neutrality_score/__init__.py
+++ b/tools/vendor-neutrality-score/src/vendor_neutrality_score/__init__.py
@@ -81,7 +81,11 @@ CONTRACT_POLICY: dict[str, tuple[str, str]] = {
     ),
     "contract:mail-archive": (VENDOR_BACKED, "Mailing-list / forum archive reads"),
     "contract:mail-source": (VENDOR_BACKED, "Inbound-mail ingestion (mbox / IMAP / …)"),
-    "contract:mail-draft": (VENDOR_BACKED, "Outbound mail composition (draft, never send)"),
+    "contract:mail-create": (
+        VENDOR_BACKED,
+        "Outbound mail composition — always an editable draft; sending is a separate "
+        "human-approved step (draft mode default; send mode declared, unimplemented)",
+    ),
     "contract:cve-authority": (VENDOR_BACKED, "CVE allocation / record management / publication"),
     "contract:report-relay": (AGNOSTIC, "Inbound security-report relay detection"),
     "contract:scan-format": (AGNOSTIC, "Security-scanner report parsing"),
@@ -118,7 +122,7 @@ CONTRACT_USAGE_TOKENS: dict[str, tuple[str, ...]] = {
         r"mcp__ponymail__",
         r"mcp__claude_ai_Gmail__(?:search_threads|get_thread|list_)",
     ),
-    "contract:mail-draft": (
+    "contract:mail-create": (
         r"mcp__claude_ai_Gmail__create_draft",
         r"\bcreate_draft\b",
     ),

--- a/tools/vendor-neutrality-score/tests/test_vendor_neutrality_score.py
+++ b/tools/vendor-neutrality-score/tests/test_vendor_neutrality_score.py
@@ -52,8 +52,8 @@ def test_vendor_backed_needs_two_distinct_vendors() -> None:
 
 
 def test_vendor_backed_single_vendor_is_not_green() -> None:
-    tools = [_tool("gmail", "contract:mail-draft", vns.IMPLEMENTATION, "Google")]
-    r = _result(vns.score_contracts(tools), "contract:mail-draft")
+    tools = [_tool("gmail", "contract:mail-create", vns.IMPLEMENTATION, "Google")]
+    r = _result(vns.score_contracts(tools), "contract:mail-create")
     assert r.green is False
     assert "needs 1 more" in r.basis
 
@@ -113,7 +113,7 @@ def _contract_results_with_gap() -> list[vns.ContractResult]:
     tools = [
         _tool("github", "contract:tracker", vns.IMPLEMENTATION, "GitHub"),
         _tool("jira", "contract:tracker", vns.IMPLEMENTATION, "Atlassian"),
-        _tool("gmail", "contract:mail-draft", vns.IMPLEMENTATION, "Google"),
+        _tool("gmail", "contract:mail-create", vns.IMPLEMENTATION, "Google"),
     ]
     return vns.score_contracts(tools)
 
@@ -172,7 +172,7 @@ def test_skill_vendor_coupled_on_sole_backend_contract() -> None:
     skills = [("reply", "ASF", "Draft a courtesy reply with mcp__claude_ai_Gmail__create_draft.")]
     (s,) = vns.score_skills(skills, _contract_results_with_gap())
     assert s.verdict == "vendor-coupled"
-    assert s.coupled == [("Google", "contract:mail-draft")]
+    assert s.coupled == [("Google", "contract:mail-create")]
 
 
 def test_prose_mention_is_not_usage() -> None:
@@ -191,7 +191,7 @@ def test_json_render_is_valid_and_complete() -> None:
     skills = vns.score_skills([("t", "agnostic", "gh pr view")], contracts)
     payload = json.loads(vns.render_json(contracts, skills))
     assert payload["overall"]["total"] == len(vns.CONTRACT_POLICY)
-    assert any(c["contract"] == "contract:mail-draft" and c["green"] is False for c in payload["contracts"])
+    assert any(c["contract"] == "contract:mail-create" and c["green"] is False for c in payload["contracts"])
 
 
 def test_markdown_render_contains_score_and_table() -> None:


### PR DESCRIPTION
## What

Renames `contract:mail-draft` → `contract:mail-create` and reframes
draft-only as an *optional mode* rather than the defining constraint of
the capability.

## Why

`mail-draft` baked Gmail's "draft, never send" framing into the contract
*name*. Generalising to `mail-create` ("compose an outbound message")
makes the capability backend-neutral: a non-Gmail "create an editable
draft" backend (local Maildir / `.eml`, SMTP-compose) now fits the
contract name naturally instead of fighting a Gmail-specific label. That
lowers the bar for the second backend that would flip this contract green
in the vendor-neutrality score.

## Semantics (unchanged safety posture)

- `create()` **always produces an editable draft** artefact.
- `mode=draft` is the default and the only mode any backend implements
  today; Gmail (the sole backend) never sends.
- `mode=send` is a **declared-but-unimplemented** future seam. Even a
  send-capable backend must surface the composed draft and require
  **explicit human approval** before anything leaves — no autonomous
  send. The framework's "human review is non-negotiable" invariant is
  preserved verbatim.

## Scope

Token renamed across both canonical registries — the vendor-neutrality
scorer's `CONTRACT_POLICY` and the validator's `TOOL_CAPABILITIES` —
their tests, all tool READMEs (`gmail`, `mail-patch`, `change-request`),
the capability docs (`labels-and-capabilities.md`), `RFC-AI-0005`, and
the `vendor-neutrality.md` prose; the generated score block was
regenerated.

**Not a gap-closer.** The contract stays ❌ (Google-only, "needs 1
more") — this is a rename + semantic reframe. A second backend is a
separate follow-up.

## Verification

- `vendor-neutrality-score` tests ✓
- `skill-and-tool-validator` tests ✓ + live validator exit 0
  (capability-sync clean: registry, labels doc, tool READMEs agree)
- pre-commit suite green (ruff, markdownlint, typos, lychee,
  skill-and-tool-validate)
