### PR TITLE
docs(allocation): document security@apache.org email as alternative CVE allocation path

### DIFF
--- a/skills/security-cve-allocate/SKILL.md
+++ b/skills/security-cve-allocate/SKILL.md
@@ -459,6 +459,14 @@ that point the original triager (or the authorised member) can
 re-invoke this skill with the CVE ID as an override argument to
 resume from Step 4.
 
+**Fallback when no governance-authorised member is reachable:**
+if every authorised member is unavailable or unresponsive, send
+an email to `security@apache.org` with subject
+`CVE request for <one-line description>`. The ASF Security Team
+will allocate the CVE and send the ID back. Re-invoke this skill
+with the returned `CVE-YYYY-NNNNN` as an override to resume from
+Step 4.
+
 **Wait for the user** to report back a `CVE-\d{4}-\d+` token. Do
 not proceed to Step 4 until that token has arrived. If the user
 says they cannot allocate right now (no authorised member

--- a/tools/cve-tool-vulnogram/allocation.md
+++ b/tools/cve-tool-vulnogram/allocation.md
@@ -64,6 +64,14 @@ Concrete PMC-member handles live in the project's roster file at
 the ASF project page,
 `https://projects.apache.org/committee.html?<project>`.
 
+**Fallback when no PMC member is reachable:** send an email to
+`security@apache.org` with subject
+`CVE request for <one-line description>`. The ASF Security Team
+will allocate the CVE and send the ID back. Re-invoke
+[`security-cve-allocate`](../../skills/security-cve-allocate/SKILL.md)
+with the returned `CVE-YYYY-NNNNN` as an override to resume from
+Step 4.
+
 ## Form fields and where the skill sources them
 
 | Vulnogram form field | Source in the tracker |


### PR DESCRIPTION
## Summary

Adds a documentation note in both allocation.md and security-cve-allocate skill describing the email-based fallback for CVE allocation when no PMC / governance-authorised member is reachable, per ASF policy at https://www.apache.org/security/committers.html.

## Type of change

<!-- Tick all that apply. -->

- [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [x] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [x] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #178

## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->
