### PR TITLE
docs(spec-loop): derive commit trailer from the running agent and model

### DIFF
--- a/tools/spec-loop/AGENTS.md
+++ b/tools/spec-loop/AGENTS.md
@@ -82,6 +82,9 @@ commit.
 ## Commits
 
 - Imperative subject describing the user-visible change.
-- Trailer `Generated-by: Claude (Opus 4.7)` — **never** `Co-Authored-By`
-  with an agent (repo-wide `AGENTS.md` § Commit and PR conventions).
+- Trailer `Generated-by: <agent> (<model>)`, where `<agent>` and `<model>`
+  are the actual agent and model you are running as (e.g. `Claude (Opus
+  4.8)`, `OpenCode (Big Pickle)`) — do not hardcode either. **Never**
+  `Co-Authored-By` with an agent (repo-wide `AGENTS.md` § Commit and PR
+  conventions).
 - One commit per build iteration (the change + its spec `status` flip).

--- a/tools/spec-loop/PROMPT_build.md
+++ b/tools/spec-loop/PROMPT_build.md
@@ -62,8 +62,10 @@ Steps:
    update **only that spec's** frontmatter/Known-gaps, and never
    `IMPLEMENTATION_PLAN.md`.)
 8. `git add -A` then `git commit` with an imperative subject and a
-   `Generated-by: Claude (Opus 4.7)` trailer. **Never** add a
-   `Co-Authored-By:` trailer for an agent.
+   `Generated-by: <agent> (<model>)` trailer, where `<agent>` and
+   `<model>` are the actual agent and model you are running as (e.g.
+   `Claude (Opus 4.8)`, `OpenCode (Big Pickle)`) — do not hardcode
+   either. **Never** add a `Co-Authored-By:` trailer for an agent.
 
 Then STOP. Do NOT push and do NOT open a PR — `git push` and
 `gh pr create` are the human's step (they are in `.claude/settings.json`

--- a/tools/spec-loop/PROMPT_consolidate.md
+++ b/tools/spec-loop/PROMPT_consolidate.md
@@ -18,7 +18,10 @@ it without losing planned work.
    the number.
 6. `git add -A` then
    `git commit -m "chore(spec-loop): consolidate implementation plan"`
-   with a `Generated-by: Claude (Opus 4.7)` trailer.
+   with a `Generated-by: <agent> (<model>)` trailer, where `<agent>` and
+   `<model>` are the actual agent and model you are running as (e.g.
+   `Claude (Opus 4.8)`, `OpenCode (Big Pickle)`) — do not hardcode
+   either.
 
 Rules:
 

--- a/tools/spec-loop/PROMPT_update.md
+++ b/tools/spec-loop/PROMPT_update.md
@@ -57,7 +57,10 @@ Steps:
    added or renamed.
 7. `git add -A` then `git commit` with subject
    `docs(spec-loop): sync specs with contributed functionality` and a
-   `Generated-by: Claude (Opus 4.7)` trailer. **Do NOT touch
+   `Generated-by: <agent> (<model>)` trailer, where `<agent>` and
+   `<model>` are the actual agent and model you are running as (e.g.
+   `Claude (Opus 4.8)`, `OpenCode (Big Pickle)`) — do not hardcode
+   either. **Do NOT touch
    `tools/spec-loop/.last-sync` yourself** — `loop.sh` amends the marker
    into this commit after you finish, so the next `update` run knows to
    scope from `$BASE_HEAD`. Leaving it alone avoids merge conflicts with


### PR DESCRIPTION
## Summary

The Generated-by trailer was hardcoded to "Claude (Opus 4.7)" in every spec-loop beat prompt. The loop can run under a different model, and even under a non-Claude agent (e.g. OpenCode), so a fixed string mislabels who produced the commit.

Change the trailer instruction to `Generated-by: <agent> (<model>)` and tell the agent to fill in the actual agent and model it is running as (e.g. `Claude (Opus 4.8)`, `OpenCode (Big Pickle)`), never a hardcoded version. Updated PROMPT_build.md, PROMPT_update.md, PROMPT_consolidate.md, and AGENTS.md.

Generated-by: Claude (Opus 4.8)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
