### PR TITLE
chore(tools/ponymail): attribute the archive backend to ASF, not PonyMail

### DIFF
--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -555,8 +555,8 @@ generated block below.
 | `contract:tracker` | ✅ | vendor-backed | Atlassian, Fossil, GitHub, SourceHut | 4 backend vendors: Atlassian, Fossil, GitHub, SourceHut |
 | `contract:source-control` | ✅ | vendor-backed | Fossil, Git, GitHub, SourceHut, Subversion | 5 backend vendors: Fossil, Git, GitHub, SourceHut, Subversion |
 | `contract:change-request` | ✅ | vendor-backed | Atlassian, GitHub, email | 3 backend vendors: Atlassian, GitHub, email |
-| `contract:mail-archive` | ✅ | vendor-backed | Google, PonyMail, SourceHut | 3 backend vendors: Google, PonyMail, SourceHut |
-| `contract:mail-source` | ✅ | vendor-backed | Google, Maildir, PonyMail | 3 backend vendors: Google, Maildir, PonyMail |
+| `contract:mail-archive` | ✅ | vendor-backed | ASF, Google, SourceHut | 3 backend vendors: ASF, Google, SourceHut |
+| `contract:mail-source` | ✅ | vendor-backed | ASF, Google, Maildir | 3 backend vendors: ASF, Google, Maildir |
 | `contract:mail-create` | ✅ | vendor-backed | Google, Maildir | 2 backend vendors: Google, Maildir |
 | `contract:cve-authority` | ✅ | vendor-backed | CVE.org, Vulnogram | 2 backend vendors: CVE.org, Vulnogram |
 | `contract:report-relay` | ✅ | agnostic | — | vendor-neutral by construction — one spec serves every backend |

--- a/tools/ponymail/README.md
+++ b/tools/ponymail/README.md
@@ -18,7 +18,7 @@
 
 **Kind:** implementation
 
-**Vendor:** PonyMail
+**Vendor:** ASF
 
 **Organization:** ASF
 


### PR DESCRIPTION
## What

PonyMail is **Apache PonyMail** — ASF infrastructure (`lists.apache.org`, the
`apache/comdev` `ponymail-mcp` server), not an independent vendor. This sets
`tools/ponymail/README.md` `**Vendor:**` from `PonyMail` to `ASF` so the
vendor-neutrality score counts the mail archive/source backend under ASF
rather than as its own vendor. (`**Organization:**` was already `ASF`.)

## Impact

No regression — both affected contracts keep three distinct backend vendors,
so the overall score stays at 10/10 (100%):

| Contract | Before | After |
|---|---|---|
| `contract:mail-archive` | Google, PonyMail, SourceHut | ASF, Google, SourceHut |
| `contract:mail-source` | Google, Maildir, PonyMail | ASF, Google, Maildir |

`docs/vendor-neutrality.md` was regenerated by the `vendor-neutrality-score`
prek hook (#747).

## Testing

- `uv run --project tools/vendor-neutrality-score --group dev pytest` → 33 passed
- Full local `prek` run green (vendor-neutrality regen hook confirms the doc is
  in sync; skill-and-tool-validate passes).