### PR TITLE
feat(validator): add no-telemetry-import check (PRINCIPLE 10 guarantee)

### DIFF
--- a/tools/egress-gateway/tool.md
+++ b/tools/egress-gateway/tool.md
@@ -11,6 +11,7 @@
   - [Relationship to RFC-AI-0003](#relationship-to-rfc-ai-0003)
   - [How adopters consume this tool](#how-adopters-consume-this-tool)
   - [What this tool is NOT for](#what-this-tool-is-not-for)
+  - [Declared egress surfaces](#declared-egress-surfaces)
   - [Failure modes](#failure-modes)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -97,6 +98,44 @@ layers.
 - **Not** a sandbox replacement. The sandbox still owns filesystem isolation,
   credential denial, and bind restrictions; the gateway only adds an
   egress-allowlist chokepoint for outbound HTTP(S).
+
+## Declared egress surfaces
+
+**The default is zero outbound calls.**  The framework guarantees that no tool
+makes a network call unless the skill it backs explicitly performs an adapter
+action (PRINCIPLE 10).  This guarantee rests on two pillars:
+
+1. **Only declared adapter tools may egress.**  Tools that declare a
+   `contract:*` capability in their `README.md` are the named egress surfaces —
+   they communicate with their designated external systems (tracker APIs, mail
+   services, VCS hosts, CVE authorities, etc.) on behalf of skill steps that
+   ask for it.  The `egress-gateway` proxy itself is also a declared surface;
+   all other `substrate:*` tools are network-free by design.
+
+2. **The validator enforces the invariant.**  `tools/skill-and-tool-validator/`
+   check #21 (`no-telemetry-import`) scans the source of every `substrate:*`
+   tool for network-calling imports (`requests`, `httpx`, `aiohttp`,
+   `urllib.request`, `http.client`, `socket`) and flags any hit as a SOFT
+   advisory.  A substrate tool that accidentally grows a network import is
+   caught before it is merged.
+
+The declared egress surfaces as of this writing:
+
+| Tool | Capability | Egresses to |
+|------|-----------|-------------|
+| `egress-gateway` | `substrate:sandbox` | any host on the allowlist (forward proxy) |
+| `bitbucket` | `contract:change-request` | Bitbucket Cloud / Server REST API |
+| `fossil` | `contract:tracker + contract:source-control` | Fossil repository host |
+| `github`, `github-body-field`, `github-rollup` | `contract:tracker` / `contract:source-control` | GitHub API (`gh` CLI) |
+| `gmail` | `contract:mail-source + contract:mail-create + contract:mail-archive` | Gmail API |
+| `jira`, `jira-patch` | `contract:tracker` / `contract:change-request` | Jira REST API |
+| `maildir`, `mail-source`, `mail-archive`, `mail-patch` | `contract:mail-*` | local maildir / IMAP |
+| `ponymail` | `contract:mail-archive + contract:mail-source` | PonyMail REST API |
+| `sourcehut` | `contract:tracker + contract:source-control + contract:mail-archive` | sourcehut API |
+| `vcs` | `contract:source-control` | generic VCS host |
+| `apache-projects`, `asf-svn`, `cve-org`, `cve-tool`, `cve-tool-vulnogram`, `forwarder-relay`, `scan-format` | `contract:*` | ASF / CVE authorities / relay |
+
+All remaining tools (`substrate:*`) make no outbound calls.
 
 ## Failure modes
 

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -133,6 +133,15 @@ skills/:
     Advisory only — existing skills that pre-date this check are flagged
     for gradual migration; the check prevents new oversized entrypoints
     from being merged unnoticed.
+21. No-default-telemetry import check (SOFT) — PRINCIPLE 10 guarantees
+    zero outbound calls from the framework unless a skill's adapter
+    action explicitly makes them.  Only ``contract:*`` adapter tools and
+    the ``egress-gateway`` proxy are declared egress surfaces; all other
+    tools (``substrate:*``) must stay network-free.  Flags Python source
+    files under ``tools/<name>/src/`` that import ``requests``,
+    ``httpx``, ``aiohttp``, ``urllib.request``, ``http.client``, or
+    ``socket`` in tools that do not declare a ``contract:*`` capability.
+    Advisory only — never fails the run unless ``--strict``.
 
 SOFT categories surface as advisory warnings (stderr) without
 failing the run unless ``--strict`` is passed.
@@ -361,6 +370,27 @@ TOOL_CAPABILITIES = {
 }
 
 
+# ---------------------------------------------------------------------------
+# No-default-telemetry check constants (aspect #21, SOFT)
+# ---------------------------------------------------------------------------
+
+# The egress-gateway tool is a network proxy by design — it is the one
+# substrate tool permitted to make outbound connections.
+_EGRESS_TOOL_NAME = "egress-gateway"
+
+# Network-calling import patterns that must not appear in substrate tool source.
+# Each entry is (compiled line-level regex, human-readable library name).
+_NETWORK_IMPORT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
+    (re.compile(r"^\s*(?:import|from)\s+requests\b"), "requests"),
+    (re.compile(r"^\s*(?:import|from)\s+httpx\b"), "httpx"),
+    (re.compile(r"^\s*(?:import|from)\s+aiohttp\b"), "aiohttp"),
+    (re.compile(r"^\s*(?:import|from)\s+urllib\.request\b"), "urllib.request"),
+    (re.compile(r"^\s*from\s+urllib\s+import\s+(?:\w+\s*,\s*)*request\b"), "urllib.request"),
+    (re.compile(r"^\s*(?:import|from)\s+http\.client\b"), "http.client"),
+    (re.compile(r"^\s*import\s+socket\b"), "socket"),
+]
+
+
 def _read_mode_table() -> dict[str, str]:
     """Read the canonical MISSION mode table from ``docs/modes.md``."""
     starts = [Path.cwd().resolve(), Path(__file__).resolve().parent]
@@ -527,6 +557,10 @@ MAIL_PRIVACY_CATEGORY = "mail-privacy-boundary"
 # markdown files linked one level deep, with no unreferenced siblings.
 SKILL_LINE_LIMIT = 500
 SKILL_LINE_LIMIT_CATEGORY = "skill-line-limit"
+# SOFT advisory: substrate tools (substrate:*) must not import network-calling
+# modules — only contract:* adapter tools and the egress-gateway proxy are
+# declared egress surfaces (PRINCIPLE 10).
+NO_TELEMETRY_CATEGORY = "no-telemetry-import"
 
 # The `magpie-` namespace prefix every installed framework skill carries.
 SKILL_NAME_PREFIX = "magpie-"
@@ -550,6 +584,7 @@ SOFT_CATEGORIES: frozenset[str] = frozenset(
         CAPABILITY_TAXONOMY_CATEGORY,
         MAIL_PRIVACY_CATEGORY,
         SKILL_LINE_LIMIT_CATEGORY,
+        NO_TELEMETRY_CATEGORY,
     }
 )
 HARD_CATEGORIES: frozenset[str] = frozenset(
@@ -3554,6 +3589,66 @@ def validate_skill_line_limit(path: Path, text: str) -> Iterable[Violation]:
         )
 
 
+def validate_no_telemetry_imports(root: Path | None = None) -> Iterable[Violation]:
+    """SOFT advisory: substrate tools must not import network-calling modules.
+
+    The framework guarantees zero outbound calls unless a skill's adapter
+    action explicitly makes them (PRINCIPLE 10).  Only ``contract:*`` adapter
+    tools and the ``egress-gateway`` proxy are declared egress surfaces; all
+    other tools (``substrate:*``) must stay network-free.
+
+    Flags Python source files under ``tools/<name>/src/`` that import
+    ``requests``, ``httpx``, ``aiohttp``, ``urllib.request``, ``http.client``,
+    or ``socket`` in tools that do not declare a ``contract:*`` capability.
+
+    Advisory only — never fails the run unless ``--strict``.
+    See ``tools/egress-gateway/tool.md`` § Declared egress surfaces.
+    """
+    for tool_dir in collect_tool_dirs(root):
+        if tool_dir.name == _EGRESS_TOOL_NAME:
+            continue  # the proxy itself makes network calls by design
+
+        readme = tool_dir / "README.md"
+        if readme.exists():
+            try:
+                readme_text = readme.read_text(encoding="utf-8")
+            except OSError:
+                readme_text = ""
+            cap_match = TOOL_CAPABILITY_RE.search(readme_text)
+            if cap_match is not None:
+                raw = cap_match.group(1).strip()
+                entries = [e.strip() for e in raw.split("+") if e.strip()]
+                if any(e.startswith(_ADAPTER_CONTRACT_PREFIX) for e in entries):
+                    continue  # declared contract:* adapter — network is expected
+
+        src_dir = tool_dir / "src"
+        if not src_dir.is_dir():
+            continue
+
+        for py_path in sorted(src_dir.rglob("*.py")):
+            if any(part in _LICENSE_SKIP_PATH_PARTS for part in py_path.parts):
+                continue
+            try:
+                py_text = py_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+
+            for line_no, line in enumerate(py_text.splitlines(), start=1):
+                for pattern, lib_name in _NETWORK_IMPORT_PATTERNS:
+                    if pattern.match(line):
+                        yield Violation(
+                            py_path,
+                            line_no,
+                            f"no-telemetry-import: substrate tool '{tool_dir.name}' "
+                            f"imports '{lib_name}' — only contract:* adapter tools and "
+                            f"egress-gateway may make network calls; "
+                            f"PRINCIPLE 10 requires zero default outbound egress "
+                            f"(see tools/egress-gateway/tool.md § Declared egress surfaces)",
+                            category=NO_TELEMETRY_CATEGORY,
+                        )
+                        break  # one violation per line
+
+
 def run_validation(root: Path | None = None) -> list[Violation]:
     """Run the full validation suite and return all violations."""
     repo_root = root or find_repo_root()
@@ -3631,6 +3726,9 @@ def run_validation(root: Path | None = None) -> list[Violation]:
 
     # Project-template drift check: _template/ and non-asf-example/ stay comparable.
     violations.extend(validate_project_template_drift(repo_root))
+
+    # No-default-telemetry import check: substrate tools must not call the network.
+    violations.extend(validate_no_telemetry_imports(repo_root))
 
     # Branch-name confidentiality check on docs/ (skills/ is already covered above).
     for doc_path in sorted(doc_files):
@@ -3716,6 +3814,7 @@ _SOFT_RULE_PREFIXES: tuple[str, ...] = (
     "lowercase-f-field",
     "mail-privacy-boundary",
     "modes-doc:",
+    "no-telemetry-import",
     "skill-line-limit",
     "multi-capability declared",
     "override-contract",

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -4807,3 +4807,169 @@ class TestValidateSkillLineLimit:
 
     def test_category_is_soft(self) -> None:
         assert SKILL_LINE_LIMIT_CATEGORY in SOFT_CATEGORIES
+
+
+# ---------------------------------------------------------------------------
+# No-default-telemetry import check (aspect #21, SOFT)
+# ---------------------------------------------------------------------------
+
+
+from skill_and_tool_validator import (  # noqa: E402
+    NO_TELEMETRY_CATEGORY,
+    validate_no_telemetry_imports,
+)
+
+
+class TestValidateNoTelemetryImports:
+    """Tests for the SOFT no-telemetry-import check (aspect #21)."""
+
+    _SUBSTRATE_README = (
+        "# my-tool\n\n"
+        "**Capability:** substrate:framework-dev\n\n"
+        "## Prerequisites\n\n"
+        "- **Runtime:** Python 3.11+\n"
+        "- **CLIs:** None.\n"
+        "- **Credentials / auth:** None.\n"
+        "- **Network:** None.\n"
+    )
+    _CONTRACT_README = (
+        "# my-adapter\n\n"
+        "**Capability:** contract:tracker\n\n"
+        "## Prerequisites\n\n"
+        "- **Runtime:** Python 3.11+\n"
+        "- **CLIs / credentials / network:** Provided by tracker backend.\n"
+    )
+
+    def _make_tool(
+        self,
+        tmp_path: Path,
+        *,
+        name: str,
+        readme: str,
+        src_files: dict[str, str] | None = None,
+    ) -> Path:
+        root = _make_tools_root(tmp_path)
+        tool_dir = root / "tools" / name
+        (tool_dir / "src" / name.replace("-", "_")).mkdir(parents=True)
+        (tool_dir / "README.md").write_text(readme)
+        for rel, content in (src_files or {}).items():
+            path = tool_dir / "src" / rel
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content)
+        return root
+
+    def test_substrate_clean_no_violations(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="clean-substrate",
+            readme=self._SUBSTRATE_README,
+            src_files={"clean_substrate/__init__.py": "# SPDX-License-Identifier: Apache-2.0\n"},
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert violations == []
+
+    def test_substrate_with_requests_flagged(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="bad-substrate",
+            readme=self._SUBSTRATE_README,
+            src_files={
+                "bad_substrate/__init__.py": (
+                    "# SPDX-License-Identifier: Apache-2.0\nimport requests\nimport json\n"
+                )
+            },
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert len(violations) == 1
+        assert NO_TELEMETRY_CATEGORY == violations[0].category
+        assert "requests" in violations[0].message
+        assert "bad-substrate" in violations[0].message
+
+    def test_substrate_with_httpx_flagged(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="bad-httpx",
+            readme=self._SUBSTRATE_README,
+            src_files={"bad_httpx/client.py": "# SPDX-License-Identifier: Apache-2.0\nimport httpx\n"},
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert any(NO_TELEMETRY_CATEGORY == v.category for v in violations)
+        assert any("httpx" in v.message for v in violations)
+
+    def test_substrate_with_urllib_request_flagged(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="bad-urllib",
+            readme=self._SUBSTRATE_README,
+            src_files={
+                "bad_urllib/fetch.py": ("# SPDX-License-Identifier: Apache-2.0\nimport urllib.request\n")
+            },
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert any("urllib.request" in v.message for v in violations)
+
+    def test_substrate_with_socket_flagged(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="bad-socket",
+            readme=self._SUBSTRATE_README,
+            src_files={"bad_socket/__init__.py": "# SPDX-License-Identifier: Apache-2.0\nimport socket\n"},
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert any("socket" in v.message for v in violations)
+
+    def test_contract_tool_with_network_import_not_flagged(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="my-adapter",
+            readme=self._CONTRACT_README,
+            src_files={
+                "my_adapter/client.py": ("# SPDX-License-Identifier: Apache-2.0\nimport urllib.request\n")
+            },
+        )
+        violations = [v for v in validate_no_telemetry_imports(root) if v.category == NO_TELEMETRY_CATEGORY]
+        assert violations == []
+
+    def test_egress_gateway_not_flagged(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="egress-gateway",
+            readme=(
+                "# egress-gateway\n\n"
+                "**Capability:** substrate:sandbox\n\n"
+                "## Prerequisites\n\n"
+                "- **Runtime:** Python 3.11+\n"
+                "- **CLIs:** None.\n"
+                "- **Credentials / auth:** None.\n"
+                "- **Network:** loopback proxy.\n"
+            ),
+            src_files={
+                "egress_gateway/__init__.py": ("# SPDX-License-Identifier: Apache-2.0\nimport socket\n")
+            },
+        )
+        violations = [v for v in validate_no_telemetry_imports(root) if v.category == NO_TELEMETRY_CATEGORY]
+        assert violations == []
+
+    def test_no_src_directory_skipped(self, tmp_path: Path) -> None:
+        root = _make_tools_root(tmp_path)
+        tool_dir = root / "tools" / "metadata-only"
+        tool_dir.mkdir()
+        (tool_dir / "README.md").write_text(self._SUBSTRATE_README)
+        # No src/ directory
+        violations = list(validate_no_telemetry_imports(root))
+        assert violations == []
+
+    def test_category_is_soft(self) -> None:
+        assert NO_TELEMETRY_CATEGORY in SOFT_CATEGORIES
+
+    def test_violation_message_mentions_principle_10(self, tmp_path: Path) -> None:
+        root = self._make_tool(
+            tmp_path,
+            name="principle-check",
+            readme=self._SUBSTRATE_README,
+            src_files={
+                "principle_check/__init__.py": "# SPDX-License-Identifier: Apache-2.0\nimport requests\n"
+            },
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert any("PRINCIPLE 10" in v.message for v in violations)


### PR DESCRIPTION
## Summary

Add check #21 (SOFT advisory) to skill-and-tool-validator that flags network-calling imports (requests, httpx, aiohttp, urllib.request, http.client, socket) in substrate:* tool source files under tools/*/src/.

Only contract:* adapter tools and the egress-gateway proxy are declared egress surfaces; all other substrate tools must stay network-free to uphold PRINCIPLE 10's guarantee of zero default outbound calls.

Also add a Declared egress surfaces section to tools/egress-gateway/tool.md that states the default-zero guarantee, lists the declared egress surfaces, and cross-references the new validator check.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

<!-- e.g. Closes #NNN, Refs #NNN. List every related issue. -->

## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->
