### PR TITLE
fix(good-first-issue-sweep): trim description to clear action-inventory advisory

### DIFF
--- a/skills/good-first-issue-sweep/SKILL.md
+++ b/skills/good-first-issue-sweep/SKILL.md
@@ -3,14 +3,11 @@ name: magpie-good-first-issue-sweep
 mode: Mentoring
 description: |
   Sweep the open `<issue-tracker>` backlog for existing issues that
-  could be labelled as good first issues. Score each candidate against
-  the G1–G7 suitability rubric (scope, self-containment, code pointer,
-  small effort, no security sensitivity, no architectural decision, no
-  deprecation decision) and classify it as READY (propose the GFI
-  label), NEAR-MISS (surface specific edits to make it GFI-ready), or
-  SKIP (not suitable). Applies labels only after explicit maintainer
-  confirmation; never edits issue bodies without the maintainer's
-  direction.
+  could be labelled as good first issues. Classifies each candidate as
+  READY (propose the GFI label), NEAR-MISS (surface edits to make it
+  GFI-ready), or SKIP using the G1–G7 suitability rubric. Applies
+  labels only after explicit maintainer confirmation; never edits issue
+  bodies without the maintainer's direction.
 when_to_use: |
   Invoke when a maintainer says "find good first issues in the backlog",
   "which open issues could a newcomer pick up", "label existing issues


### PR DESCRIPTION
## Summary

The frontmatter description embedded the full G1–G7 criterion list inline (8 commas in one sentence), triggering the skill-and-tool-validator action-inventory SOFT advisory.  The G1–G7 rubric is already documented in the skill body; the description now names the rubric without repeating it, keeping the description compact and validator-clean.

Generated-by: Claude (Opus 4.7)

## Type of change

- [X] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [ ] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [X] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
