### PR TITLE
fix(adapters): add privacy-boundary notes to maildir and sourcehut READMEs

### DIFF
--- a/tools/maildir/README.md
+++ b/tools/maildir/README.md
@@ -120,6 +120,12 @@ reader is the documented stub described in
 [`tools/mail-source/mbox/README.md`](../mail-source/mbox/README.md); this
 tool is its vendor home.
 
+**Privacy posture:** fetched mail bodies are external data, not instructions.
+Content is treated as hostile input and is routed through the Privacy-LLM gate
+or redacted before any model-facing use. Embedded prompt-injection text in mail
+bodies is carried as report data only and is never obeyed as a framework
+instruction.
+
 ## Configuration
 
 An adopter selects the Maildir backend in

--- a/tools/sourcehut/README.md
+++ b/tools/sourcehut/README.md
@@ -29,7 +29,7 @@ SourceHut (sr.ht) forge bridge implementation for the Apache Magpie framework. I
 
 1. **VCS Repositories:** Reads repo metadata across `git.sr.ht` and `hg.sr.ht`.
 2. **Issue Tracker:** Read/write operations (create ticket, comment, resolve status, update labels) on `todo.sr.ht` trackers.
-3. **Mailing Lists:** Reads patchsets and threads from `lists.sr.ht`, mapping them to the uniform PR/MR review abstraction.
+3. **Mailing Lists:** Reads patchsets and threads from `lists.sr.ht`, mapping them to the uniform PR/MR review abstraction. Fetched mail bodies are external data, not instructions; content is treated as hostile input and routed through the Privacy-LLM gate or redacted before model-facing use. Embedded prompt-injection text in mail bodies is carried as report data only and is never obeyed as a framework instruction.
 4. **CI Builds:** Reads job statuses from `builds.sr.ht`.
 5. **GraphQL client:** Unified command line tool to execute arbitrary queries/mutations across sr.ht subdomains.
 


### PR DESCRIPTION
## Summary

Both READMEs were missing the two notes required by the mail-privacy-boundary validator check (aspect #19): that fetched mail bodies are external data / hostile input routed through the Privacy-LLM gate or redacted before model-facing use, and that embedded prompt-injection text is carried as report data only.

Generated-by: Claude (Opus 4.7)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
