### PR TITLE
fix(cve-tool-vulnogram): fall back to the legacy config path after the tool rename

### DIFF
--- a/tools/cve-tool-vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/src/generate_cve_json/cve_json.py
@@ -121,6 +121,8 @@ import tempfile
 #      `_load_config()`).
 #   2. The `CVE_JSON_CONFIG` environment variable.
 #   3. `<cwd>/.apache-magpie-overrides/tools/cve-tool-vulnogram/cve-json-config.toml`.
+#      Back-compat: if only the pre-rename `tools/vulnogram/` copy exists at
+#      this default location, it is used with a deprecation warning.
 #
 # Schema: see the README in this package.
 import tomllib
@@ -128,6 +130,9 @@ import urllib.parse
 from pathlib import Path
 
 _DEFAULT_CONFIG_RELPATH = ".apache-magpie-overrides/tools/cve-tool-vulnogram/cve-json-config.toml"
+# Pre-rename location (`tools/vulnogram` was renamed to `tools/cve-tool-vulnogram`).
+# Used as a fallback for adopters who upgraded across the rename — see `_load_config`.
+_LEGACY_CONFIG_RELPATH = ".apache-magpie-overrides/tools/vulnogram/cve-json-config.toml"
 _CONFIG_PATH_ENV = "CVE_JSON_CONFIG"
 
 # Cached, lazily-loaded config. `_populate_constants()` reads this and
@@ -137,28 +142,51 @@ _CONFIG_PATH_ENV = "CVE_JSON_CONFIG"
 _CONFIG: dict | None = None
 
 
-def _resolve_config_path(config_path: Path | str | None = None) -> Path:
-    """Resolve the config file path following the documented order."""
+def _resolve_config_path(config_path: Path | str | None = None) -> tuple[Path, bool]:
+    """Resolve the config file path following the documented order.
+
+    Returns ``(path, is_default)`` — ``is_default`` is True only when the path
+    came from the default location (no ``--config``, no ``$CVE_JSON_CONFIG``),
+    the single case the legacy-path fallback in ``_load_config`` applies to.
+    Keeping the precedence decision here means the fallback keys off one source
+    of truth instead of re-deriving it.
+    """
     if config_path is not None:
-        return Path(config_path)
+        return Path(config_path), False
     env = os.environ.get(_CONFIG_PATH_ENV)
     if env:
-        return Path(env)
-    return Path.cwd() / _DEFAULT_CONFIG_RELPATH
+        return Path(env), False
+    return Path.cwd() / _DEFAULT_CONFIG_RELPATH, True
 
 
 def _load_config(config_path: Path | str | None = None) -> dict:
     """Load TOML config, raising ``FileNotFoundError`` with usage hints
     if it cannot be located.
     """
-    path = _resolve_config_path(config_path)
+    path, is_default = _resolve_config_path(config_path)
     if not path.exists():
-        raise FileNotFoundError(
-            f"generate-cve-json: config file not found at {path}.\n"
-            f"  Pass --config <path>, set ${_CONFIG_PATH_ENV}, or place a config\n"
-            f"  at {_DEFAULT_CONFIG_RELPATH} relative to the cwd.\n"
-            f"  Schema: see the generate-cve-json package README."
-        )
+        # Back-compat: `tools/vulnogram` was renamed to `tools/cve-tool-vulnogram`.
+        # An adopter who upgraded across the rename still keeps their committed
+        # config at the pre-rename path. When resolving from the default location
+        # (no `--config`, no `$CVE_JSON_CONFIG`) and only the legacy copy exists,
+        # use it and warn — so the upgrade doesn't hard-break mid-run.
+        legacy = Path.cwd() / _LEGACY_CONFIG_RELPATH
+        if is_default and legacy.is_file():
+            print(
+                f"generate-cve-json: WARNING reading config from the legacy path "
+                f"{_LEGACY_CONFIG_RELPATH}. The tool dir was renamed "
+                f"`tools/vulnogram` -> `tools/cve-tool-vulnogram`; move the file to "
+                f"{_DEFAULT_CONFIG_RELPATH} to silence this warning.",
+                file=sys.stderr,
+            )
+            path = legacy
+        else:
+            raise FileNotFoundError(
+                f"generate-cve-json: config file not found at {path}.\n"
+                f"  Pass --config <path>, set ${_CONFIG_PATH_ENV}, or place a config\n"
+                f"  at {_DEFAULT_CONFIG_RELPATH} relative to the cwd.\n"
+                f"  Schema: see the generate-cve-json package README."
+            )
     return tomllib.loads(path.read_text(encoding="utf-8"))
 
 

--- a/tools/cve-tool-vulnogram/generate-cve-json/tests/test_config_resolution.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/tests/test_config_resolution.py
@@ -1,0 +1,73 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+import pytest
+
+from generate_cve_json.cve_json import _load_config
+
+_DEFAULT_REL = ".apache-magpie-overrides/tools/cve-tool-vulnogram/cve-json-config.toml"
+_LEGACY_REL = ".apache-magpie-overrides/tools/vulnogram/cve-json-config.toml"
+
+
+def _write(root, relpath, vendor):
+    p = root / relpath
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(f'vendor = "{vendor}"\n')
+    return p
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """Resolve config from the (empty) tmp cwd, with no env override."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("CVE_JSON_CONFIG", raising=False)
+
+
+def test_default_path_is_used_when_present(tmp_path, capsys):
+    _write(tmp_path, _DEFAULT_REL, "New")
+    assert _load_config() == {"vendor": "New"}
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_legacy_path_used_with_warning_when_default_missing(tmp_path, capsys):
+    _write(tmp_path, _LEGACY_REL, "Legacy")
+    assert _load_config() == {"vendor": "Legacy"}
+    err = capsys.readouterr().err
+    assert "legacy path" in err
+    assert "tools/cve-tool-vulnogram" in err  # points the adopter at the new path
+
+
+def test_default_wins_over_legacy_when_both_present(tmp_path, capsys):
+    _write(tmp_path, _DEFAULT_REL, "New")
+    _write(tmp_path, _LEGACY_REL, "Legacy")
+    assert _load_config() == {"vendor": "New"}
+    assert "WARNING" not in capsys.readouterr().err
+
+
+def test_missing_both_raises_pointing_at_the_new_path():
+    with pytest.raises(FileNotFoundError) as exc:
+        _load_config()
+    assert "cve-tool-vulnogram" in str(exc.value)
+
+
+def test_explicit_config_path_does_not_fall_back_to_legacy(tmp_path):
+    # Legacy exists, but an explicit (missing) --config path must not silently
+    # resolve to it — explicit intent wins and the error is surfaced.
+    _write(tmp_path, _LEGACY_REL, "Legacy")
+    with pytest.raises(FileNotFoundError):
+        _load_config(tmp_path / "explicit-but-missing.toml")


### PR DESCRIPTION
## Summary

- `generate-cve-json` resolves its config only at `.apache-magpie-overrides/tools/cve-tool-vulnogram/cve-json-config.toml`. The tool dir was renamed `tools/vulnogram` -> `tools/cve-tool-vulnogram`, so an adopter who upgraded across the rename keeps their config at the **old** path and every run hard-fails with `config file not found` until they pass `--config` or move the file by hand.
- Fix: when resolving from the default location (no `--config`, no `$CVE_JSON_CONFIG`) and only the pre-rename copy exists, use it with a one-line deprecation warning pointing at the new path. An explicit `--config` / env path that is missing still errors — no silent fallback.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)

## Test plan

- [x] `uv run pytest tools/cve-tool-vulnogram/generate-cve-json/tests/test_config_resolution.py` — 5 cases: default used when present; legacy fallback + warning when default missing; default wins over legacy; both-missing raises pointing at the new path; explicit missing `--config` does **not** fall back. Existing suite unaffected.
- [x] `prek run --files <changed>` — ruff check / ruff format / mypy / pytest / typos / check-placeholders all pass.

## RFC-AI-0004 compliance

- No behavioural or mutation change — a back-compat path-resolution fix. No new host access, no outbound messages, HITL unchanged.

## Linked issues

<!-- none -->

## Notes for reviewers

Hit while running `generate-cve-json` in an adopter repo that adopted **before** the `vulnogram` -> `cve-tool-vulnogram` rename. A more systemic alternative would be to migrate `.apache-magpie-overrides/tools/<renamed>/` directories during `/magpie-setup upgrade` (the framework already migrates other renamed artefacts on upgrade); this PR is the minimal, self-contained fix that unblocks affected adopters immediately and nudges them to migrate.

Generated-by: Claude Code (Opus 4.8)