### PR TITLE
fix(evals/gfi-sweep): auto-grade step-3-present-proposals MANUAL fallback

### DIFF
--- a/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/assertions.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/assertions.json
@@ -1,0 +1,6 @@
+{
+  "has_label_confirmation_prompt": {
+    "type": "field_true",
+    "field": "has_label_confirmation_prompt"
+  }
+}

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/grading-schema.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/grading-schema.json
@@ -1,0 +1,3 @@
+{
+  "prose_fields": []
+}


### PR DESCRIPTION
## Summary

Add assertions.json mapping has_label_confirmation_prompt to a field_true predicate, and grading-schema.json setting prose_fields=[] so all remaining boolean/integer fields are exact-compared. With assertions.json present the runner no longer routes to MANUAL; all four cases (ready-only, mixed, near-miss-only, injection-flagged) now report PASS or FAIL automatically.

No skill edit — fixtures-only change, per the plan item.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other: eval change

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [X] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
