### PR TITLE
feat(cve-json): classify .ai service handles as tool credits

### DIFF
--- a/tools/cve-tool-vulnogram/bot-credits-policy.md
+++ b/tools/cve-tool-vulnogram/bot-credits-policy.md
@@ -88,6 +88,9 @@ A handle or email is *obvious bot/AI* when **any** of these match:
    these case-insensitive regex patterns:
    * `*-bot`, `*bot` (e.g. `securitybot`, `release-bot`)
    * `*-ai`, `*ai` (e.g. `scan-ai`, `securityai`)
+   * `*.ai` — domain-style AI-service handles (e.g. `bugbunny.ai`,
+     `xbow.ai`); an AI bug-hunting service credited by its `.ai`
+     product handle is a tool, not a human finder
    * `*-agent`, `*agent` (e.g. `triage-agent`)
    * `*-gpt`, `*gpt` (e.g. `secaudit-gpt`)
    * `*scanner*`, `*-scan` (e.g. `securityscanner-7`, `audit-scan`)

--- a/tools/cve-tool-vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
@@ -350,6 +350,7 @@ BOT_CREDIT_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"\b[\w]*-bot\b", re.IGNORECASE),
     re.compile(r"\b[\w]+bot\b", re.IGNORECASE),
     re.compile(r"\b[\w]*-ai\b", re.IGNORECASE),
+    re.compile(r"\b[\w-]+\.ai\b", re.IGNORECASE),
     re.compile(r"\b[\w]*-agent\b", re.IGNORECASE),
     re.compile(r"\b[\w]*-gpt\b", re.IGNORECASE),
     re.compile(r"\b[\w]*scanner[\w]*\b", re.IGNORECASE),

--- a/tools/cve-tool-vulnogram/generate-cve-json/tests/test_generate_cve_json.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/tests/test_generate_cve_json.py
@@ -194,6 +194,8 @@ class TestIsBotCredit:
             "release-bot",
             "securitybot",
             "scan-ai",
+            "bugbunny.ai",  # domain-style AI-service handle
+            "xbow.ai",
             "triage-agent",
             "secaudit-gpt",
             "securityscanner-7",


### PR DESCRIPTION
## Summary

- Bot-credit detection in `generate-cve-json` matched hyphenated `-ai` / `-agent` / `-gpt` handles but **not** domain-style AI-service handles like `bugbunny.ai`, so an AI bug-hunting service credited by its `.ai` product handle landed as `type: finder` instead of `type: tool` in the CVE record's `credits[]`.
- Add a `\b[\w-]+\.ai\b` pattern to `BOT_CREDIT_PATTERNS`, a matching bullet to `bot-credits-policy.md`, and two test cases (`bugbunny.ai`, `xbow.ai`).

## Motivation

Surfaced while crediting an AI bug-hunting service (a `.ai` product handle) on an advisory: it's an automated discovery service, so CVE 5.x `type: "tool"` is the accurate row — but the `.ai` domain form slipped past the existing hyphen-suffix patterns and there's no manual override hook (the field is the single source of truth; the generator decides finder-vs-tool). Adding the `.ai` form closes that gap.

## Test plan

- `pytest tools/cve-tool-vulnogram/generate-cve-json` — green; `test_pattern_handles_match` now covers `bugbunny.ai` / `xbow.ai`, `test_human_names_do_not_match` still green (the `\b…\.ai\b` anchor doesn't fire on free-standing "AI" or human names).
- `prek run --files …` — ruff, mypy, markdownlint, typos, pytest all pass.
