### PR TITLE
Count pr-body folded triage notes in pr-management-stats

### DIFF
--- a/tools/pr-management-stats/dashboard.py
+++ b/tools/pr-management-stats/dashboard.py
@@ -71,10 +71,12 @@ from reference import (
     compute_weekly_velocity,
     fetch_codeowners,
     fetch_ready_pr_files,
+    fold_triaged_at,
     is_backport,
     is_bot,
     paginated_search,
     parse_iso,
+    triage_marker_events,
     weeks_buckets,
 )
 
@@ -793,22 +795,17 @@ def compute_ready_queue_cumulative(open_prs, weeks):
 
 
 def compute_triage_velocity(all_prs, weeks, ctx):
-    """2-line: AI-drafted, manual QC marker — by first QC-comment week."""
+    """2-line: AI-drafted, manual — by first-triage week across BOTH channels
+    (collaborator QC comments AND the pr-body fold block)."""
     out = []
     for s, e in weeks:
         b = {"start": s, "end": e, "ai": 0, "manual": 0}
         for pr in all_prs:
-            first_qc = None
-            is_ai = False
-            for c in (pr.get("comments", {}) or {}).get("nodes", []) or []:
-                if c.get("authorAssociation") not in COLLAB_ASSOCIATIONS:
-                    continue
-                if ctx["triage_marker"] in (c.get("body") or ""):
-                    at = parse_iso(c["createdAt"])
-                    if first_qc is None or at < first_qc:
-                        first_qc = at
-                        is_ai = ctx["ai_footer"] in (c.get("body") or "")
-            if first_qc and s <= first_qc < e:
+            events = triage_marker_events(pr, ctx)
+            if not events:
+                continue
+            first_qc, is_ai = min(events, key=lambda ev: ev[0])
+            if s <= first_qc < e:
                 if is_ai:
                     b["ai"] += 1
                 else:
@@ -945,6 +942,17 @@ def compute_triager_activity(open_prs, closed_prs, weeks, ctx):
                     else:
                         activity[author][idx]["manual"].add(pr_num)
                     break
+        # pr-body fold channel: credit the folded triage note to its operator
+        # (the `by @login` in the note header), always AI, at the fold time.
+        fat = fold_triaged_at(pr)
+        if fat:
+            om = re.search(r"by `@([A-Za-z0-9-]+)`", pr.get("body") or "")
+            operator = om.group(1) if om else None
+            if operator and not is_bot(operator):
+                for idx, (s, e) in enumerate(weeks):
+                    if s <= fat < e:
+                        activity[operator][idx]["ai"].add(pr_num)
+                        break
     rows = []
     for login, per_week in activity.items():
         totals_ai = set().union(*[w["ai"] for w in per_week])
@@ -2292,7 +2300,7 @@ def main():
     # ---- Aggregate ----
     print("Aggregating ...", file=sys.stderr)
     hero = compute_hero_counts(open_prs)
-    weekly = compute_weekly_velocity(closed_prs, ctx["weeks"], args.triage_marker)
+    weekly = compute_weekly_velocity(closed_prs, ctx["weeks"], ctx)
     pressure = compute_pressure_by_area(open_prs, args.area_prefix)
     ready_trend = compute_ready_trend_by_area(
         open_prs, ctx["weeks"], pressure, args.area_prefix

--- a/tools/pr-management-stats/reference.py
+++ b/tools/pr-management-stats/reference.py
@@ -128,7 +128,7 @@ query($q: String!, $first: Int!, $after: String) {
     pageInfo { hasNextPage endCursor }
     nodes {
       ... on PullRequest {
-        number title isDraft createdAt updatedAt
+        number title isDraft createdAt updatedAt body
         author { login __typename } authorAssociation
         baseRefName reviewDecision
         labels(first: 20) { nodes { name } }
@@ -169,7 +169,7 @@ query($q: String!, $first: Int!, $after: String) {
     pageInfo { hasNextPage endCursor }
     nodes {
       ... on PullRequest {
-        number title isDraft createdAt closedAt mergedAt merged state
+        number title isDraft createdAt closedAt mergedAt merged state body
         author { login __typename } authorAssociation
         baseRefName
         labels(first: 20) { nodes { name } }
@@ -318,6 +318,42 @@ def fetch_codeowners(repo):
 # Classification — see classify.md
 # --------------------------------------------------------------------------
 
+_FOLD_TRIAGED_RE = re.compile(r"<!--\s*pr-triage-fold:\s*triaged=(\S+)")
+
+
+def fold_triaged_at(pr):
+    """Timestamp of the pr-body fold triage note, or None.
+
+    The default ``pr-body`` feedback channel folds the triage marker into the
+    PR *description* as a ``<!-- pr-triage-fold: triaged=<ISO> ... -->`` block
+    rather than posting a comment. A comment-only marker scan is blind to it,
+    so every folded triage note goes uncounted -- the bug this fixes. A fold is
+    always AI-drafted (it is written by the automated triage tool)."""
+    m = _FOLD_TRIAGED_RE.search(pr.get("body") or "")
+    return parse_iso(m.group(1)) if m else None
+
+
+def triage_marker_events(pr, ctx):
+    """All triage-marker occurrences across BOTH feedback channels.
+
+    Returns ``(at, is_ai)`` tuples -- one per collaborator comment carrying the
+    QC marker (``comment`` channel) plus one for the pr-body fold block
+    (``pr-body`` channel, always AI). Empty when the PR was never triaged in
+    either channel. The single source of truth for "is this PR triaged, when,
+    and by which channel" -- classification and every velocity metric route
+    through it so the fold channel is never invisible again."""
+    events = []
+    for c in (pr.get("comments", {}) or {}).get("nodes", []) or []:
+        if c.get("authorAssociation") in COLLAB_ASSOCIATIONS and ctx["triage_marker"] in c.get("body", ""):
+            at = parse_iso(c.get("createdAt"))
+            if at:
+                events.append((at, ctx["ai_footer"] in c.get("body", "")))
+    fat = fold_triaged_at(pr)
+    if fat:
+        events.append((fat, True))
+    return events
+
+
 def classify(pr, ctx, *, partial=False):
     """Annotate a PR node in place with `_`-prefixed classification fields.
 
@@ -349,14 +385,11 @@ def classify(pr, ctx, *, partial=False):
         and not is_bot(c["author"]["login"] if c["author"] else None)
         for c in pr["comments"]["nodes"]
     )
-    has_qc_marker = any(
-        c.get("authorAssociation") in COLLAB_ASSOCIATIONS and ctx["triage_marker"] in c.get("body", "")
-        for c in pr["comments"]["nodes"]
-    )
-    has_ai_footer = any(
-        c.get("authorAssociation") in COLLAB_ASSOCIATIONS and ctx["ai_footer"] in c.get("body", "")
-        for c in pr["comments"]["nodes"]
-    )
+    # Triage marker across BOTH channels: collaborator comments (comment
+    # channel) AND the pr-body fold block (pr-body channel, the default).
+    triage_events = triage_marker_events(pr, ctx)
+    has_qc_marker = bool(triage_events)
+    has_ai_footer = any(is_ai for _, is_ai in triage_events)
     has_review = any(
         r.get("author", {}).get("login") and not is_bot(r["author"]["login"])
         for r in (pr.get("latestReviews", {}).get("nodes") or [])
@@ -401,14 +434,8 @@ def classify(pr, ctx, *, partial=False):
         and not pr["_has_ready"]
     )
 
-    # Triage timestamp + responded
-    triage_at = None
-    if has_qc_marker:
-        for c in pr["comments"]["nodes"]:
-            if c.get("authorAssociation") in COLLAB_ASSOCIATIONS and ctx["triage_marker"] in c.get("body", ""):
-                at = parse_iso(c["createdAt"])
-                if triage_at is None or at > triage_at:
-                    triage_at = at
+    # Triage timestamp + responded -- latest marker across both channels
+    triage_at = max((at for at, _ in triage_events), default=None)
     pr["_triage_at"] = triage_at
 
     responded = False
@@ -437,7 +464,7 @@ def weeks_buckets(now, weeks=6):
             for i in range(weeks)]
 
 
-def compute_weekly_velocity(closed_prs, weeks, triage_marker):
+def compute_weekly_velocity(closed_prs, weeks, ctx):
     out = []
     for s, e in weeks:
         b = {"start": s, "end": e, "merged": 0, "closed_not_merged": 0,
@@ -446,13 +473,10 @@ def compute_weekly_velocity(closed_prs, weeks, triage_marker):
             ca = parse_iso(pr.get("closedAt"))
             if not ca or not (s <= ca < e):
                 continue
-            has_triage = False
-            t_at = None
-            for c in pr["comments"]["nodes"]:
-                if c.get("authorAssociation") in COLLAB_ASSOCIATIONS and triage_marker in c.get("body", ""):
-                    has_triage = True
-                    t_at = parse_iso(c["createdAt"])
-                    break
+            # Triage across both channels (comments + pr-body fold)
+            events = triage_marker_events(pr, ctx)
+            has_triage = bool(events)
+            t_at = min((at for at, _ in events), default=None)
             responded = False
             if has_triage and t_at:
                 for c in pr["comments"]["nodes"]:

--- a/tools/pr-management-stats/tests/test_aggregations.py
+++ b/tools/pr-management-stats/tests/test_aggregations.py
@@ -145,9 +145,43 @@ def test_weekly_velocity_counts_merged_and_closed():
         make_pr(31, assoc="NONE", created_days_ago=20, closed_days_ago=3,
                 merged=False, include_engagement=False),
     ]
-    weekly = reference.compute_weekly_velocity(closed, ctx["weeks"], ctx["triage_marker"])
+    weekly = reference.compute_weekly_velocity(closed, ctx["weeks"], ctx)
 
     assert len(weekly) == 6
     assert sum(w["merged"] for w in weekly) == 1
     assert sum(w["closed_not_merged"] for w in weekly) == 1
     assert sum(w["merged_triaged"] for w in weekly) == 1
+
+
+def test_fold_channel_triage_is_counted():
+    """A PR triaged via the pr-body fold block (no QC comment) must count as
+    triaged + AI-drafted across classify, triage-velocity, and weekly-velocity
+    — the regression that made recent-week triage velocity read as zero once
+    the pr-body channel became the default."""
+    from datetime import timedelta
+
+    ctx = make_ctx()
+    now = ctx["now"]
+    triaged_iso = (now - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    fold_body = (
+        f"Original description.\n\n"
+        f"<!-- pr-triage-fold: triaged={triaged_iso} head=abc1234 action=comment -->\n"
+        f"> Maintainer triage note for @alice · by `@potiuk`\n"
+        f"> see the {QC}\n"
+        f"<!-- /pr-triage-fold -->"
+    )
+    # No collaborator QC *comment* — the marker lives only in the body fold.
+    pr = make_pr(50, assoc="NONE", created_days_ago=10, comments=[])
+    pr["body"] = fold_body
+
+    reference.classify(pr, ctx)
+    assert pr["_is_triaged"] is True
+    assert pr["_has_ai_footer"] is True  # a fold is always AI-drafted
+    assert pr["_triage_at"] is not None
+
+    events = reference.triage_marker_events(pr, ctx)
+    assert len(events) == 1 and events[0][1] is True
+
+    vel = dashboard.compute_triage_velocity([pr], ctx["weeks"], ctx)
+    assert sum(w["ai"] for w in vel) == 1
+    assert sum(w["manual"] for w in vel) == 0


### PR DESCRIPTION
The default triage feedback channel is `pr-body`: the QC triage marker is
folded into the PR *description* as a `<!-- pr-triage-fold: triaged=<ISO> ... -->`
block, not posted as a comment. But the stats tool only scanned collaborator
*comments* for the marker (and never even fetched the PR body), so every folded
triage note was invisible. Once the pr-body channel became the default, triage
velocity read near-zero for recent weeks and `_is_triaged` / `_has_ai_footer` /
triage-coverage / triager-activity all under-counted.

Fetch the PR `body` in both queries and add a single cross-channel helper,
`triage_marker_events`, returning every marker occurrence (collaborator QC
comments + the pr-body fold block, the latter always AI-drafted). Route
`classify`, `compute_weekly_velocity`, `compute_triage_velocity`, and
`compute_triager_activity` through it so neither channel is ever invisible again.

Verified against apache/airflow: AI-triaged **68 → 121**, and the
triage-velocity chart now populates the recent weeks it previously read as empty.
New regression test `test_fold_channel_triage_is_counted`; full suite green.
