### PR TITLE
fix(agent-guard): make the PreToolUse hook a no-op until agent-guard.py is present

### DIFF
--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -1248,9 +1248,16 @@ Four passes, in this order:
 
      ```json
      { "matcher": "Bash", "hooks": [ { "type": "command",
-       "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\"",
+       "command": "[ -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" ] && python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" || true",
        "timeout": 30 } ] }
      ```
+
+     The `[ -f … ] && … || true` guard makes the hook a **no-op on a
+     fresh clone** — before `/magpie-setup` has synced `agent-guard.py`
+     in (the script is gitignored framework code, not committed), so
+     without the guard the committed hook would exec a missing file on
+     every Bash call and a `PreToolUse` error can block the tool. Once
+     the script is present the guard passes and the hook runs normally.
 
      Wiring happens **only once**; thereafter guards are
      added/removed purely by syncing `guards.d` — no settings.json

--- a/tools/agent-guard/README.md
+++ b/tools/agent-guard/README.md
@@ -107,7 +107,7 @@ The guard is registered as a `PreToolUse` hook on the `Bash` matcher in
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\"", "timeout": 30 }
+          { "type": "command", "command": "[ -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" ] && python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" || true", "timeout": 30 }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

The adopter's committed `.claude/settings.json` wires the agent-guard
`PreToolUse` hook to
`python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py"`, but
`agent-guard.py` is **gitignored framework code** synced by `/magpie-setup`
(like the skills) — it is not committed. On a **fresh clone**, before
`/magpie-setup` has run, the script does not exist yet, so the committed hook
execs a missing file on **every** `Bash` tool call, and a `PreToolUse` error
can block the tool.

Guard the committed command so it is a **no-op until the script exists**:

```
[ -f "$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py" ] && \
  python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py" || true
```

Once `/magpie-setup` drops the script in, the guard passes and the hook runs
normally. No behaviour change for an already-set-up repo; only the
fresh-clone window (wiring committed, script not yet synced) is repaired.

Updated in the two places that ship the snippet:

- `skills/setup/adopt.md` — the Step 12 wiring snippet (plus a short note on
  why the guard is there);
- `tools/agent-guard/README.md` — the Wiring section.

Found while adopting Magpie in Apache JMeter: a PMC reviewer flagged the
committed hook pointing at a script absent from the adoption PR.

## Type of change

- [x] Bug fix (docs / committed template)

## Test plan

Documentation / template change.

- Confirmed the current `main` snippet is unguarded in both files.
- `uvx prek run --files skills/setup/adopt.md tools/agent-guard/README.md`
  passes (markdownlint, typos, lychee link check, SPDX, TOC,
  skill-and-tool-validate, …).
- The guarded form is a valid `PreToolUse` command: on a fresh clone it is a
  no-op (no error on Bash calls); once `agent-guard.py` is present it runs the
  guard unchanged.
