### PR TITLE
fix(setup): warn before the sandboxed snapshot rm/clone hits the nested .git

### DIFF
--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -279,6 +279,13 @@ Per the chosen method (FRESH) or per the committed lock
   verify, `unzip` to `.apache-magpie/`. Re-fetch
   verification details into `<committed-lock>` (FRESH only).
 
+**Sandboxed agents:** for the `git-branch` / `git-tag` methods
+the clone writes the snapshot's nested `.apache-magpie/.git/`,
+which is in Claude Code's git-internals write-deny set, so the
+clone fails with `operation not permitted`. Only the local
+`.git/` write is blocked (the fetch host is allowlisted) —
+propose a sandbox bypass to the operator before cloning.
+
 If `<snapshot-dir>/` already exists with content, skip the
 fetch — the recipe ran first and left the snapshot in place.
 

--- a/skills/setup/upgrade.md
+++ b/skills/setup/upgrade.md
@@ -168,6 +168,14 @@ The snapshot is gitignored — destroying it loses no
 committed work. Do this **before** the new install to avoid
 "new layered on top of old" partial state.
 
+**Sandboxed agents:** the snapshot's nested `.git/` (its
+`config` + `hooks/*.sample`) sits in Claude Code's built-in
+git-internals write-deny set, so this `rm -rf` fails with
+`operation not permitted` and leaves the snapshot half-deleted.
+Propose a sandbox bypass to the operator *before* running it —
+the same propose-then-bypass pattern Step 6c uses for its
+`.claude/` writes.
+
 ## Step 4 — Install per the committed lock
 
 Per `<committed-lock>.method`:
@@ -183,6 +191,13 @@ Per `<committed-lock>.method`:
   `unzip` to `.apache-magpie/`. The verification step is
   **mandatory**; mismatched SHA-512 stops the upgrade and
   surfaces the discrepancy.
+
+**Sandboxed agents (git methods):** writing the clone's nested
+`.apache-magpie/.git/hooks/*.sample` hits the same git-internals
+write-deny set, so `git clone` fails with `operation not
+permitted`. The fetch host is already allowlisted — only the
+local `.git/` write needs the bypass; propose it before cloning,
+as in Step 3.
 
 After install, capture the actual on-disk state for the
 new `<local-lock>`:


### PR DESCRIPTION
## Summary

- Under a Claude Code sandbox, `upgrade` Step 3 (`rm -rf .apache-magpie`), Step 4 (`git clone`), and `adopt`'s snapshot fetch fail with `operation not permitted` — the snapshot's nested `.git/` is in the sandbox's git-internals write-deny set.
- Step 6c already proposes a bypass for its `.claude/` writes; these earlier steps didn't, so a sandboxed run hit a hard failure (and a half-deleted snapshot) with no guidance. Adds the matching propose-then-bypass note to all three spots.

## Type of change

- [X] Skill change (`skills/setup/`) — prose/instruction clarification, no behaviour-eval fixture (the copied bootstrap `setup` skill has no eval suite)
- [X] Documentation

## Test plan

- [X] `prek run --files skills/setup/upgrade.md skills/setup/adopt.md` passes (markdownlint, lychee link-check, check-placeholders, skill-and-tool-validate)
- Prose-only; the notes reference Step 3 / Step 6c by name (no new links).

## RFC-AI-0004 compliance

- [X] **HITL** — the added guidance *strengthens* HITL: propose the bypass to the operator before the destructive/clone step
- [X] **Sandbox** — documents the existing sandbox deny-set behaviour; no new host access

## Linked issues

(none — surfaced while running `/magpie-setup upgrade`)
