### PR TITLE
chore(setup): re-sync self-adoption symlinks missed by #730 and #752

### DIFF
--- a/.agents/skills/magpie-setup-upstream-fix
+++ b/.agents/skills/magpie-setup-upstream-fix
@@ -1,0 +1,1 @@
+../../skills/setup-upstream-fix

--- a/.claude/skills/magpie-setup-upstream-fix
+++ b/.claude/skills/magpie-setup-upstream-fix
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-setup-upstream-fix

--- a/.github/skills/magpie-pre-first-pr-check
+++ b/.github/skills/magpie-pre-first-pr-check
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-pre-first-pr-check

--- a/.github/skills/magpie-setup-upstream-fix
+++ b/.github/skills/magpie-setup-upstream-fix
@@ -1,0 +1,1 @@
+../../.agents/skills/magpie-setup-upstream-fix


### PR DESCRIPTION
## What

Running `/magpie-setup upgrade` on the framework checkout surfaced two
merged skill PRs that shipped without their committed self-adoption relay
symlinks, leaving the `.agents` / `.claude` / `.github` skill targets out of
balance with `skills/`:

- **`setup-upstream-fix`** (#730) had **no** `magpie-` symlink in any target.
- **`pre-first-pr-check`** (#752) was missing its `.github` relay.

## Change

Adds the missing canonical + relay links so all three targets balance with
`skills/` at **69/69/69**:

- `.agents/skills/magpie-setup-upstream-fix` → `../../skills/setup-upstream-fix` (canonical)
- `.claude/skills/magpie-setup-upstream-fix` → `../../.agents/skills/magpie-setup-upstream-fix` (relay)
- `.github/skills/magpie-setup-upstream-fix` → `../../.agents/skills/magpie-setup-upstream-fix` (relay)
- `.github/skills/magpie-pre-first-pr-check` → `../../.agents/skills/magpie-pre-first-pr-check` (relay)

Symlinks only; no skill content changes.

## Validation

- `symlink-lint` clean on all four links; `skill-and-tool-validate` reports no relay errors.
- All pre-commit hooks pass.

Generated-by: Claude Code (Opus 4.8)
