### PR TITLE
refactor(skills): push regenerated CVE JSON on every regen, not only at fix-released

### DIFF
--- a/skills/security-issue-sync/apply-and-push.md
+++ b/skills/security-issue-sync/apply-and-push.md
@@ -455,6 +455,35 @@ instead of leaving the paste step to the release manager. The push
 is mechanical and follows from the same JSON the user just approved
 as part of the body update.
 
+**Push trigger — every regen, not only `fix released`.** The push
+above fires on **every** run that regenerates the CVE JSON (any
+`generate-cve-json` / Step 5a `--attach`), not only at the
+`pr merged → fix released` transition. Whenever a confirmed change
+causes a regen, the regenerated JSON is pushed to the record in the
+**same apply pass**, so the live record never drifts from the tracker
+body. The operator's confirmation of the underlying change that
+triggered the regen **is** the authorisation to push — it is not a
+separate confirmation, and the push is never deferred to the release
+manager. Triggers include, beyond `fix released`:
+
+- **advisory-URL / `announced` close-out** on an already-`public`
+  (Vulnogram: `PUBLIC`) record — the regen adds the
+  `vendor-advisory` reference captured from the *Public advisory URL*
+  body field, and the push writes it to the published record;
+- **reviewer-feedback title / summary edits** on a record still in
+  `allocated` / `review-ready` (Vulnogram: `DRAFT` / `REVIEW`);
+- **field corrections** — *Affected versions*, *CWE*, *Severity*,
+  *Reporter credited as*, *Remediation developer* — that change any
+  value the generator reads into the record.
+
+Because `push_update` writes the generator-computed `CNA_private.state`
+verbatim (see below), a regen can legitimately walk a record **back**
+— e.g. `review-ready → allocated` (Vulnogram: `REVIEW → DRAFT`) — when
+a title or summary edit re-opens a question a reviewer had already
+signed off on. That walk-back is intended: the reviewer re-reviews
+from the corrected lower state. Surface every such state change in the
+Step 6 recap so it is never silent.
+
 **State auto-promote from `allocated` to `review-ready` — driven by
 the generator, not by sync.** The CVE JSON the generator produces
 already carries the correct `CNA_private.state` value based on the
@@ -489,8 +518,10 @@ transition. This is the load-bearing gate for the release-manager
 hand-off (see Step 2b's *Two-stage gate*): the RM never receives
 the hand-off comment while the record is still in `allocated`.
 
-**The `pr merged → fix released` transition performs this push in
-the same apply pass — it is not deferrable.** When a sync run
+**The `pr merged → fix released` transition is the one instance of
+the general push-on-regen rule above that is also *mandatory*: it
+performs this push in the same apply pass and it is not deferrable.**
+When a sync run
 advances a tracker `pr merged → fix released`, the label flip and
 this 5a-regen + 5b-push are **one atomic unit**: the user's
 confirmation of the transition authorises the push, and both land in


### PR DESCRIPTION
## Summary
- Step 5b of `security-issue-sync` now states explicitly that the CVE-tool
  push fires on **every** regen of the CVE JSON, not only at the
  `pr merged → fix released` transition.
- Enumerates the non-fix-released triggers (advisory-URL/`announced`
  close-out on PUBLISHED records; reviewer-feedback title/summary edits on
  DRAFT/REVIEW; field corrections).
- Reframes the `fix released` paragraph as the one instance of the general
  rule that is *also* mandatory/non-deferrable.
- Documents that a generator-driven `REVIEW → DRAFT` state walk-back on a
  title/summary edit is intended.

## Motivation
Step 5b's push mechanics are already trigger-agnostic, but the only
*emphatic* prose about when the push fires is the `fix released`
"not deferrable" paragraph. In a real Apache Airflow sync run that
prominence led the operator to hedge and *not* auto-push six advisory
close-out regens (adding the `vendor-advisory` reference to already-PUBLISHED
records) plus a reviewer-feedback title/summary edit — the records drifted
from the tracker body until a manual re-push. This removes the ambiguity.

Originated as a local adopter override:
`.apache-magpie-overrides/security-issue-sync.md` ("Always push the
regenerated CVE JSON on every regen").

## Migration path for existing adopters
Documentation-only clarification of existing behaviour — no config knob, no
default flip. Adopters running the authenticated-session push path get the
same mechanics; those without a session still fall through to the
manual-paste hand-off exactly as before. All Step 5b guardrails (pre-push
hygiene gates, session probe, verify-after-push) are unchanged.

## Test plan
- `SKIP=lychee prek run --files skills/security-issue-sync/apply-and-push.md`
  → all hooks pass (markdownlint, typos, check-placeholders,
  skill-and-tool-validate).
- Exercised end-to-end in the originating adopter: seven records
  regenerated + pushed (six PUBLISHED gaining the vendor-advisory reference,
  one walked REVIEW→DRAFT on a title/summary edit), states verified via
  `vulnogram-api-record-fetch --state-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
