### PR TITLE
docs(prerequisites): make the prerequisites vendor-neutral (agent, LLM, mail, tracker)

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -4,9 +4,9 @@
 
 - [Prerequisites for running framework skills](#prerequisites-for-running-framework-skills)
   - [Prerequisites for running the agent skills](#prerequisites-for-running-the-agent-skills)
-    - [1. An agent that speaks the `SKILL.md` convention](#1-an-agent-that-speaks-the-skillmd-convention)
-    - [2. Email connection (Gmail MCP, today)](#2-email-connection-gmail-mcp-today)
-    - [3. GitHub connection (GitHub MCP / `gh` CLI)](#3-github-connection-github-mcp--gh-cli)
+    - [1. An agentic tool + access to an LLM](#1-an-agentic-tool--access-to-an-llm)
+    - [2. A mail backend (read + draft — Gmail is one option, not the only one)](#2-a-mail-backend-read--draft--gmail-is-one-option-not-the-only-one)
+    - [3. A tracker + change-request backend (GitHub by default — not required)](#3-a-tracker--change-request-backend-github-by-default--not-required)
     - [4. PMC membership (only for CVE allocation)](#4-pmc-membership-only-for-cve-allocation)
     - [5. Browser (for the human-click steps)](#5-browser-for-the-human-click-steps)
     - [6. Local `<upstream>` clone (only for `security-issue-fix`)](#6-local-upstream-clone-only-for-security-issue-fix)
@@ -41,39 +41,83 @@ runs a short Step 0 pre-flight against the same list and stops with a
 clear message if something is missing, so you do not discover a
 missing piece half-way through a workflow.
 
-### 1. An agent that speaks the `SKILL.md` convention
+### 1. An agentic tool + access to an LLM
 
-[Claude Code](https://www.anthropic.com/claude-code) is the reference
-implementation the skills are written against. Any agent that reads
-the `.claude/skills/*/SKILL.md` files and follows their step-by-step
-instructions should work; there is no hard dependency on Claude Code
-specifically. Note that Claude Code requires a subscription; the free
-version cannot be used to power Magpie. Other providers may offer a
-free agent that can be used with Magpie.
+Running Magpie needs two things: an **agentic coding tool** that speaks
+the `SKILL.md` / [`AGENTS.md`](https://agents.md/) skill convention, and
+**access to an LLM** for that tool to drive. There is no hard dependency
+on any single vendor for either — any agent that reads the shared
+`.agents/skills/*/SKILL.md` files and follows their steps should work.
+
+**Agentic tool — two are fully supported today:**
+
+- **[OpenCode](https://opencode.ai/)** is the **reference implementation**:
+  it is open source and model-agnostic, so it can drive *every* LLM-access
+  option below.
+- **[Claude Code](https://www.anthropic.com/claude-code)** is a second
+  complete implementation, powered by Anthropic subscriptions — the paid
+  plans, or the free tier Anthropic often grants to open-source
+  maintainers.
+
+Support for more runtimes (Codex, Gemini CLI, Cursor, Copilot, …) is
+tracked in the
+[open adapter issues](https://github.com/apache/magpie/issues?q=is%3Aissue%20is%3Aopen%20adapter).
+
+**Access to an LLM — any one of these works:**
+
+- a **paid LLM subscription** (e.g. Anthropic, for Claude Code);
+- a **free subscription** — several providers grant free or discounted
+  access to open-source maintainers;
+- an **organisation-hosted LLM** — for example the planned
+  [`llm.apache.org`](https://llm.apache.org) endpoint for ASF projects;
+- an **open-weight model** — hosted on a provider of your choice, or run
+  **locally** (Ollama, llama.cpp, vLLM) for sovereign or air-gapped use.
+
+Because **OpenCode is model-agnostic it is the reference tool — it allows
+all of the above**; Claude Code is the complete alternative for the
+Anthropic-subscription paths. That is also the concrete answer to *"what
+does an LLM or agent need to provide to be usable with Magpie?"*: an agent
+on the `SKILL.md` / `AGENTS.md` convention, plus any one of the LLM-access
+paths above.
 
 The agent runs against pre-disclosure CVE content (private mail
 threads, draft advisories, in-flight tracker discussions). Run it
 with the credential-isolation setup documented in
 [`docs/setup/secure-agent-setup.md`](setup/secure-agent-setup.md) — a layered
-defence built around Claude Code's filesystem sandbox, tool-level
-permission rules, and a clean-env wrapper that strips credential-
-shaped variables from the agent's environment. The required system
-tools (`bubblewrap`, `socat`, `claude-code` itself) are pinned with
-a 7-day upstream-release cooldown, mirroring the same convention the
+defence built around the agent's filesystem sandbox, tool-level
+permission rules, and a harness-neutral clean-env wrapper
+(`agent-iso.sh`, exposing both a `claude-iso` and an `opencode-iso`
+launcher) that strips credential-shaped variables from the agent's
+environment. The permission + sandbox posture is enforced for both
+harnesses — a `PreToolUse` hook / `tool.execute.before` plugin
+(`agent-guard`), plus `permission-audit` / `sandbox-lint` for the
+Claude `settings.json` and OpenCode `opencode.json` policies. The
+required system tools (`bubblewrap`, `socat`, and the agent CLI
+itself — `claude-code` or `opencode`) are pinned with a 7-day
+upstream-release cooldown, mirroring the same convention the
 framework uses for its `[tool.uv] exclude-newer` and Dependabot
 configs.
 
-### 2. Email connection (Gmail MCP, today)
+### 2. A mail backend (read + draft — Gmail is one option, not the only one)
 
 The import, sync, and security-cve-allocate skills **read the security-list
-mail thread** associated with each tracker and draft replies on that
-thread. Today this goes through the
-[Claude Gmail MCP](https://docs.anthropic.com/en/docs/build-with-claude/mcp)
-connected to the personal Gmail account of a security-team member
-who is subscribed to the adopting project's security list (see
-`<project-config>/project.md → Mailing lists`). That is enough
-access for the skills to see inbound reports and create drafts on
-the right threads.
+mail thread** for each tracker and **draft replies** on it. Both sides are
+vendor-neutral contracts — `contract:mail-source` / `contract:mail-archive`
+for reads and `contract:mail-create` for drafts — so **Gmail is one
+backend, not a requirement:**
+
+- **Read** backends: the
+  [Claude Gmail MCP](https://docs.anthropic.com/en/docs/build-with-claude/mcp)
+  (a security-team member's Gmail subscribed to the list), the ASF
+  **PonyMail** MCP (below), or a **local mbox / Maildir archive** for
+  offline / forensic triage
+  ([`tools/mail-source/mbox`](../tools/mail-source/mbox/README.md)).
+- **Draft** backends: Gmail, or the offline local **Maildir** backend
+  (below).
+
+The ASF-default setup is described next; a project on a different mail
+stack declares its own backends in
+`<project-config>/project.md → Mail sources`.
 
 There is now an official ASF alternative for the **read** side:
 [`apache/comdev`'s `mcp/ponymail-mcp/`](https://github.com/apache/comdev/tree/main/mcp/ponymail-mcp)
@@ -84,9 +128,20 @@ OAuth and can read private ASF lists. Individual triagers can wire
 it up to read inbound `security@<project>.apache.org` threads
 without subscribing a personal Gmail account — see
 [`tools/ponymail/tool.md`](../tools/ponymail/tool.md) for the
-setup. **Drafts remain Gmail-only** today (PonyMail MCP is
-read-only and has no `create_draft` equivalent), so Gmail MCP is
-still required for the reply path.
+setup. (PonyMail MCP is read-only — it has no `create_draft`
+equivalent — so it covers the archive **read** side only.)
+
+On the **draft (reply)** side, Gmail is no longer the only option.
+Alongside the Gmail backend, Magpie now ships a local
+[**Maildir** draft backend](../tools/maildir/) (`contract:mail-create`,
+vendor `Maildir`): it composes an editable RFC 5322 message into a
+local Maildir with **no cloud account, no credentials and no
+network**, and any Maildir-aware mail client (Thunderbird, mutt,
+Evolution, …) picks it up to review, edit and send. So the reply
+path no longer requires Gmail — Gmail stays the default where a
+triager already reads the list there, and the offline Maildir
+backend covers everyone else. Like every `contract:mail-create`
+backend, both only ever create drafts; a human sends.
 
 **For ASF projects the PonyMail MCP is a mandatory prerequisite,
 not an opt-in backstop.** The reference adopter's manifest declares
@@ -94,8 +149,10 @@ not an opt-in backstop.** The reference adopter's manifest declares
 [`<project-config>/project.md → Mail sources`](<project-config>/project.md#mail-sources)),
 so the mail-reading skills that run the Step 0 mail-source check
 (`security-issue-import`, `security-issue-sync`) **refuse to start**
-if it is not installed and reachable — Gmail keeps the `primary`
-role for drafts, but PonyMail must also be present. (Skills that
+if it is not installed and reachable — the configured
+`contract:mail-create` backend (Gmail by default, or the offline
+Maildir backend) handles the drafts, but PonyMail must also be
+present for the read side. (Skills that
 only read a single Gmail thread opportunistically, such as
 `security-cve-allocate`, do not hard-gate on it.) Install it from the **latest `main`** of `apache/comdev`
 (the MCP servers ship as in-repo source with no tagged releases —
@@ -109,20 +166,31 @@ reports, `security-issue-sync` cannot reconcile status with the mail
 thread, and no skill can draft replies to reporters. The skills will
 refuse to start and tell you to configure the MCP first.
 
-### 3. GitHub connection (GitHub MCP / `gh` CLI)
+### 3. A tracker + change-request backend (GitHub by default — not required)
 
-Every skill reads and writes `<tracker>` issues. Claude Code ships
-with the GitHub MCP by default, and the skills also use the `gh`
-CLI directly for some calls. What the skills need:
+Every skill reads and writes issues on the project's **tracker**, and the
+`pr-management-*` skills drive its **change-request** (review + merge)
+backend. Both are vendor-neutral contracts — `contract:tracker` (GitHub or
+JIRA), `contract:change-request` (GitHub PRs, JIRA patches, or dev@
+`[PATCH]` mail), `contract:source-control` (Git, GitHub, or SVN) — so
+*which* connection you need depends on how the project is hosted, and
+**`gh` is not a universal prerequisite:**
 
-- Authenticated `gh auth status` on the shell the agent runs in.
-- Collaborator access (any permission level) on `<tracker>` — the
-  security-team roster is maintained per-project; for the active
-  project see
-  [`<project-config>/release-trains.md`](<project-config>/release-trains.md#security-team-roster).
-- For `security-issue-fix`: a fork of `<upstream>` on your GitHub
-  account (the skill pushes a branch there before opening the PR
-  via `gh pr create --web`).
+- **GitHub-hosted projects (the ASF default).** Authenticate the `gh` CLI
+  (`gh auth status`) on the shell the agent runs in, with collaborator
+  access (any level) on `<tracker>`. `security-issue-fix` additionally
+  needs a fork of `<upstream>` on your GitHub account (it pushes a branch
+  there, then opens the PR via `gh pr create --web`). Claude Code also
+  ships a GitHub MCP; `gh` covers the rest and is what OpenCode uses.
+- **JIRA / SVN-first projects.** No `gh` is required. The tracker is JIRA,
+  review + merge run through `jira-patch` or `dev@` `[PATCH]` mail, and
+  commits land via SVN — declare those backends in
+  `<project-config>/project.md` and install their CLIs (`svn`, the JIRA
+  connection) instead.
+
+The security-team roster is maintained per-project; for the active project
+see
+[`<project-config>/release-trains.md`](<project-config>/release-trains.md#security-team-roster).
 
 ### 4. PMC membership (only for CVE allocation)
 


### PR DESCRIPTION
## What

Brings `docs/prerequisites.md` in line with the vendor-neutrality work
merged this week (#682, #685, #686, #687, #688). Nothing is presented as a
single-vendor requirement when the contract behind it now has
alternatives.

## Changes

- **§1 — "an agentic tool + access to an LLM".** Two fully-supported tools:
  **OpenCode** (the model-agnostic *reference* implementation) and
  **Claude Code**. Plus the four LLM-access paths a user can bring: a paid
  subscription, a free/OSS-maintainer subscription, an organisation-hosted
  LLM (e.g. the planned `llm.apache.org`), or an open-weight model hosted
  or run locally. This is the concrete answer to **magpie-site#58** ("what
  an LLM/agent needs to be usable with Magpie"). The credential-isolation
  note is made harness-neutral (`agent-iso.sh` → `claude-iso` /
  `opencode-iso`; `agent-guard`; `permission-audit` / `sandbox-lint` over
  `settings.json` / `opencode.json`).
- **§2 mail — Gmail is one backend, not a requirement.** Reads go through
  the Gmail MCP, the ASF PonyMail MCP, or a **local mbox / Maildir
  archive**; drafts through Gmail or the offline local **Maildir**
  `contract:mail-create` backend.
- **§3 tracker / change-request — `gh` is not universal.** It is the
  requirement for GitHub-hosted projects; JIRA / SVN-first projects use
  `jira-patch` or dev@ `[PATCH]` mail + `svn` instead
  (`contract:tracker` / `contract:change-request` /
  `contract:source-control`).

## Note

`apache/magpie-site` regenerates `src/content/docs/prerequisites.md` from
this file via `scripts/sync-docs.sh`, so the site picks these up on its
next docs sync.
