### PR TITLE
docs(education): use concise page names in the learning-progression table

### DIFF
--- a/docs/education/README.md
+++ b/docs/education/README.md
@@ -84,14 +84,14 @@ each builds on the ones before it.
 | # | Page | What you will learn |
 |---|---|---|
 | 1 | [What agents are](what-agents-are.md) | What an agent actually is (a model, tools, a loop, and context) and why its answers can vary |
-| 2 | [How to work with agents](working-with-agents.md) | Driving an agent through a conversation: how to ask, how to steer, when to confirm |
-| 3 | [How to use different models](choosing-models.md) | Choosing a model by capability, speed, and cost, and letting evals decide |
-| 4 | [How to write your first skill](your-first-skill.md) | Writing and merging your own skill, the main work in Magpie |
+| 2 | [Working with agents](working-with-agents.md) | Driving an agent through a conversation: how to ask, how to steer, when to confirm |
+| 3 | [Choosing models](choosing-models.md) | Choosing a model by capability, speed, and cost, and letting evals decide |
+| 4 | [Your first skill](your-first-skill.md) | Writing and merging your own skill, the main work in Magpie |
 | 5 | [Writing safe skills](writing-safe-skills.md) | Authoring patterns that hold the data-not-instructions and sandbox principles in every skill you write |
 | 6 | [Eval-driven development](eval-driven-development.md) | How to judge whether an agent's answers are good, when the answers can change |
-| 7 | [Agentic and autonomous work](agentic-work.md) | Letting an agent run a whole task, and the guardrails that make that safe |
-| 8 | [English as a programming language](english-as-code.md) | The mindset underneath it all: the words you write *are* the program |
-| 9 | [How to contribute to Magpie](contributing.md) | Giving your work back: contributing skills, patterns, and docs to the framework |
+| 7 | [Agentic & autonomous work](agentic-work.md) | Letting an agent run a whole task, and the guardrails that make that safe |
+| 8 | [English as code](english-as-code.md) | The mindset underneath it all: the words you write *are* the program |
+| 9 | [Contributing back](contributing.md) | Giving your work back: contributing skills, patterns, and docs to the framework |
 
 **Supporting references for the skill-writing steps (4 and 5):**
 


### PR DESCRIPTION
## Summary

- The learning-progression table in `docs/education/README.md` linked several pages with long "How to…" phrasings ("How to work with agents", "How to write your first skill", "English as a programming language", …).
- Switch them to the concise names used elsewhere (nav / site education graph): **Working with agents**, **Choosing models**, **Your first skill**, **Agentic & autonomous work**, **English as code**, **Contributing back**.
- Link targets and the "What you will learn" descriptions are unchanged — this is a link-text-only change to 6 table cells.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- [x] Rendered the page and eyeballed the table — the six links show the concise names, targets still resolve.
- [ ] `prek run --all-files` — not run in this environment; change is pure link text (no code, skills, tools, or evals touched).

## RFC-AI-0004 compliance

Docs-only, no behavioural surface — none of the HITL / sandbox / privacy items apply.

## Linked issues

_None._

## Notes for reviewers (optional)

After this change the progression link text no longer matches each page's own H1 (e.g. "Working with agents" vs. the page heading "How to work with agents"). That was intentional — the goal is short, scannable labels consistent with the nav and the site's education graph. Happy to instead align the page H1s to these names if you'd prefer link-text == heading.

Generated-by: Claude Code (Opus 4.8)
