### PR TITLE
feat(tools/skill-and-tool-validator): add SOFT SKILL.md line-limit check

### DIFF
--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -17,7 +17,7 @@
 
 """Validate framework skill definitions.
 
-This module validates seventeen aspects of every skill under
+This module validates eighteen aspects of every skill under
 skills/:
 
 1. YAML frontmatter — every SKILL.md must have a valid frontmatter
@@ -126,6 +126,13 @@ skills/:
     mention the prompt-injection risk in embedded mail content. Both
     are advisories — the check warns without failing the run so legacy
     adapters can be brought into compliance deliberately.
+20. SKILL.md line-length limit (SOFT) — ``SKILL.md`` entrypoint files
+    must stay under ``SKILL_LINE_LIMIT`` (500) lines per PRINCIPLE 14.
+    Reference material beyond that limit should move into sibling
+    markdown files linked one level deep, with no unreferenced siblings.
+    Advisory only — existing skills that pre-date this check are flagged
+    for gradual migration; the check prevents new oversized entrypoints
+    from being merged unnoticed.
 
 SOFT categories surface as advisory warnings (stderr) without
 failing the run unless ``--strict`` is passed.
@@ -515,6 +522,11 @@ CAPABILITY_TAXONOMY_CATEGORY = "capability-taxonomy"
 # SOFT advisory: contract:mail-source and contract:mail-archive adapter READMEs must
 # declare the data-not-instructions posture and prompt-injection risk for fetched mail.
 MAIL_PRIVACY_CATEGORY = "mail-privacy-boundary"
+# SOFT advisory: SKILL.md entrypoint files must stay under SKILL_LINE_LIMIT lines
+# (PRINCIPLES.md).  Reference material beyond the limit should move into sibling
+# markdown files linked one level deep, with no unreferenced siblings.
+SKILL_LINE_LIMIT = 500
+SKILL_LINE_LIMIT_CATEGORY = "skill-line-limit"
 
 # The `magpie-` namespace prefix every installed framework skill carries.
 SKILL_NAME_PREFIX = "magpie-"
@@ -537,6 +549,7 @@ SOFT_CATEGORIES: frozenset[str] = frozenset(
         BRANCH_CONFIDENTIALITY_CATEGORY,
         CAPABILITY_TAXONOMY_CATEGORY,
         MAIL_PRIVACY_CATEGORY,
+        SKILL_LINE_LIMIT_CATEGORY,
     }
 )
 HARD_CATEGORIES: frozenset[str] = frozenset(
@@ -3517,6 +3530,30 @@ def validate_branch_name_confidentiality(path: Path, text: str) -> Iterable[Viol
                 )
 
 
+def validate_skill_line_limit(path: Path, text: str) -> Iterable[Violation]:
+    """SOFT advisory: SKILL.md entrypoint files must stay under SKILL_LINE_LIMIT lines.
+
+    PRINCIPLES.md requires SKILL.md to stay under 500 lines; reference material
+    beyond that limit moves into sibling markdown files linked one level deep, with
+    no unreferenced siblings.  Reported as SOFT so existing over-limit skills can be
+    migrated deliberately without blocking unrelated changes.
+    """
+    if path.name != "SKILL.md":
+        return
+    lines = text.splitlines()
+    line_count = len(lines)
+    if line_count > SKILL_LINE_LIMIT:
+        yield Violation(
+            path,
+            SKILL_LINE_LIMIT,
+            f"skill-line-limit: SKILL.md is {line_count} lines, exceeding the "
+            f"{SKILL_LINE_LIMIT}-line limit (PRINCIPLES.md §14) — move reference "
+            f"material into sibling markdown files linked one level deep; "
+            f"no unreferenced siblings",
+            category=SKILL_LINE_LIMIT_CATEGORY,
+        )
+
+
 def run_validation(root: Path | None = None) -> list[Violation]:
     """Run the full validation suite and return all violations."""
     repo_root = root or find_repo_root()
@@ -3541,6 +3578,7 @@ def run_validation(root: Path | None = None) -> list[Violation]:
             violations.extend(validate_privacy_patterns(path, text))
             violations.extend(validate_trigger_preservation(path, text, repo_root=repo_root))
             violations.extend(validate_asf_coupling(path, text))
+            violations.extend(validate_skill_line_limit(path, text))
 
         # All skill files get link + placeholder + security-pattern checks
         violations.extend(validate_links(path, text, skill_dirs, doc_files))
@@ -3678,6 +3716,7 @@ _SOFT_RULE_PREFIXES: tuple[str, ...] = (
     "lowercase-f-field",
     "mail-privacy-boundary",
     "modes-doc:",
+    "skill-line-limit",
     "multi-capability declared",
     "override-contract",
     "override-weakening",

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -57,6 +57,8 @@ from skill_and_tool_validator import (
     PRIVACY_CATEGORY,
     SECURITY_PATTERN_CATEGORY,
     SKILL_CAPABILITIES,
+    SKILL_LINE_LIMIT,
+    SKILL_LINE_LIMIT_CATEGORY,
     SKILL_SOURCE_CATEGORY,
     SOFT_CATEGORIES,
     STATUS_CATEGORY,
@@ -109,6 +111,7 @@ from skill_and_tool_validator import (
     validate_privacy_patterns,
     validate_project_template_drift,
     validate_security_patterns,
+    validate_skill_line_limit,
     validate_skill_source_descriptors,
     validate_skill_source_pointers,
     validate_tools,
@@ -4745,3 +4748,62 @@ class TestMailPrivacyBoundary:
         )
         violations = list(validate_mail_privacy_boundary(root))
         assert all(v.category == MAIL_PRIVACY_CATEGORY for v in violations)
+
+
+class TestValidateSkillLineLimit:
+    """Tests for the SOFT skill-line-limit check (aspect #20)."""
+
+    def _skill_md(self, tmp_path: Path, line_count: int) -> Path:
+        """Write a SKILL.md with exactly *line_count* lines under tmp_path."""
+        skill_dir = tmp_path / "skills" / "my-skill"
+        skill_dir.mkdir(parents=True)
+        skill_path = skill_dir / "SKILL.md"
+        lines = ["line"] * line_count
+        skill_path.write_text("\n".join(lines))
+        return skill_path
+
+    def test_under_limit_no_violation(self, tmp_path: Path) -> None:
+        path = self._skill_md(tmp_path, SKILL_LINE_LIMIT - 100)
+        text = path.read_text()
+        violations = list(validate_skill_line_limit(path, text))
+        assert violations == []
+
+    def test_at_limit_no_violation(self, tmp_path: Path) -> None:
+        path = self._skill_md(tmp_path, SKILL_LINE_LIMIT)
+        text = path.read_text()
+        violations = list(validate_skill_line_limit(path, text))
+        assert violations == []
+
+    def test_one_over_limit_fires_violation(self, tmp_path: Path) -> None:
+        path = self._skill_md(tmp_path, SKILL_LINE_LIMIT + 1)
+        text = path.read_text()
+        violations = list(validate_skill_line_limit(path, text))
+        assert len(violations) == 1
+
+    def test_violation_message_contains_line_count(self, tmp_path: Path) -> None:
+        line_count = SKILL_LINE_LIMIT + 42
+        path = self._skill_md(tmp_path, line_count)
+        text = path.read_text()
+        violations = list(validate_skill_line_limit(path, text))
+        assert str(line_count) in violations[0].message
+
+    def test_violation_message_contains_limit(self, tmp_path: Path) -> None:
+        path = self._skill_md(tmp_path, SKILL_LINE_LIMIT + 1)
+        text = path.read_text()
+        violations = list(validate_skill_line_limit(path, text))
+        assert str(SKILL_LINE_LIMIT) in violations[0].message
+
+    def test_violation_category_is_skill_line_limit(self, tmp_path: Path) -> None:
+        path = self._skill_md(tmp_path, SKILL_LINE_LIMIT + 1)
+        text = path.read_text()
+        violations = list(validate_skill_line_limit(path, text))
+        assert violations[0].category == SKILL_LINE_LIMIT_CATEGORY
+
+    def test_non_skill_md_not_checked(self, tmp_path: Path) -> None:
+        other = tmp_path / "SOMETHING.md"
+        other.write_text("\n".join(["line"] * (SKILL_LINE_LIMIT + 10)))
+        violations = list(validate_skill_line_limit(other, other.read_text()))
+        assert violations == []
+
+    def test_category_is_soft(self) -> None:
+        assert SKILL_LINE_LIMIT_CATEGORY in SOFT_CATEGORIES


### PR DESCRIPTION
## Summary

Adds check #20 to the skill-and-tool-validator: a SOFT advisory that flags
any `SKILL.md` entrypoint exceeding `SKILL_LINE_LIMIT` (500 lines), per
PRINCIPLES.md §14.

## Why

Oversized SKILL.md entrypoints should move reference material into sibling
markdown files linked one level deep. This check keeps new oversized
entrypoints from being merged unnoticed, while staying advisory so existing
over-limit skills can be migrated deliberately rather than blocking unrelated
work.

## Behaviour

- Category `skill-line-limit`, registered as SOFT: surfaces as a stderr
  advisory and does not fail the run unless `--strict` is passed.
- Only applies to files named `SKILL.md`.
- Message points to PRINCIPLES.md §14 and names the actual line count.
- Currently flags 19 pre-existing over-limit skills as advisories.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X ] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
