### PR TITLE
chore(release): gitignore RC build artefacts so they can't be committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,11 @@ reassess-*/
 /apache-rat-*/
 rat-report.txt
 rat-stderr.log
+
+# Release-candidate build artefacts (produced by release-rc-cut: the source
+# zip, its detached signature, and its checksum). They are staged to
+# dist/dev via svn, never committed to git — ignore them so a stray
+# `git add` at the repo root can't pick them up.
+/apache-magpie-*-source.zip
+/apache-magpie-*-source.zip.asc
+/apache-magpie-*-source.zip.sha512

--- a/skills/release-rc-cut/SKILL.md
+++ b/skills/release-rc-cut/SKILL.md
@@ -263,14 +263,15 @@ git push <git-upstream-remote> <version>-<rcN>
 ```
 
 `<git-upstream-remote>` resolves from `git_upstream_remote` in
-`release-management-config.md` — the git remote name pointing at the
-upstream repo (typical: `origin`, `upstream`, `apache`; default `origin`;
-`--remote` overrides). Emit the concrete resolved name, not the placeholder.
+`release-management-config.md` — the upstream repo's git remote name
+(typical `origin`/`upstream`/`apache`; default `origin`; `--remote` overrides). Emit the concrete name.
 
 **Section 2 — Build command.**
 
-The exact `build_command` from `release-build.md`, emitted verbatim with
-a note that it must run at the release tag:
+The exact `build_command` from `release-build.md`, emitted verbatim (run at
+the tag). First **gitignore the RC artefacts** (`<artefact>` + `.asc`/`.sha512`,
+e.g. a committed glob like `*-source.zip*`) so a stray `git add` never commits
+an RC build:
 
 ```text
 # Run at the release tag <version>-<rcN>


### PR DESCRIPTION
## Summary

`release-rc-cut` builds the source artefact (`apache-magpie-<version>-source.zip`), its detached signature (`.asc`), and its checksum (`.sha512`) **in the repo root** as untracked files. Those get staged to `dist/dev` via `svn` and must **never** be committed to git — but a stray `git add .` / `git commit -a` at the wrong moment could pick them up.

This ignores them and documents the guard in the skill.

## Changes

- **`.gitignore`** — ignore `/apache-magpie-*-source.zip`, `.asc`, and `.sha512` (mirrors the existing "Apache RAT working artefacts" pattern already in the file). Verified with `git check-ignore` that all three RC artefacts now match.
- **`skills/release-rc-cut/SKILL.md`** — Section 2 (Build) now tells the RM to gitignore the RC artefacts first (via a committed glob like `*-source.zip*`) so adopters get the same protection. Kept SKILL.md at 500 lines (trimmed a line from the tag-command note).

## Test plan

- `git check-ignore apache-magpie-0.1.0-source.zip{,.asc,.sha512}` → all three ignored.
- `skill-and-tool-validate` passes, no new warnings (SKILL.md at 500 lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
