### PR TITLE
feat(tools): regenerate vendor-neutrality score doc block as a prek hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,6 +146,26 @@ repos:
         entry: tools/dev/check-placeholders.sh
         files: ^(skills/.*|tools/.*)\.(md|sh|py|yaml|yml|toml)$
         pass_filenames: false
+  # Vendor-neutrality score — regenerate the block embedded in
+  # docs/vendor-neutrality.md from repository metadata (tool README
+  # `**Vendor:**` / `**Harness:**` fields, skill frontmatter, the
+  # privacy-llm registry) so the published number never drifts from the
+  # tree. `--in-place` rewrites the block and exits non-zero when it
+  # changed, so a stale doc fails the commit and the contributor re-stages
+  # the regenerated file — the doctoc pattern, but for a computed score.
+  # `pass_filenames: false`: the scorer always reads the whole tree; the
+  # `files:` filter only gates *whether* the regen fires (and it always
+  # runs on `prek run --all-files` in CI). Deterministic and offline, so
+  # the same tree always yields the same block. Tool + tests + scoring
+  # rule live in tools/vendor-neutrality-score (README + tests).
+  - repo: local
+    hooks:
+      - id: vendor-neutrality-score
+        name: Regenerate the vendor-neutrality score in docs/vendor-neutrality.md
+        language: system
+        entry: uv run --project tools/vendor-neutrality-score vendor-neutrality-score --in-place
+        files: ^(tools/[^/]+/README\.md|tools/privacy-llm/models\.md|tools/vendor-neutrality-score/.*|skills/[^/]+/SKILL\.md|docs/vendor-neutrality\.md)$
+        pass_filenames: false
   # Self-adoption symlink hygiene: reject cyclic symlinks and misdirected
   # skill relays. `types: [symlink]` fires it on any staged symlink (always
   # on `prek run --all-files`). Rules, rationale, and the pytest suite live

--- a/tools/vendor-neutrality-score/README.md
+++ b/tools/vendor-neutrality-score/README.md
@@ -7,6 +7,7 @@
   - [What it reads](#what-it-reads)
   - [The scoring rule](#the-scoring-rule)
   - [Usage](#usage)
+  - [Keeping `docs/vendor-neutrality.md` in sync](#keeping-docsvendor-neutralitymd-in-sync)
   - [Run tests](#run-tests)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -78,12 +79,27 @@ uv run --project tools/vendor-neutrality-score vendor-neutrality-score
 # Machine-readable JSON
 uv run --project tools/vendor-neutrality-score vendor-neutrality-score --json
 
-# Regenerate the block embedded in docs/vendor-neutrality.md
+# Print the block embedded in docs/vendor-neutrality.md
 uv run --project tools/vendor-neutrality-score vendor-neutrality-score --markdown
+
+# Rewrite that block in docs/vendor-neutrality.md in place; exits non-zero
+# if it changed anything (this is what the pre-commit hook runs)
+uv run --project tools/vendor-neutrality-score vendor-neutrality-score --in-place
 
 # CI gate: fail if neutrality drops below a threshold
 uv run --project tools/vendor-neutrality-score vendor-neutrality-score --fail-under 80
 ```
+
+## Keeping `docs/vendor-neutrality.md` in sync
+
+The `vendor-neutrality-score` pre-commit hook (`.pre-commit-config.yaml`)
+runs `--in-place` and fails the commit when the generated block between the
+`<!-- BEGIN vendor-neutrality-score … -->` / `<!-- END … -->` markers no
+longer matches the tree — mirroring how `doctoc` keeps a table of contents
+current. It fires whenever a tool `README.md`, a skill `SKILL.md`, the
+`privacy-llm` model registry, this tool, or the doc itself changes; when it
+rewrites the block, re-stage `docs/vendor-neutrality.md` and commit again.
+`test_doc_block_is_in_sync` guards the same invariant in CI.
 
 ## Run tests
 

--- a/tools/vendor-neutrality-score/src/vendor_neutrality_score/__init__.py
+++ b/tools/vendor-neutrality-score/src/vendor_neutrality_score/__init__.py
@@ -694,6 +694,56 @@ def render_markdown(
 
 
 # ---------------------------------------------------------------------------
+# Generated-block sync (docs/vendor-neutrality.md)
+# ---------------------------------------------------------------------------
+
+DOC_RELPATH = Path("docs") / "vendor-neutrality.md"
+DOC_BEGIN = "<!-- BEGIN vendor-neutrality-score"
+DOC_END = "<!-- END vendor-neutrality-score -->"
+
+
+def render_doc(repo_root: Path) -> str:
+    """Return the full docs/vendor-neutrality.md text with the generated block refreshed.
+
+    The block is considered in sync when its *content* (stripped of surrounding
+    whitespace) already matches the tool output — the same equality the
+    ``test_doc_block_is_in_sync`` guard uses. When it is in sync the document is
+    returned byte-for-byte unchanged, so the hook never churns the file over a
+    stray blank line or an environment-specific whitespace quirk; only a genuine
+    content change triggers a rewrite (which normalises the spacing to a single
+    blank line on each side of the block).
+    """
+    doc_path = repo_root / DOC_RELPATH
+    doc = doc_path.read_text(encoding="utf-8")
+    begin_idx = doc.find(DOC_BEGIN)
+    end_idx = doc.find(DOC_END)
+    if begin_idx == -1 or end_idx == -1:
+        raise ValueError(f"regen markers missing from {DOC_RELPATH}")
+    # Preserve the BEGIN comment (everything up to and including its closing "-->").
+    marker_end = doc.find("-->", begin_idx)
+    if marker_end == -1 or marker_end > end_idx:
+        raise ValueError(f"malformed BEGIN marker in {DOC_RELPATH}")
+    marker_end += len("-->")
+    block = render_markdown(*compute_all(repo_root)).strip()
+    if doc[marker_end:end_idx].strip() == block:
+        return doc  # content already in sync — leave the bytes untouched
+    return doc[:marker_end] + "\n\n" + block + "\n\n" + doc[end_idx:]
+
+
+def write_doc_block(repo_root: Path) -> bool:
+    """Refresh the generated block in docs/vendor-neutrality.md in place.
+
+    Returns True if the file was changed, False if it was already in sync.
+    """
+    doc_path = repo_root / DOC_RELPATH
+    new_text = render_doc(repo_root)
+    if new_text == doc_path.read_text(encoding="utf-8"):
+        return False
+    doc_path.write_text(new_text, encoding="utf-8")
+    return True
+
+
+# ---------------------------------------------------------------------------
 # CLI
 # ---------------------------------------------------------------------------
 
@@ -726,6 +776,14 @@ def main(argv: Iterable[str] | None = None) -> int:
     group.add_argument(
         "--markdown", action="store_true", help="Emit the generated block for docs/vendor-neutrality.md."
     )
+    group.add_argument(
+        "--in-place",
+        action="store_true",
+        help=(
+            "Rewrite the generated block in docs/vendor-neutrality.md and exit non-zero "
+            "if it changed (for the pre-commit hook)."
+        ),
+    )
     parser.add_argument(
         "--fail-under",
         type=int,
@@ -741,6 +799,19 @@ def main(argv: Iterable[str] | None = None) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
+
+    if args.in_place:
+        try:
+            changed = write_doc_block(repo_root)
+        except ValueError as exc:
+            print(f"error: {exc}", file=sys.stderr)
+            return 2
+        rel = DOC_RELPATH.as_posix()
+        if changed:
+            print(f"regenerated {rel} — re-stage it and commit again", file=sys.stderr)
+            return 1
+        print(f"{rel} already in sync")
+        return 0
 
     if args.json:
         print(render_json(contract_results, skill_results, harness_results, llm_classes))

--- a/tools/vendor-neutrality-score/tests/test_vendor_neutrality_score.py
+++ b/tools/vendor-neutrality-score/tests/test_vendor_neutrality_score.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -306,3 +307,88 @@ def test_main_json_exits_zero() -> None:
 def test_fail_under_gate() -> None:
     # Far above any achievable score → non-zero exit.
     assert vns.main(["--fail-under", "101"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# In-place doc regeneration (the pre-commit hook)
+# ---------------------------------------------------------------------------
+
+
+def _mirror_repo(root: Path, live: Path) -> None:
+    """Build a repo_root whose inputs symlink the live tree but whose
+    docs/vendor-neutrality.md is a real, mutable copy."""
+    (root / "tools").symlink_to(live / "tools")
+    (root / "skills").symlink_to(live / "skills")
+    docs = root / "docs"
+    docs.mkdir()
+    (docs / "labels-and-capabilities.md").symlink_to(live / "docs" / "labels-and-capabilities.md")
+    (docs / "vendor-neutrality.md").write_text(
+        (live / "docs" / "vendor-neutrality.md").read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+
+def test_render_doc_matches_live_file_when_in_sync() -> None:
+    root = vns.find_repo_root()
+    rendered = vns.render_doc(root)
+    assert rendered == (root / vns.DOC_RELPATH).read_text(encoding="utf-8")
+
+
+def test_write_doc_block_is_noop_when_in_sync() -> None:
+    assert vns.write_doc_block(vns.find_repo_root()) is False
+
+
+def test_in_sync_content_with_non_normalized_whitespace_is_a_noop(tmp_path) -> None:
+    """A block whose content matches but whose surrounding whitespace is not the
+    normalised single blank line must be left untouched — the hook keys on
+    content, not byte-exact spacing, so it never churns the file (this is the
+    scenario that made the byte-exact comparison fail on CI)."""
+    _mirror_repo(tmp_path, vns.find_repo_root())
+    doc = tmp_path / vns.DOC_RELPATH
+    text = doc.read_text(encoding="utf-8")
+    marker_end = text.index("-->", text.index(vns.DOC_BEGIN)) + len("-->")
+    end = text.index(vns.DOC_END)
+    block = text[marker_end:end].strip()
+    # Extra blank lines around the (unchanged) block content.
+    doc.write_text(text[:marker_end] + "\n\n\n" + block + "\n\n\n" + text[end:], encoding="utf-8")
+
+    before = doc.read_text(encoding="utf-8")
+    assert vns.write_doc_block(tmp_path) is False
+    assert doc.read_text(encoding="utf-8") == before  # bytes untouched
+    assert vns.render_doc(tmp_path) == before
+
+
+def test_write_doc_block_regenerates_stale_block(tmp_path) -> None:
+    _mirror_repo(tmp_path, vns.find_repo_root())
+    doc = tmp_path / vns.DOC_RELPATH
+    # Corrupt the generated block so it goes stale.
+    text = doc.read_text(encoding="utf-8")
+    marker_end = text.index("-->", text.index(vns.DOC_BEGIN)) + len("-->")
+    end = text.index(vns.DOC_END)
+    doc.write_text(text[:marker_end] + "\n\nSTALE\n\n" + text[end:], encoding="utf-8")
+
+    assert vns.write_doc_block(tmp_path) is True
+    assert vns.write_doc_block(tmp_path) is False  # idempotent second run
+    refreshed = doc.read_text(encoding="utf-8")
+    assert "STALE" not in refreshed
+    block = refreshed.split(vns.DOC_BEGIN, 1)[1].split("-->", 1)[1].split(vns.DOC_END, 1)[0].strip()
+    assert block == vns.render_markdown(*vns.compute_all(tmp_path)).strip()
+
+
+def test_in_place_cli_exit_codes(tmp_path) -> None:
+    _mirror_repo(tmp_path, vns.find_repo_root())
+    doc = tmp_path / vns.DOC_RELPATH
+    text = doc.read_text(encoding="utf-8")
+    marker_end = text.index("-->", text.index(vns.DOC_BEGIN)) + len("-->")
+    end = text.index(vns.DOC_END)
+    doc.write_text(text[:marker_end] + "\n\nSTALE\n\n" + text[end:], encoding="utf-8")
+
+    # First run rewrites the file → exit 1; second run is already in sync → exit 0.
+    assert vns.main(["--in-place", "--repo-root", str(tmp_path)]) == 1
+    assert vns.main(["--in-place", "--repo-root", str(tmp_path)]) == 0
+
+
+def test_render_doc_raises_without_markers(tmp_path) -> None:
+    _mirror_repo(tmp_path, vns.find_repo_root())
+    (tmp_path / vns.DOC_RELPATH).write_text("no markers here\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="markers missing"):
+        vns.render_doc(tmp_path)


### PR DESCRIPTION
## What

`tools/vendor-neutrality-score` can print the generated block for
`docs/vendor-neutrality.md` (`--markdown`), but nothing kept the *published*
block in sync with the tree — `test_doc_block_is_in_sync` only fails after
the fact. This wires the generation into prek so the block is regenerated on
commit, the same way `doctoc` keeps a table of contents current.

## Changes

- **`--in-place` mode** (`render_doc` / `write_doc_block`): rewrites the block
  between the `<!-- BEGIN vendor-neutrality-score … -->` / `<!-- END … -->`
  markers and exits non-zero when it changed anything, so a stale doc fails
  the commit and the contributor re-stages the regenerated file.
- **`.pre-commit-config.yaml`**: a `local` `vendor-neutrality-score` hook runs
  `--in-place`, gated by `files:` to tool `README.md`s, skill `SKILL.md`s, the
  `privacy-llm` model registry, the tool itself, and the doc; `pass_filenames:
  false` because the scorer always reads the whole tree. Deterministic and
  offline, so the same tree always yields the same block.
- **Tests**: live round-trip, no-op-when-in-sync, stale-block regeneration +
  idempotency, CLI exit codes (1 then 0), and missing-markers `ValueError`.
- **README**: documents `--in-place` and the sync hook.

## Testing

- `uv run --project tools/vendor-neutrality-score --group dev pytest` → 32 passed
- Full `prek` run green (new hook, workspace ruff/mypy/pytest, sandbox-lint,
  skill-and-tool-validate).
- Verified the fail→regenerate→pass cycle: corrupting the block fails the
  hook, which rewrites it; a second run passes; the doc is restored byte-identical.