### PR TITLE
docs(atr-runbook): correct the atr client commands (start/upload/check/vote)

### DIFF
--- a/docs/release-management/atr-release-runbook.md
+++ b/docs/release-management/atr-release-runbook.md
@@ -296,9 +296,11 @@ key and perform the registration
    Poll them:
 
    ```bash
-   atr check status magpie "${VERSION}" --verbose
-   # for anything blocking on a given revision:
+   atr revisions magpie "${VERSION}"                # list revisions; note the revision id
+   atr check status magpie "${VERSION}" --verbose   # poll checks
+   # review a specific revision's hard blockers and non-blocking concerns:
    #   atr check blockers magpie "${VERSION}" <revision>
+   #   atr check concerns magpie "${VERSION}" <revision>
    ```
 
    Fix any failing check and re-upload a new revision before voting.
@@ -330,8 +332,10 @@ the binding votes.
    vote is an **RM action** — the agent drafts, the RM starts:
 
    ```bash
-   # atr vote start PROJECT VERSION REVISION -m MAILING-LIST [--duration H] [--subject S]
-   # REVISION comes from `atr check status` / the candidate page.
+   # atr vote start PROJECT VERSION REVISION -m LIST [--duration H] [--subject S] [CONCERNS-NOTED]
+   # REVISION comes from `atr revisions magpie "${VERSION}"` (or the candidate page).
+   # If `atr check concerns` flagged non-blocking concerns, start the vote WITH the
+   # concerns-noted flag so they're acknowledged in the thread (see `atr vote start --help`).
    atr vote start magpie "${VERSION}" <revision> \
      -m dev@magpie.apache.org --duration "${VOTE_WINDOW_HOURS:-72}" \
      --subject "[VOTE] Release Apache Magpie ${VERSION} from ${RC_TAG}"

--- a/docs/release-management/atr-release-runbook.md
+++ b/docs/release-management/atr-release-runbook.md
@@ -277,13 +277,17 @@ key and perform the registration
 2. **Create the draft release and upload** to ATR (Compose):
 
    ```bash
-   # Create a draft candidate for magpie <version> and upload the
-   # artefact + signature + checksum. Confirm exact subcommands with
-   # `atr --help`; these map to POST /api/release/create and
-   # POST /api/release/upload.
-   atr release create magpie "${VERSION}" --rc "${RC}"
-   atr release upload  magpie "${VERSION}" \
-     "${ARTIFACT}" "${ARTIFACT}.asc" "${ARTIFACT}.sha512"
+   # Start a draft release for magpie <version>, then upload the artefact
+   # + signature + checksum. ATR tracks *revisions*, not rc-numbers: each
+   # upload adds to the current revision (the rcN identity lives in the tag
+   # and the [VOTE] subject, not in the ATR release name). `atr upload` takes
+   # PROJECT VERSION PATH FILEPATH — PATH is the file's name inside the
+   # release, FILEPATH the local file — so upload one file per call.
+   # (Verbs per the client's COMMANDS.md; run `atr <cmd> --help` for flags.)
+   atr release start magpie "${VERSION}"
+   atr upload magpie "${VERSION}" "${ARTIFACT}"        "${ARTIFACT}"
+   atr upload magpie "${VERSION}" "${ARTIFACT}.asc"    "${ARTIFACT}.asc"
+   atr upload magpie "${VERSION}" "${ARTIFACT}.sha512" "${ARTIFACT}.sha512"
    ```
 
 3. **Let the checks run.** On upload, ATR fires asynchronous checks:
@@ -292,7 +296,9 @@ key and perform the registration
    Poll them:
 
    ```bash
-   atr checks list magpie "${VERSION}"     # GET /api/checks/list/...
+   atr check status magpie "${VERSION}" --verbose
+   # for anything blocking on a given revision:
+   #   atr check blockers magpie "${VERSION}" <revision>
    ```
 
    Fix any failing check and re-upload a new revision before voting.
@@ -321,7 +327,15 @@ the binding votes.
 2. **Start the vote in ATR.** The RM triggers the vote for the
    composed candidate; ATR sends the `[VOTE]` email to
    `dev@magpie.apache.org` and opens the tabulation. Starting the
-   vote is an **RM action** — the agent drafts, the RM starts.
+   vote is an **RM action** — the agent drafts, the RM starts:
+
+   ```bash
+   # atr vote start PROJECT VERSION REVISION -m MAILING-LIST [--duration H] [--subject S]
+   # REVISION comes from `atr check status` / the candidate page.
+   atr vote start magpie "${VERSION}" <revision> \
+     -m dev@magpie.apache.org --duration "${VOTE_WINDOW_HOURS:-72}" \
+     --subject "[VOTE] Release Apache Magpie ${VERSION} from ${RC_TAG}"
+   ```
 3. **72-hour window** (Step 8). Minimum per
    [release-policy § release approval](https://www.apache.org/legal/release-policy.html#release-approval);
    the Magpie config may lengthen but not shorten it


### PR DESCRIPTION
## Summary

The ATR runbook's Compose (Step C) and Vote (Step D) command blocks were placeholders that don't match the actual `atr` client — they used `atr release create … --rc`, `atr release upload`, and `atr checks list`, none of which exist. Corrected against the client's [`COMMANDS.md`](https://github.com/apache/tooling-releases-client/blob/main/COMMANDS.md):

| Was | Now |
|---|---|
| `atr release create magpie <v> --rc <rc>` | `atr release start magpie <v>` — revision-based, **no `--rc`** |
| `atr release upload magpie <v> <files…>` | `atr upload magpie <v> PATH FILEPATH` — top-level, **one file per call** |
| `atr checks list magpie <v>` | `atr check status magpie <v> --verbose` (+ `atr check blockers … <revision>`) |
| (vote start unspecified) | `atr vote start magpie <v> <revision> -m dev@… --duration 72 --subject …` |

Discovered while running the ATR path for the 0.1.0 release: `atr release create` / `atr release upload` errored, and the client uses revisions rather than rc-numbers.

## Notes

- Docs-only change to `docs/release-management/atr-release-runbook.md` (Steps C + D).
- ATR is still alpha and the client's API is explicitly unstable, so the runbook keeps the "run `atr <cmd> --help` to confirm flags" caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
