### PR TITLE
docs(vulnogram): add oss-security@lists.openwall.com to advisory send checklist

### DIFF
--- a/tools/cve-tool-vulnogram/record.md
+++ b/tools/cve-tool-vulnogram/record.md
@@ -37,8 +37,9 @@ Per-project URL templates live in
 | `#email` tab (preview the advisory email before sending) | `https://cveprocess.apache.org/cve5/<CVE-ID>#email` |
 
 The `#email` tab is the **email-preview** surface: it renders the
-advisory exactly as Vulnogram will send it to `<users-list>` and
-`<announce-list>` — same subject, same body, same recipient list.
+advisory exactly as Vulnogram will send it to `<users-list>`,
+`<announce-list>`, and `oss-security@lists.openwall.com` (as BCC)
+— same subject, same body, same recipient list.
 The release-manager checklist in
 [the *Release-manager checklist* section below](#release-manager-checklist)
 calls this out as a load-bearing checkpoint **before** hitting Send,
@@ -274,7 +275,10 @@ flow described in [*`#source` paste flow*](#source-paste-flow):
    regenerate, re-paste in `#source`, and re-preview.
 
 5. **Send the advisory emails.** Vulnogram dispatches to
-   `<users-list>` and `<announce-list>`. On the tracker, add the
+   `<users-list>`, `<announce-list>`, and
+   `oss-security@lists.openwall.com` (as BCC per the
+   [ASF security-committers policy](https://www.apache.org/security/committers.html)).
+   On the tracker, add the
    `announced - emails sent` label and remove `fix released`.
 
 6. **Wait for the publication-ready notification comment.** The

--- a/tools/cve-tool-vulnogram/record.md
+++ b/tools/cve-tool-vulnogram/record.md
@@ -37,9 +37,8 @@ Per-project URL templates live in
 | `#email` tab (preview the advisory email before sending) | `https://cveprocess.apache.org/cve5/<CVE-ID>#email` |
 
 The `#email` tab is the **email-preview** surface: it renders the
-advisory exactly as Vulnogram will send it to `<users-list>`,
-`<announce-list>`, and `oss-security@lists.openwall.com` (as BCC)
-— same subject, same body, same recipient list.
+advisory exactly as Vulnogram will send it to `<users-list>` and
+`<announce-list>` — same subject, same body, same recipient list.
 The release-manager checklist in
 [the *Release-manager checklist* section below](#release-manager-checklist)
 calls this out as a load-bearing checkpoint **before** hitting Send,
@@ -275,9 +274,11 @@ flow described in [*`#source` paste flow*](#source-paste-flow):
    regenerate, re-paste in `#source`, and re-preview.
 
 5. **Send the advisory emails.** Vulnogram dispatches to
-   `<users-list>`, `<announce-list>`, and
-   `oss-security@lists.openwall.com` (as BCC per the
-   [ASF security-committers policy](https://www.apache.org/security/committers.html)).
+   `<users-list>` and `<announce-list>`.
+   **Then manually send a copy to
+   [`oss-security@lists.openwall.com`](https://oss-security.openwall.org/)
+   (required per the
+   [ASF security-committers policy](https://www.apache.org/security/committers.html)).**
    On the tracker, add the
    `announced - emails sent` label and remove `fix released`.
 

--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
@@ -113,7 +113,7 @@ Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** fie
 
 ### Step 2 of 3 — preview the advisory email, then send it
 
-With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC per the [ASF security-committers policy](https://www.apache.org/security/committers.html)).
+With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
 
 **Check that:**
 - The subject line is `CVE_ID: <one-line description>` and the description matches what you'd want public.
@@ -123,7 +123,7 @@ With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `
 
 **If anything looks wrong**: don't edit it in Vulnogram. Comment on this tracker (just `@potiuk: the X field needs Y`) and we'll fix the corresponding body field here, regenerate the JSON, and re-push within the next sync. Re-preview after that.
 
-**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC). **That is the only manual send action you make for this CVE.**
+**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **Then manually send a copy to [`oss-security@lists.openwall.com`](https://oss-security.openwall.org/) (required per the [ASF security-committers policy](https://www.apache.org/security/committers.html)).** **That is the only Vulnogram send action you make for this CVE.**
 
 > ⚠️ **Do not touch the tracker labels yourself.** Sync flips `fix released` → `announced - emails sent` + `announced` automatically when it sees the advisory in the public archive (usually within the same day). If you flip them manually you race the automation.
 

--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment-oauth-pushed.md
@@ -113,7 +113,7 @@ Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** fie
 
 ### Step 2 of 3 — preview the advisory email, then send it
 
-With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
+With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC per the [ASF security-committers policy](https://www.apache.org/security/committers.html)).
 
 **Check that:**
 - The subject line is `CVE_ID: <one-line description>` and the description matches what you'd want public.
@@ -123,7 +123,7 @@ With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `
 
 **If anything looks wrong**: don't edit it in Vulnogram. Comment on this tracker (just `@potiuk: the X field needs Y`) and we'll fix the corresponding body field here, regenerate the JSON, and re-push within the next sync. Re-preview after that.
 
-**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **That is the only manual send action you make for this CVE.**
+**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC). **That is the only manual send action you make for this CVE.**
 
 > ⚠️ **Do not touch the tracker labels yourself.** Sync flips `fix released` → `announced - emails sent` + `announced` automatically when it sees the advisory in the public archive (usually within the same day). If you flip them manually you race the automation.
 

--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
@@ -115,7 +115,7 @@ Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** fie
 
 ### Step 2 of 3 — preview the advisory email, then send it
 
-With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
+With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC per the [ASF security-committers policy](https://www.apache.org/security/committers.html)).
 
 **Check that:**
 - The subject line is `CVE_ID: <one-line description>` and the description matches what you'd want public.
@@ -125,7 +125,7 @@ With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `
 
 **If anything looks wrong**: don't edit it in Vulnogram. Comment on this tracker (just `@potiuk: the X field needs Y`) and we'll fix the corresponding body field here, regenerate the JSON, and re-push within the next sync. Re-preview after that.
 
-**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **That is the only manual send action you make for this CVE.**
+**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC). **That is the only manual send action you make for this CVE.**
 
 > ⚠️ **Do not touch the tracker labels yourself.** Sync flips `fix released` → `announced - emails sent` + `announced` automatically when it sees the advisory in the public archive (usually within the same day). If you flip them manually you race the automation.
 

--- a/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
+++ b/tools/cve-tool-vulnogram/release-manager-handoff-comment.md
@@ -115,7 +115,7 @@ Open the record's [`#source` tab](SOURCE_TAB_URL) in your browser. **State** fie
 
 ### Step 2 of 3 — preview the advisory email, then send it
 
-With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC per the [ASF security-committers policy](https://www.apache.org/security/committers.html)).
+With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `#email` anchor) on the same record page. This shows you, in the exact format that goes out, what the advisory email will look like when sent to `USERS_LIST` and `ANNOUNCE_LIST`.
 
 **Check that:**
 - The subject line is `CVE_ID: <one-line description>` and the description matches what you'd want public.
@@ -125,7 +125,7 @@ With the record in `READY`, click the [OSS/ASF Emails tab](EMAIL_TAB_URL) (the `
 
 **If anything looks wrong**: don't edit it in Vulnogram. Comment on this tracker (just `@potiuk: the X field needs Y`) and we'll fix the corresponding body field here, regenerate the JSON, and re-push within the next sync. Re-preview after that.
 
-**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST`, `ANNOUNCE_LIST`, and `oss-security@lists.openwall.com` (as BCC). **That is the only manual send action you make for this CVE.**
+**If everything looks right**: click the **Send these Emails** button on the OSS/ASF Emails tab. The advisory ships to `USERS_LIST` and `ANNOUNCE_LIST`. **Then manually send a copy to [`oss-security@lists.openwall.com`](https://oss-security.openwall.org/) (required per the [ASF security-committers policy](https://www.apache.org/security/committers.html)).** **That is the only Vulnogram send action you make for this CVE.**
 
 > ⚠️ **Do not touch the tracker labels yourself.** Sync flips `fix released` → `announced - emails sent` + `announced` automatically when it sees the advisory in the public archive (usually within the same day). If you flip them manually you race the automation.
 


### PR DESCRIPTION
## Summary

Moves the oss-security@lists.openwall.com announcement requirement from the generic process docs into the ASF-specific Vulnogram adapter, per review feedback. Updated three files in the adapter.

The ASF security-committers policy (https://www.apache.org/security/committers.html) requires that every vulnerability announcement also be sent to oss-security@lists.openwall.com (subscription not required). This is now documented in the ASF-specific CVE-tool adapter where it belongs.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [x] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `prek run markdownlint typos trailing-whitespace --all-files` passes

## Linked issues

Closes #176

## Notes for reviewers

Per feedback from potiuk on the first iteration: the oss-security requirement is ASF-specific and belongs in the Vulnogram adapter (`tools/cve-tool-vulnogram/`), not in the generic process docs (`docs/security/`). The earlier process.md/roles.md changes have been reverted.