### PR TITLE
ci(tests): skip the pytest job on an empty matrix instead of failing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,6 +146,13 @@ jobs:
     name: "pytest (${{ matrix.project.name }})"
     runs-on: ubuntu-latest
     needs: members
+    # Guard against an empty selection. When the path filter selects no
+    # members (a PR that changed no project's Python), the members output
+    # is `[]`; feeding an empty array to `matrix` makes GitHub mark this
+    # job `failure` ("matrix vector does not contain any values"), not
+    # `skipped` — which would fail `tests-ok`. Skipping the job on an
+    # empty list yields the `skipped` result `tests-ok` treats as a pass.
+    if: ${{ needs.members.outputs.members != '[]' }}
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
## Problem

The pytest path-filter added in #751 can legitimately select **zero**
workspace members — a PR that changes no project's Python (docs / skill /
eval-fixture only). Feeding an empty array to a job `matrix` makes GitHub
mark the job **`failure`** ("matrix vector 'project' does not contain any
values"), not `skipped`. Because `tests-ok` treats anything other than
`success`/`skipped` as a failure, such PRs went red with nothing actually
wrong.

Observed on #745 (onboarding-concierge): 0 pytest jobs ran, yet `tests-ok`
failed with `result="failure"`.

## Fix

Guard the `pytest` job:

```yaml
if: ${{ needs.members.outputs.members != '[]' }}
```

An empty selection now **skips** the job (result `skipped`), which
`tests-ok` already treats as a pass. Non-empty selections are unaffected.

## Note

My earlier assumption in #751 that an empty matrix yields `skipped` was
wrong — it yields `failure`. This is the one-line follow-up.

Generated-by: Claude Code (Opus 4.8)
