### PR TITLE
fix(cve-tool-vulnogram): read/write CNA_private under the read API's body envelope

### DIFF
--- a/tools/cve-tool-vulnogram/oauth-api/src/vulnogram_api/client.py
+++ b/tools/cve-tool-vulnogram/oauth-api/src/vulnogram_api/client.py
@@ -170,6 +170,27 @@ def get_record(
     return first
 
 
+def record_body(document: dict[str, Any]) -> dict[str, Any]:
+    """Return the CVE 5.x document inside a record fetched via :func:`get_record`.
+
+    Vulnogram's read endpoint wraps the stored record in an envelope::
+
+        {"comments": [...], "files": [...],
+         "body": {"cveMetadata": ..., "CNA_private": ..., "containers": ...},
+         "author": ..., "__v": ...}
+
+    The CVE document — and its ``CNA_private.state`` — lives under ``body``. A
+    locally-generated document (e.g. from ``generate-cve-json``) has those keys
+    at the top level and carries no ``body`` envelope, so fall back to the
+    document itself. This keeps callers agnostic to which shape they hold: read
+    or mutate ``CNA_private`` on the returned mapping, and POST that same
+    mapping back via :func:`update_record` (which expects the unwrapped CVE
+    document, not the read envelope).
+    """
+    body = document.get("body")
+    return body if isinstance(body, dict) else document
+
+
 def fetch_csrf_token(
     session: Session,
     cve_id: str,

--- a/tools/cve-tool-vulnogram/oauth-api/src/vulnogram_api/record_fetch.py
+++ b/tools/cve-tool-vulnogram/oauth-api/src/vulnogram_api/record_fetch.py
@@ -48,6 +48,7 @@ from vulnogram_api.client import (
     SessionExpired,
     VulnogramAPIError,
     get_record,
+    record_body,
 )
 from vulnogram_api.credentials import Session, locate_session
 
@@ -107,7 +108,7 @@ def main(argv: list[str] | None = None) -> int:
         return 6
 
     if args.state_only:
-        cna = document.get("CNA_private")
+        cna = record_body(document).get("CNA_private")
         if not isinstance(cna, dict):
             print(
                 f"✗ {args.cve_id} document's CNA_private field is not an object: {type(cna).__name__}.",

--- a/tools/cve-tool-vulnogram/oauth-api/src/vulnogram_api/record_publish.py
+++ b/tools/cve-tool-vulnogram/oauth-api/src/vulnogram_api/record_publish.py
@@ -56,6 +56,7 @@ from vulnogram_api.client import (
     SessionExpired,
     VulnogramAPIError,
     get_record,
+    record_body,
     update_record,
 )
 from vulnogram_api.credentials import Session, locate_session
@@ -109,7 +110,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def _state(document: dict[str, object]) -> str | None:
-    cna = document.get("CNA_private")
+    cna = record_body(document).get("CNA_private")
     if not isinstance(cna, dict):
         return None
     s = cna.get("state")
@@ -152,15 +153,18 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 3
 
-    document.setdefault("CNA_private", {})
-    if not isinstance(document["CNA_private"], dict):
+    # The read API wraps the record under `body`; operate on that inner CVE
+    # document, and POST it back unwrapped (the shape `update_record` expects).
+    body = record_body(document)
+    body.setdefault("CNA_private", {})
+    if not isinstance(body["CNA_private"], dict):
         print(
             f"✗ {args.cve_id} document's CNA_private field is not an object: "
-            f"{type(document['CNA_private']).__name__}. Refusing to publish.",
+            f"{type(body['CNA_private']).__name__}. Refusing to publish.",
             file=sys.stderr,
         )
         return 3
-    document["CNA_private"]["state"] = "PUBLIC"
+    body["CNA_private"]["state"] = "PUBLIC"
 
     if args.dry_run:
         print(
@@ -169,7 +173,7 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     try:
-        envelope = update_record(session, args.cve_id, document, section=args.section)
+        envelope = update_record(session, args.cve_id, body, section=args.section)
     except SessionExpired as e:
         print(f"✗ {e}", file=sys.stderr)
         return 2

--- a/tools/cve-tool-vulnogram/oauth-api/tests/test_record_fetch.py
+++ b/tools/cve-tool-vulnogram/oauth-api/tests/test_record_fetch.py
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import json
+
+from vulnogram_api import record_fetch
+from vulnogram_api.client import record_body
+
+
+def _write_session(path):
+    path.write_text(
+        json.dumps(
+            {
+                "host": "cveprocess.apache.org",
+                "session_cookie_name": "connect.sid",
+                "session_cookie_value": "s%3Atest",
+                "from_address": "you@apache.org",
+            }
+        )
+    )
+    return path
+
+
+def _wrapped(state):
+    """A record shaped the way Vulnogram's read API returns it: the CVE
+    document nested under a ``body`` envelope."""
+    return {
+        "comments": [],
+        "files": [],
+        "body": {
+            "CNA_private": {"state": state},
+            "cveMetadata": {"cveId": "CVE-2026-12345"},
+        },
+        "author": "x",
+        "__v": 1,
+    }
+
+
+def test_state_only_reads_state_under_body_envelope(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+    monkeypatch.setattr(record_fetch, "get_record", lambda *a, **kw: _wrapped("REVIEW"))
+    rc = record_fetch.main(["--cve-id", "CVE-2026-12345", "--state-only"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() == "REVIEW"
+
+
+def test_state_only_errors_when_cna_private_missing(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+    # A record whose body carries no CNA_private object.
+    monkeypatch.setattr(
+        record_fetch,
+        "get_record",
+        lambda *a, **kw: {"body": {"cveMetadata": {"cveId": "CVE-2026-12345"}}},
+    )
+    rc = record_fetch.main(["--cve-id", "CVE-2026-12345", "--state-only"])
+    assert rc == 7
+    assert "CNA_private" in capsys.readouterr().err
+
+
+def test_full_fetch_dumps_the_envelope(tmp_path, monkeypatch, capsys):
+    _write_session(tmp_path / "session.json")
+    monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
+    doc = _wrapped("PUBLIC")
+    monkeypatch.setattr(record_fetch, "get_record", lambda *a, **kw: doc)
+    rc = record_fetch.main(["--cve-id", "CVE-2026-12345"])
+    assert rc == 0
+    assert json.loads(capsys.readouterr().out) == doc
+
+
+def test_record_body_unwraps_envelope_or_passes_through():
+    wrapped = {"body": {"CNA_private": {"state": "REVIEW"}}, "comments": []}
+    assert record_body(wrapped) == {"CNA_private": {"state": "REVIEW"}}
+    # A locally-generated (unwrapped) document is returned unchanged.
+    top_level = {"CNA_private": {"state": "PUBLIC"}, "cveMetadata": {}}
+    assert record_body(top_level) is top_level

--- a/tools/cve-tool-vulnogram/oauth-api/tests/test_record_publish.py
+++ b/tools/cve-tool-vulnogram/oauth-api/tests/test_record_publish.py
@@ -37,6 +37,16 @@ def _write_session(path):
     return path
 
 
+def _wrapped(state, **extra):
+    """A record shaped the way Vulnogram's read API returns it: the CVE
+    document (``CNA_private``, ``cveMetadata``, …) nested under a ``body``
+    envelope. Publishing must read and write ``CNA_private`` under ``body``,
+    not at the top level — mocking the unwrapped shape here is what let the
+    body-envelope bug ship."""
+    body = {"CNA_private": {"state": state}, **extra}
+    return {"comments": [], "files": [], "body": body, "author": "x", "__v": 1}
+
+
 def test_invalid_cve_id_rejected(tmp_path, monkeypatch):
     _write_session(tmp_path / "session.json")
     monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
@@ -50,7 +60,7 @@ def test_already_public_is_noop(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
 
     def _fake_get(*a, **kw):
-        return {"CNA_private": {"state": "PUBLIC"}, "cveMetadata": {"cveId": "CVE-2026-12345"}}
+        return _wrapped("PUBLIC", cveMetadata={"cveId": "CVE-2026-12345"})
 
     monkeypatch.setattr(record_publish, "get_record", _fake_get)
     rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
@@ -64,7 +74,7 @@ def test_unexpected_state_refused(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
 
     def _fake_get(*a, **kw):
-        return {"CNA_private": {"state": "DRAFT"}}
+        return _wrapped("DRAFT")
 
     monkeypatch.setattr(record_publish, "get_record", _fake_get)
     rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
@@ -79,7 +89,7 @@ def test_allow_state_widens_acceptance(tmp_path, monkeypatch):
     monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
 
     def _fake_get(*a, **kw):
-        return {"CNA_private": {"state": "READY"}}
+        return _wrapped("READY")
 
     monkeypatch.setattr(record_publish, "get_record", _fake_get)
     rc = record_publish.main(
@@ -101,7 +111,7 @@ def test_review_to_public_dry_run(tmp_path, monkeypatch, capsys):
     monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
 
     def _fake_get(*a, **kw):
-        return {"CNA_private": {"state": "REVIEW"}, "cveMetadata": {"cveId": "CVE-2026-12345"}}
+        return _wrapped("REVIEW", cveMetadata={"cveId": "CVE-2026-12345"})
 
     monkeypatch.setattr(record_publish, "get_record", _fake_get)
     rc = record_publish.main(["--cve-id", "CVE-2026-12345", "--dry-run"])
@@ -115,7 +125,7 @@ def test_review_to_public_apply_flips_state(tmp_path, monkeypatch, capsys):
     _write_session(tmp_path / "session.json")
     monkeypatch.setenv("VULNOGRAM_SESSION", str(tmp_path / "session.json"))
 
-    fetched = {"CNA_private": {"state": "REVIEW"}, "cveMetadata": {"cveId": "CVE-2026-12345"}}
+    fetched = _wrapped("REVIEW", cveMetadata={"cveId": "CVE-2026-12345"})
     captured: dict[str, object] = {}
 
     def _fake_get(*a, **kw):
@@ -124,13 +134,16 @@ def test_review_to_public_apply_flips_state(tmp_path, monkeypatch, capsys):
     def _fake_update(session, cve_id, document, *, section="cve5", **kw):
         captured["cve_id"] = cve_id
         captured["state"] = document["CNA_private"]["state"]
+        # Regression: publish must POST the unwrapped CVE document
+        # (CNA_private/cveMetadata at the top level), never the read envelope.
+        captured["posted_body_envelope"] = "body" in document
         return {"type": "saved"}
 
     monkeypatch.setattr(record_publish, "get_record", _fake_get)
     monkeypatch.setattr(record_publish, "update_record", _fake_update)
     rc = record_publish.main(["--cve-id", "CVE-2026-12345"])
     assert rc == 0
-    assert captured == {"cve_id": "CVE-2026-12345", "state": "PUBLIC"}
+    assert captured == {"cve_id": "CVE-2026-12345", "state": "PUBLIC", "posted_body_envelope": False}
     out = capsys.readouterr().out
     assert "published" in out
     assert "'REVIEW'" in out


### PR DESCRIPTION
## Summary

- `vulnogram-api-record-publish` and `record-fetch --state-only` read `CNA_private` at the **top level** of the fetched record, but Vulnogram's read API nests the CVE document under a `body` envelope (`{comments, files, body:{cveMetadata, CNA_private, containers}, author, __v}`) — so both fail on **every real record** with `✗ … CNA_private field is not an object: NoneType` / `is in state None`. `record-update` was unaffected because `merge_mode` already reads `body.CNA_private`.
- Fix: add `client.record_body()` (returns the doc under `body`, else the doc itself) and route both commands' reads/writes through it; publish now POSTs the **unwrapped** document — the shape `record-update` already POSTs.
- The tests mocked the unwrapped top-level shape, which is exactly why this shipped green.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)

## Test plan

- [x] `prek run --files <the 5 changed files>` — all hooks pass (ruff check, ruff format, mypy, pytest, typos, check-placeholders)
- [x] For Python packages touched: `uv run --project tools/cve-tool-vulnogram/oauth-api pytest` — **96 pass**; `ruff` / `mypy` clean
- Regression coverage: `test_record_publish` mocks now use the real `body`-wrapped read shape and assert the POST carries the unwrapped document (`posted_body_envelope is False`); without the source fix, publish returns `3` (state unreadable). New `test_record_fetch` covers the previously-**untested** `--state-only` path, plus a `record_body` unit test for both shapes.

## RFC-AI-0004 compliance

- No behavioural or mutation-policy change — a read/write-location bug fix inside the Vulnogram CVE-tool adapter. No new host access, no new outbound messages, HITL unchanged.

## Linked issues

<!-- none -->

## Notes for reviewers

Found while publishing a real CVE end-to-end: `record-update` set the record to `PUBLIC` correctly, but `record-publish --dry-run` and `record-fetch --state-only` both reported `state None` on the very same record — the two commands that read `CNA_private` at the top level instead of under `body`. The write path also mattered: `record-publish` mutated a bogus top-level `CNA_private` and POSTed the read envelope; it now mutates `body.CNA_private` and POSTs the unwrapped doc.

Generated-by: Claude Code (Opus 4.8)