### PR TITLE
build(workspace): self-contained per-project mypy; run checks via uv --project + python -m

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,12 +42,15 @@ requires-python = ">=3.11"
 # - `prek` is the static-check / pre-commit runner. CI installs it
 #   via `uv sync --group dev` and invokes `uv run prek …`.
 # - `ruff`, `mypy`, `pytest` are the shared static-analysis +
-#   test toolchain used by every workspace member under `tools/`.
-#   They are declared once here (workspace-root) instead of being
-#   repeated in every member's `[dependency-groups] dev` block.
-#   `uv sync` at workspace root installs them into the shared
-#   workspace environment and `uv run --directory <member> <tool>`
-#   picks them up.
+#   test toolchain. They are declared here for root-level ad-hoc
+#   use AND, pinned to the same lower bounds, in every workspace
+#   member's own `[dependency-groups] dev` block — so each
+#   sub-project's environment is self-contained. The workspace
+#   checks run each tool against the member's own project via
+#   `uv run --directory <member> --project . …` (see
+#   `tools/dev/run-workspace-check.sh`), so a member is never
+#   dependent on tools leaking in from the shared root environment.
+#   Keep the version bounds here and in every member in lockstep.
 #
 # Lower bounds mirror what individual tools needed at their last
 # bump; the upper bound is enforced implicitly by the 7-day

--- a/tools/agent-guard/pyproject.toml
+++ b/tools/agent-guard/pyproject.toml
@@ -76,3 +76,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/agent-isolation/pyproject.toml
+++ b/tools/agent-isolation/pyproject.toml
@@ -36,3 +36,14 @@ packages = ["src/agent_isolation"]
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/cve-tool-vulnogram/generate-cve-json/pyproject.toml
+++ b/tools/cve-tool-vulnogram/generate-cve-json/pyproject.toml
@@ -85,3 +85,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/cve-tool-vulnogram/oauth-api/pyproject.toml
+++ b/tools/cve-tool-vulnogram/oauth-api/pyproject.toml
@@ -86,3 +86,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/dev/run-workspace-check.sh
+++ b/tools/dev/run-workspace-check.sh
@@ -76,21 +76,14 @@ shift 2
 # so it needs none of these itself.
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_COMMON_DIR GIT_PREFIX
 
-# On Apple Silicon Macs, git ships as x86_64 (Rosetta). Pre-commit hooks
-# invoked by git therefore run in an x86_64 context where universal Python
-# binaries also run as x86_64, which cannot load arm64-compiled extensions
-# (e.g. mypy .so files, cffi, cryptography). Probe for this condition at
-# runtime: if the workspace venv Python runs as x86_64 but arch -arm64 can
-# switch it to arm64, prefer the native arm64 path for Python-based checks.
-_NATIVE_PYTHON=""
-_VENV_PYTHON="$(pwd)/.venv/bin/python3"
-if [[ -x "$_VENV_PYTHON" ]]; then
-  _CURR_ARCH=$("$_VENV_PYTHON" -c "import platform; print(platform.machine())" 2>/dev/null || echo "")
-  _ARM64_ARCH=$(arch -arm64 "$_VENV_PYTHON" -c "import platform; print(platform.machine())" 2>/dev/null || echo "")
-  if [[ "$_CURR_ARCH" == "x86_64" ]] && [[ "$_ARM64_ARCH" == "arm64" ]]; then
-    _NATIVE_PYTHON="arch -arm64 $_VENV_PYTHON"
-  fi
-fi
+# Every check runs through `uv` against the member's own project — never a
+# bare interpreter — so the tool version comes from that sub-project's
+# pyproject.toml + dev group (see each member's `[dependency-groups] dev`).
+# mypy and pytest are invoked as `python -m <tool>` rather than via their
+# console scripts: a console script bakes an absolute interpreter path into
+# its shebang, which breaks when the shared workspace venv is reused across
+# repos (a stale `#!/…/other-repo/.venv/bin/python3` fails to spawn). The
+# `-m` form resolves the tool from the live interpreter and sidesteps that.
 
 # Discover workspace members + per-check applicability. The Python
 # helper walks the root `[tool.uv.workspace] members` list, opens
@@ -171,18 +164,20 @@ echo "→ workspace-check: ${CHECK_KEY} (${CHECK_CMD} $*) across ${count} member
 failed=()
 for member in $applicable; do
   name=$(basename "$member")
-  # `uv run --directory` so each member runs with its own `cwd` —
-  # ruff / mypy / pytest configs resolve paths relative to the
-  # member root.
-  # On Apple Silicon + Rosetta, use native arm64 Python for Python-based
-  # checks to avoid loading arm64 extensions from an x86_64 Python process.
-  # Ruff is a Rust binary that already runs natively so no prefix is needed.
+  # Run every check via uv, against the member's own project:
+  #   --directory "$member"  → cwd is the member, so ruff / mypy / pytest
+  #                            configs resolve paths relative to the member root
+  #   --project .            → the environment is that member's project (its
+  #                            pyproject.toml + dev group), resolved after the
+  #                            --directory chdir
+  # mypy and pytest go through `python -m` to bypass console-script shebangs;
+  # ruff is a native binary with no interpreter shebang, so it runs directly.
   # shellcheck disable=SC2086 # CHECK_CMD may legitimately be multi-token
-  if [[ -n "$_NATIVE_PYTHON" ]] && [[ "$CHECK_KEY" != "ruff" ]] && [[ "$CHECK_KEY" != "ruff-format" ]]; then
-    if ! (cd "$member" && $_NATIVE_PYTHON -m $CHECK_CMD "$@"); then
+  if [[ "$CHECK_KEY" == "mypy" ]] || [[ "$CHECK_KEY" == "pytest" ]]; then
+    if ! uv run --directory "$member" --project . python -m $CHECK_CMD "$@"; then
       failed+=("$name")
     fi
-  elif ! uv run --directory "$member" $CHECK_CMD "$@"; then
+  elif ! uv run --directory "$member" --project . $CHECK_CMD "$@"; then
     failed+=("$name")
   fi
 done

--- a/tools/egress-gateway/pyproject.toml
+++ b/tools/egress-gateway/pyproject.toml
@@ -67,7 +67,7 @@ testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
-  "pytest>=8.0",
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
   "ruff>=0.15.18",
-  "mypy>=1.11",
 ]

--- a/tools/github-body-field/pyproject.toml
+++ b/tools/github-body-field/pyproject.toml
@@ -79,3 +79,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/github-rollup/pyproject.toml
+++ b/tools/github-rollup/pyproject.toml
@@ -65,3 +65,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/gmail/oauth-draft/pyproject.toml
+++ b/tools/gmail/oauth-draft/pyproject.toml
@@ -93,3 +93,14 @@ ignore_missing_imports = true
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/jira/pyproject.toml
+++ b/tools/jira/pyproject.toml
@@ -48,3 +48,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/permission-audit/pyproject.toml
+++ b/tools/permission-audit/pyproject.toml
@@ -68,3 +68,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/pilot-report-validator/pyproject.toml
+++ b/tools/pilot-report-validator/pyproject.toml
@@ -48,8 +48,9 @@ ignore = ["E501"]
 
 [dependency-groups]
 dev = [
-  "pytest>=8.0",
-  "ruff>=0.4",
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
 ]
 
 [tool.pytest.ini_options]

--- a/tools/pr-management-stats/pyproject.toml
+++ b/tools/pr-management-stats/pyproject.toml
@@ -35,3 +35,14 @@ testpaths = ["tests"]
 # `uv run pytest` (matching how the scripts find each other at runtime). "tests"
 # is added so the shared `helpers` fixture module is importable.
 pythonpath = [".", "tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/preflight-audit/pyproject.toml
+++ b/tools/preflight-audit/pyproject.toml
@@ -78,3 +78,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/privacy-llm/checker/pyproject.toml
+++ b/tools/privacy-llm/checker/pyproject.toml
@@ -79,3 +79,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/privacy-llm/redactor/pyproject.toml
+++ b/tools/privacy-llm/redactor/pyproject.toml
@@ -82,3 +82,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/sandbox-lint/pyproject.toml
+++ b/tools/sandbox-lint/pyproject.toml
@@ -79,3 +79,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/security-tracker-stats-dashboard/pyproject.toml
+++ b/tools/security-tracker-stats-dashboard/pyproject.toml
@@ -53,5 +53,7 @@ testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
-    "pytest>=9.1.1",
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
 ]

--- a/tools/skill-and-tool-validator/pyproject.toml
+++ b/tools/skill-and-tool-validator/pyproject.toml
@@ -83,7 +83,7 @@ testpaths = ["tests"]
 
 [dependency-groups]
 dev = [
+  "mypy>=2.1.0",
   "pytest>=9.1.1",
   "ruff>=0.15.18",
-  "mypy>=2.1.0",
 ]

--- a/tools/skill-evals/pyproject.toml
+++ b/tools/skill-evals/pyproject.toml
@@ -46,3 +46,14 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 minversion = "8.0"
 addopts = "-ra -q"
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/spec-status-index/pyproject.toml
+++ b/tools/spec-status-index/pyproject.toml
@@ -78,3 +78,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/spec-validator/pyproject.toml
+++ b/tools/spec-validator/pyproject.toml
@@ -48,7 +48,8 @@ ignore = ["E501"]
 
 [dependency-groups]
 dev = [
-  "pytest>=8.0",
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
   "ruff>=0.15.18",
 ]
 

--- a/tools/symlink-lint/pyproject.toml
+++ b/tools/symlink-lint/pyproject.toml
@@ -79,3 +79,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/vcs/pyproject.toml
+++ b/tools/vcs/pyproject.toml
@@ -79,3 +79,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/tools/vendor-neutrality-score/pyproject.toml
+++ b/tools/vendor-neutrality-score/pyproject.toml
@@ -78,3 +78,14 @@ disallow_incomplete_defs = false
 minversion = "8.0"
 addopts = "-ra -q"
 testpaths = ["tests"]
+
+[dependency-groups]
+# Shared static-analysis + test toolchain, pinned to the same versions as the
+# workspace root so every sub-project's own environment is self-contained.
+# The workspace checks run each tool via `uv run --directory <member>
+# --project . python -m <tool>` — see tools/dev/run-workspace-check.sh.
+dev = [
+  "mypy>=2.1.0",
+  "pytest>=9.1.1",
+  "ruff>=0.15.18",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -44,10 +44,42 @@ name = "agent-guard"
 version = "0.1.0"
 source = { editable = "tools/agent-guard" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "agent-isolation"
 version = "0.1.0"
 source = { editable = "tools/agent-isolation" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "apache-magpie"
@@ -285,6 +317,22 @@ name = "checker"
 version = "0.1.0"
 source = { editable = "tools/privacy-llm/checker" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "colorama"
 version = "0.4.6"
@@ -373,8 +421,8 @@ requires-dist = [{ name = "proxy-py", specifier = ">=2.4,<3" }]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=1.11" },
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.18" },
 ]
 
@@ -383,15 +431,63 @@ name = "generate-cve-json"
 version = "0.1.0"
 source = { editable = "tools/cve-tool-vulnogram/generate-cve-json" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "github-body-field"
 version = "0.1.0"
 source = { editable = "tools/github-body-field" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "github-rollup"
 version = "0.1.0"
 source = { editable = "tools/github-rollup" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "google-auth"
@@ -441,6 +537,22 @@ wheels = [
 name = "jira-bridge"
 version = "0.1.0"
 source = { editable = "tools/jira" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "librt"
@@ -520,6 +632,22 @@ name = "magpie-vcs"
 version = "0.1.0"
 source = { editable = "tools/vcs" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "mypy"
 version = "2.1.0"
@@ -588,8 +716,22 @@ dependencies = [
     { name = "google-auth-oauthlib" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
 [package.metadata]
 requires-dist = [{ name = "google-auth-oauthlib", specifier = ">=1.4.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "oauthlib"
@@ -623,13 +765,9 @@ name = "permission-audit"
 version = "0.1.0"
 source = { editable = "tools/permission-audit" }
 
-[[package]]
-name = "pilot-report-validator"
-version = "0.1.0"
-source = { editable = "tools/pilot-report-validator" }
-
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -638,8 +776,30 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "ruff", specifier = ">=0.4" },
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
+[[package]]
+name = "pilot-report-validator"
+version = "0.1.0"
+source = { editable = "tools/pilot-report-validator" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
 ]
 
 [[package]]
@@ -656,10 +816,42 @@ name = "pr-management-stats"
 version = "0.1.0"
 source = { virtual = "tools/pr-management-stats" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "preflight-audit"
 version = "0.1.0"
 source = { editable = "tools/preflight-audit" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "prek"
@@ -754,6 +946,22 @@ name = "redactor"
 version = "0.1.0"
 source = { editable = "tools/privacy-llm/redactor" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "requests"
 version = "2.34.2"
@@ -812,6 +1020,22 @@ name = "sandbox-lint"
 version = "0.1.0"
 source = { editable = "tools/sandbox-lint" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "security-tracker-stats-dashboard"
 version = "0.1.0"
@@ -819,13 +1043,19 @@ source = { editable = "tools/security-tracker-stats-dashboard" }
 
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=9.1.1" }]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "skill-and-tool-validator"
@@ -853,18 +1083,9 @@ name = "skill-evals"
 version = "0.1.0"
 source = { editable = "tools/skill-evals" }
 
-[[package]]
-name = "spec-status-index"
-version = "0.1.0"
-source = { editable = "tools/spec-status-index" }
-
-[[package]]
-name = "spec-validator"
-version = "0.1.0"
-source = { editable = "tools/spec-validator" }
-
 [package.dev-dependencies]
 dev = [
+    { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
 ]
@@ -873,7 +1094,50 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=8.0" },
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
+[[package]]
+name = "spec-status-index"
+version = "0.1.0"
+source = { editable = "tools/spec-status-index" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
+[[package]]
+name = "spec-validator"
+version = "0.1.0"
+source = { editable = "tools/spec-validator" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.18" },
 ]
 
@@ -881,6 +1145,22 @@ dev = [
 name = "symlink-lint"
 version = "0.1.0"
 source = { editable = "tools/symlink-lint" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
 
 [[package]]
 name = "typing-extensions"
@@ -905,7 +1185,39 @@ name = "vendor-neutrality-score"
 version = "0.1.0"
 source = { editable = "tools/vendor-neutrality-score" }
 
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]
+
 [[package]]
 name = "vulnogram-api"
 version = "0.1.0"
 source = { editable = "tools/cve-tool-vulnogram/oauth-api" }
+
+[package.dev-dependencies]
+dev = [
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "pytest", specifier = ">=9.1.1" },
+    { name = "ruff", specifier = ">=0.15.18" },
+]


### PR DESCRIPTION
## What

Makes every uv-workspace sub-project self-contained for static analysis
and tests, and fixes the `workspace-mypy` pre-commit hook that could not
find `mypy`.

## Why the mypy hook was broken

`run-workspace-check.sh` invoked `uv run --directory <member> mypy`, but
only two members declared mypy (at two different versions), so the tool
was expected to leak in from the shared root venv. It didn't reliably:
the `mypy` **console script** in the shared venv had a shebang pointing
at *another repo's* venv (`#!/…/airflow-steward/.venv/bin/python3`), so
exec'ing it failed with ENOENT — while `python -m mypy` worked fine.

## Changes

- **mypy in every member's `[dependency-groups] dev`**, unified at
  `>=2.1.0` (same lower bound as the workspace root). pytest (`>=9.1.1`)
  and ruff (`>=0.15.18`) are declared alongside it so each sub-project's
  environment is complete on its own — no dependence on tools leaking in
  from the shared root venv.
- **`run-workspace-check.sh` runs every check through uv against the
  member's own project:** `uv run --directory <member> --project . …`
  — `--directory` sets cwd (so ruff/mypy/pytest find the member's
  config), `--project .` selects that member's environment.
- **mypy and pytest run as `python -m <tool>`**, bypassing the
  console-script shebang so a stale cross-repo interpreter path can
  never break them again.
- **Drops the Apple-Silicon `_NATIVE_PYTHON` arch shim** — `uv run`
  already resolves a native interpreter, and `python -m` removed the
  console-script failure the shim worked around.
- Root `pyproject.toml` comment updated; root + standalone member
  lockfiles regenerated.

## Verification

Full pre-commit suite green, including the previously-failing hook:

```
ruff check (workspace) ......... Passed
ruff format (workspace) ........ Passed
mypy (workspace) ............... Passed   (18 applicable members)
pytest (workspace) ............. Passed   (24 applicable members)
```
