### PR TITLE
feat(spec-loop): support additional agent harnesses

### DIFF
--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -8,7 +8,7 @@
   - [Specs are not RFCs](#specs-are-not-rfcs)
   - [A branch per fix or feature](#a-branch-per-fix-or-feature)
   - [Why it never pushes](#why-it-never-pushes)
-  - [Security and the dangerously-skip-permissions flag](#security-and-the-dangerously-skip-permissions-flag)
+  - [Security and unattended agent loops](#security-and-unattended-agent-loops)
   - [Keeping specs honest: the update beat](#keeping-specs-honest-the-update-beat)
   - [Layout](#layout)
   - [Quick start](#quick-start)
@@ -118,7 +118,7 @@ Opening the PR with `--web` is the framework's convention so the reviewer
 sees the title, body, and generative-AI disclosure in the browser before
 submitting. The agent drafts; the human presses the button.
 
-## Security and the dangerously-skip-permissions flag
+## Security and unattended agent loops
 
 The loop runs the agent headless with `--dangerously-skip-permissions`.
 That deserves a direct explanation, because it looks, at a glance, like
@@ -133,7 +133,9 @@ commit — unattended.
 **What it bypasses, and what it does not.** The framework's sandbox is
 layered (see [`docs/rfcs/RFC-AI-0004.md`](rfcs/RFC-AI-0004.md) for the
 normative statement and `docs/setup/secure-agent-internals.md` for the
-mechanism). `--dangerously-skip-permissions` only reaches the top two:
+mechanism). The harness-specific unattended flag
+(`--dangerously-skip-permissions`, `--dangerously-bypass-approvals-and-sandbox`,
+`--force`, `--yolo`, etc.) only reaches the top two:
 
 | Layer | Mechanism | Bypassed by the flag? |
 |---|---|---|
@@ -142,11 +144,11 @@ mechanism). `--dangerously-skip-permissions` only reaches the top two:
 | 2. Tool permissions | `.claude/settings.json` `permissions.deny` | **Yes** |
 | 3. Forced confirmation | `.claude/settings.json` `permissions.ask` on `git push`, `gh …` | **Yes** |
 
-So the flag removes the *agent-level* gate (Layers 2–3), but the
+So the unattended mode removes the *agent-level* gate (Layers 2–3), but the
 *OS-level* boundary (Layers 0–1) is untouched — it is enforced beneath
 the agent and cannot be turned off from inside it. This is exactly the
-posture the flag's own guidance assumes: it is *"recommended only for
-sandboxes with no internet access."*
+posture these flags' own guidance assumes: use them only inside an
+external sandbox.
 
 **How the loop stays safe anyway.** Three things, in order of
 importance:
@@ -158,9 +160,10 @@ importance:
 2. **Run it with no push/write credentials in the environment.** The
    clean-env wrapper already strips them; keep it that way. `github.com`
    is on the network allow-list, but a `git push` or `gh pr create` with
-   no token cannot authenticate, so it fails closed. As defence in depth
-   the loop also passes
-   `--disallowedTools "Bash(git push *)" "Bash(gh *)"`.
+   no token cannot authenticate, so it fails closed. As Claude-specific
+   defence in depth, the loop also passes
+   `--disallowedTools "Bash(git push *)" "Bash(gh *)"` when using the
+   Claude harness.
 3. **Structural containment.** Every iteration works on its own
    `spec/<slug>` branch, the loop guards against commits landing on the
    base branch, and the prompts forbid push/PR. The human-in-the-loop
@@ -233,9 +236,11 @@ gh pr create --web --base main --head spec/<slug> --title "…" --body-file …
 Stop any run with `Ctrl+C` or `touch STOP`. By default the loop forks
 work items from the branch you start it on (typically `main`); set
 `SPEC_LOOP_BASE` to build on top of a different branch. Set
-`SPEC_LOOP_AGENT` when the Claude-compatible agent CLI is installed
-under a command name other than `claude`. Set `SPEC_LOOP_PR_LIMIT` to
-change how many open PRs are included in the duplicate-work check.
+`SPEC_LOOP_AGENT` to choose a supported headless agent CLI (`claude`,
+`codex`, `cursor`, `gemini`, or `opencode`), and set
+`SPEC_LOOP_HARNESS` when a wrapper's name does not imply its run
+convention. Set `SPEC_LOOP_PR_LIMIT` to change how many open PRs are
+included in the duplicate-work check.
 
 ## How this composes with the framework's principles
 

--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -591,7 +591,7 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 49.
 | `security-tracker-stats-dashboard` | analytics | any | ✅ agnostic |
 | `skill-and-tool-validator` | framework-dev | any | ✅ agnostic |
 | `skill-evals` | framework-dev | any | ✅ agnostic |
-| `spec-loop` | framework-dev | Claude Code, OpenCode | ✅ portable |
+| `spec-loop` | framework-dev | Claude Code, Codex, Cursor, Gemini CLI, OpenCode | ✅ portable |
 | `spec-status-index` | framework-dev, analytics | any | ✅ agnostic |
 | `spec-validator` | framework-dev | any | ✅ agnostic |
 | `symlink-lint` | framework-dev | any | ✅ agnostic |
@@ -600,6 +600,9 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 49.
 Harness → substrate tools it supports:
 
 - **Claude Code** (5): `agent-guard`, `agent-isolation`, `permission-audit`, `sandbox-lint`, `spec-loop`
+- **Codex** (1): `spec-loop`
+- **Cursor** (1): `spec-loop`
+- **Gemini CLI** (1): `spec-loop`
 - **OpenCode** (5): `agent-guard`, `agent-isolation`, `permission-audit`, `sandbox-lint`, `spec-loop`
 - **any harness** (15): `dashboard-generator`, `dev`, `egress-gateway`, `pilot-report-validator`, `pr-management-stats`, `preflight-audit`, `privacy-llm`, `probe-templates`, `security-tracker-stats-dashboard`, `skill-and-tool-validator`, `skill-evals`, `spec-status-index`, `spec-validator`, `symlink-lint`, `vendor-neutrality-score`
 

--- a/tools/spec-loop/README.md
+++ b/tools/spec-loop/README.md
@@ -5,7 +5,7 @@
 
 **Capability:** substrate:framework-dev
 
-**Harness:** Claude Code, OpenCode
+**Harness:** Claude Code, Codex, Cursor, Gemini CLI, OpenCode
 
 A spec-driven build loop for this framework, in the general
 [Ralph](https://ghuntley.com/ralph/) style (run a fresh agent context
@@ -16,29 +16,55 @@ this is the operator quickstart.
 
 The loop drives a **headless agent CLI** and is not tied to one harness.
 `SPEC_LOOP_AGENT` picks the CLI (default `claude`) and `SPEC_LOOP_HARNESS`
-picks its run convention — `claude` (`claude -p --dangerously-skip-permissions
---output-format …`, prompt on stdin) or `opencode` (`opencode run --auto
---model … "<prompt>"`, prompt as a positional argument). `SPEC_LOOP_HARNESS`
-defaults from the agent basename, so `SPEC_LOOP_AGENT=opencode` is usually all
-that is needed:
+picks its run convention:
+
+- `claude` — `claude -p --dangerously-skip-permissions --output-format …`,
+  prompt on stdin.
+- `codex` — `codex exec --dangerously-bypass-approvals-and-sandbox -`,
+  prompt on stdin.
+- `cursor` — `cursor agent --print --force --trust --workspace … "<prompt>"`
+  or `cursor-agent --print --force --trust --workspace … "<prompt>"`.
+- `gemini` — `gemini --yolo --prompt "<prompt>"`.
+- `opencode` — `opencode run --auto --model … "<prompt>"`, prompt as a
+  positional argument.
+
+`SPEC_LOOP_HARNESS` defaults from the agent basename, so
+`SPEC_LOOP_AGENT=codex`, `SPEC_LOOP_AGENT=cursor-agent`,
+`SPEC_LOOP_AGENT=gemini`, or `SPEC_LOOP_AGENT=opencode` is usually all that
+is needed:
+
+```bash
+SPEC_LOOP_AGENT=codex tools/spec-loop/loop.sh build 5
+```
+
+```bash
+SPEC_LOOP_AGENT=cursor-agent tools/spec-loop/loop.sh build 5
+```
+
+```bash
+SPEC_LOOP_AGENT=gemini tools/spec-loop/loop.sh build 5
+```
 
 ```bash
 SPEC_LOOP_AGENT=opencode SPEC_LOOP_MODEL=anthropic/claude-sonnet-4-5 \
   tools/spec-loop/loop.sh build 5
 ```
 
-Both conventions run the agent non-interactively with permissions
+All conventions run the agent non-interactively with permissions
 auto-approved; the loop's safety rails (never push, never open a PR) come from
-the OS sandbox and the loop's own guards, not from the harness — see the
-SECURITY notes in [`loop.sh`](loop.sh).
+the OS sandbox, missing push/write credentials, repo hooks, and the loop's own
+guards. Claude also gets per-invocation `--disallowedTools` hard-deny flags;
+the other harnesses rely on their own policy/config plus the external sandbox.
+See the SECURITY notes in [`loop.sh`](loop.sh).
 
 ## Prerequisites
 
 - **Runtime:** Bash + coreutils (`loop.sh` is the runner); the
   spec-side helper tools it drives are Python 3.11+ run via `uv`.
 - **CLIs:** `git` (required — must run inside a git checkout), `gh`
-  (for open-PR duplicate-work checks), and a Claude-compatible agent
-  CLI (`SPEC_LOOP_AGENT`, default `claude`).
+  (for open-PR duplicate-work checks), and one supported headless agent
+  CLI (`SPEC_LOOP_AGENT`, default `claude`; also supports `codex`,
+  `cursor` / `cursor-agent`, `gemini`, and `opencode`).
 - **Credentials / auth:** `gh` must be authenticated for the PR checks;
   the loop is designed to run with **no** push/write credentials in the
   environment (it hard-denies `git push` and `gh` writes).
@@ -94,18 +120,24 @@ The loop runs the agent with `--dangerously-skip-permissions`, so it
 push/write credentials in the environment. The flag bypasses the agent
 permission layer (`.claude/settings.json` deny/ask) but **not** the OS
 sandbox (clean-env + filesystem/network), which stays the real boundary;
-as defence in depth the loop also hard-denies `git push` and `gh` via
-`--disallowedTools`. Full rationale:
-[`docs/spec-driven-development.md` § Security and the dangerously-skip-permissions flag](../../docs/spec-driven-development.md#security-and-the-dangerously-skip-permissions-flag).
+for Claude, as defence in depth, the loop also hard-denies `git push` and
+`gh` via `--disallowedTools`. Full rationale:
+[`docs/spec-driven-development.md` § Security and unattended agent loops](../../docs/spec-driven-development.md#security-and-unattended-agent-loops).
 
 ## Stop / configure
 
 - Stop: `Ctrl+C`, or `touch STOP` (exits after the current iteration).
 - `SPEC_LOOP_BASE` — branch to fork work items from. Defaults to `main`;
   set it explicitly to build on top of a different branch.
-- `SPEC_LOOP_AGENT` — Claude-compatible agent CLI or wrapper to run
-  (default `claude`).
-- `SPEC_LOOP_MODEL` — model passed to the agent CLI (default `sonnet`).
+- `SPEC_LOOP_AGENT` — supported headless agent CLI or wrapper to run
+  (default `claude`; `codex`, `cursor`, `gemini`, and `opencode` are
+  first-class harnesses).
+- `SPEC_LOOP_HARNESS` — override the invocation convention when the CLI
+  name does not imply it (`claude`, `codex`, `cursor`, `gemini`, or
+  `opencode`).
+- `SPEC_LOOP_MODEL` — model passed to the agent CLI. Defaults to `sonnet`
+  for Claude; Codex/Cursor/Gemini/OpenCode use their configured default
+  unless this is set.
 - `SPEC_LOOP_PR_LIMIT` — number of open PRs to include in duplicate-work
   checks (default `100`).
 - `SPEC_LOOP_PLAN_MAX` — plan line count that triggers one consolidation

--- a/tools/spec-loop/loop.sh
+++ b/tools/spec-loop/loop.sh
@@ -31,28 +31,32 @@
 #     iteration and rebuild it forever (an endless loop).
 #
 # SECURITY — read before running:
-#   This loop runs the agent with `--dangerously-skip-permissions`, which
-#   bypasses the AGENT permission layer (.claude/settings.json deny/ask)
-#   but NOT the OS sandbox (clean-env + filesystem/network). Per the
-#   project's security model it MUST be launched inside the sandbox
-#   harness, with no push/write credentials in the environment. Full
-#   rationale: docs/spec-driven-development.md § Security and the
-#   dangerously-skip-permissions flag.
+#   This loop runs the agent in each harness's unattended / auto-approval mode
+#   (for example Claude's `--dangerously-skip-permissions`, Codex's
+#   `--dangerously-bypass-approvals-and-sandbox`, Cursor's `--force`, or
+#   Gemini's `--yolo`). That bypasses the agent permission layer but NOT the
+#   external OS sandbox (clean-env + filesystem/network). Per the project's
+#   security model it MUST be launched inside the sandbox harness, with no
+#   push/write credentials in the environment. Full rationale:
+#   docs/spec-driven-development.md § Security and unattended agent loops.
 #
 # Stop gracefully: press Ctrl+C, or `touch STOP` (exits after the current
 # iteration finishes).
 #
 # Env overrides:
 #   SPEC_LOOP_BASE   branch to fork work items from (default: main)
-#   SPEC_LOOP_AGENT  agent CLI to run (default: claude). Any headless agent
-#                    CLI works; the invocation convention is chosen by
-#                    SPEC_LOOP_HARNESS below.
+#   SPEC_LOOP_AGENT  agent CLI to run (default: claude). Any supported
+#                    headless agent CLI works; the invocation convention is
+#                    chosen by SPEC_LOOP_HARNESS below.
 #   SPEC_LOOP_HARNESS  which harness's headless-run convention to use when
-#                    invoking SPEC_LOOP_AGENT: `claude` (default) or
-#                    `opencode`. Defaults from the agent basename (a CLI named
-#                    `opencode` selects the opencode convention), so setting
+#                    invoking SPEC_LOOP_AGENT: `claude` (default), `codex`,
+#                    `cursor`, `gemini`, or `opencode`. Defaults from the
+#                    agent basename, so setting SPEC_LOOP_AGENT=codex,
+#                    SPEC_LOOP_AGENT=cursor-agent, SPEC_LOOP_AGENT=gemini, or
 #                    SPEC_LOOP_AGENT=opencode is usually enough.
-#   SPEC_LOOP_MODEL  model passed to the agent CLI (default: sonnet)
+#   SPEC_LOOP_MODEL  model passed to the agent CLI. Defaults to `sonnet` for
+#                    Claude; all other harnesses use their configured default
+#                    unless this is set.
 #   SPEC_LOOP_PR_LIMIT  open PRs to list for duplicate-work checks (default: 100)
 #   SPEC_LOOP_PLAN_MAX  plan line count that triggers ONE consolidation
 #                    round before building (default: 500)
@@ -96,10 +100,19 @@ AGENT="${SPEC_LOOP_AGENT:-claude}"
 # agent basename so `SPEC_LOOP_AGENT=opencode` is enough; override explicitly
 # with SPEC_LOOP_HARNESS when the CLI name doesn't match the convention.
 case "${SPEC_LOOP_HARNESS:-$(basename "$AGENT")}" in
+    *codex*)    HARNESS=codex ;;
+    *cursor*)   HARNESS=cursor ;;
+    *gemini*)   HARNESS=gemini ;;
     *opencode*) HARNESS=opencode ;;
     *)          HARNESS=claude ;;
 esac
-MODEL="${SPEC_LOOP_MODEL:-sonnet}"
+if [ -n "${SPEC_LOOP_MODEL:-}" ]; then
+    MODEL="$SPEC_LOOP_MODEL"
+elif [ "$HARNESS" = "claude" ]; then
+    MODEL="sonnet"
+else
+    MODEL=""
+fi
 PR_LIMIT="${SPEC_LOOP_PR_LIMIT:-100}"
 # Agent output format. Default `text` is what the spinner expects; switch to
 # `stream-json` (SPEC_LOOP_OUTPUT_FORMAT=stream-json) to see live tool-call
@@ -163,7 +176,7 @@ fi
 
 if ! command -v "$AGENT" >/dev/null 2>&1; then
     echo "Error: agent CLI '$AGENT' not found on PATH." >&2
-    echo "Set SPEC_LOOP_AGENT to a headless agent CLI (claude / opencode / a wrapper)" >&2
+    echo "Set SPEC_LOOP_AGENT to a headless agent CLI (claude / codex / cursor / gemini / opencode / a wrapper)" >&2
     echo "and SPEC_LOOP_HARNESS to its run convention if the name doesn't imply it." >&2
     exit 1
 fi
@@ -173,7 +186,7 @@ echo "Mode:   $MODE"
 echo "Prompt: $PROMPT_FILE"
 echo "Base:   $BASE  (work items fork from here)"
 echo "Agent:  $AGENT"
-echo "Model:  $MODEL"
+if [ -n "$MODEL" ]; then echo "Model:  $MODEL"; else echo "Model:  (agent default)"; fi
 if [ "$MAX_ITERATIONS" -gt 0 ]; then echo "Max:    $MAX_ITERATIONS iterations"; else echo "Max:    unlimited"; fi
 echo "Stop:   Ctrl+C  or  touch STOP"
 echo "Note:   this loop never pushes and never opens a PR."
@@ -445,6 +458,8 @@ while true; do
     #                                   remote even with permissions skipped.
     # Claude CLI requires --verbose with -p when output-format is stream-json;
     # add it only in that case to keep the default `text` run quiet.
+    MODEL_ARGS=()
+    [ -n "$MODEL" ] && MODEL_ARGS=(--model "$MODEL")
     if [ "$HARNESS" = "opencode" ]; then
         # OpenCode headless: `opencode run <message>` takes the prompt as a
         # positional argument (no stdin), `--model provider/model`, `--auto`
@@ -460,9 +475,48 @@ while true; do
         [ "$OUTPUT_FORMAT" = "stream-json" ] && OC_FORMAT_ARGS=(--format json)
         "$AGENT" run \
             --auto \
-            --model "$MODEL" \
+            ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} \
             ${OC_FORMAT_ARGS[@]+"${OC_FORMAT_ARGS[@]}"} \
             "$(cat "$PROMPT_WITH_CONTEXT")" &
+    elif [ "$HARNESS" = "codex" ]; then
+        # Codex CLI headless: `codex exec -` reads the prompt from stdin.
+        # `--dangerously-bypass-approvals-and-sandbox` is Codex's unattended
+        # automation switch; as with the other harnesses, only use this loop
+        # inside the external OS sandbox described in the SECURITY header.
+        # Codex has no per-invocation --disallowedTools equivalent here; the
+        # hard boundary is the OS sandbox plus repo hooks / exec policy.
+        CODEX_FORMAT_ARGS=()
+        [ "$OUTPUT_FORMAT" = "stream-json" ] && CODEX_FORMAT_ARGS=(--json)
+        "$AGENT" exec \
+            --dangerously-bypass-approvals-and-sandbox \
+            --cd "$ROOT" \
+            ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} \
+            ${CODEX_FORMAT_ARGS[@]+"${CODEX_FORMAT_ARGS[@]}"} \
+            - < "$PROMPT_WITH_CONTEXT" &
+    elif [ "$HARNESS" = "cursor" ]; then
+        # Cursor Agent headless: `cursor agent --print <prompt>` or the
+        # standalone `cursor-agent --print <prompt>`. `--force` is Cursor's
+        # unattended "allow commands unless explicitly denied" mode, and
+        # `--trust` avoids a workspace-trust prompt in headless runs.
+        CURSOR_FORMAT_ARGS=(--output-format "$OUTPUT_FORMAT")
+        CURSOR_SUBCOMMAND=()
+        [ "$(basename "$AGENT")" = "cursor" ] && CURSOR_SUBCOMMAND=(agent)
+        "$AGENT" \
+            ${CURSOR_SUBCOMMAND[@]+"${CURSOR_SUBCOMMAND[@]}"} \
+            --print \
+            --force \
+            --trust \
+            --workspace "$ROOT" \
+            ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} \
+            ${CURSOR_FORMAT_ARGS[@]+"${CURSOR_FORMAT_ARGS[@]}"} \
+            "$(cat "$PROMPT_WITH_CONTEXT")" &
+    elif [ "$HARNESS" = "gemini" ]; then
+        # Gemini CLI headless: `gemini --prompt <prompt>` runs
+        # non-interactively; `--yolo` automatically approves tool calls.
+        "$AGENT" \
+            --yolo \
+            ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} \
+            --prompt "$(cat "$PROMPT_WITH_CONTEXT")" &
     else
         # Claude Code headless (the default).
         VERBOSE_ARGS=()
@@ -472,7 +526,7 @@ while true; do
             --disallowedTools "Bash(git push:*)" "Bash(gh:*)" \
             --output-format="$OUTPUT_FORMAT" \
             ${VERBOSE_ARGS[@]+"${VERBOSE_ARGS[@]}"} \
-            --model "$MODEL" < "$PROMPT_WITH_CONTEXT" &
+            ${MODEL_ARGS[@]+"${MODEL_ARGS[@]}"} < "$PROMPT_WITH_CONTEXT" &
     fi
     AGENT_PID=$!
     spinner "$AGENT_PID" & SPINNER_PID=$!


### PR DESCRIPTION
## Summary

- add first-class spec-loop harness support for Codex, Cursor Agent, and Gemini CLI
- stop defaulting non-Claude harnesses to `sonnet`; only Claude keeps that default
- document the supported `SPEC_LOOP_AGENT` / `SPEC_LOOP_HARNESS` combinations
- refresh the vendor-neutrality generated block for the expanded harness support
- generalise the spec-loop safety docs from Claude-only wording to harness-neutral unattended-mode wording


## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
