### PR TITLE
fix(bitbucket): tolerate null datacenter comment replies

### DIFF
--- a/tools/bitbucket/src/magpie_bitbucket/normalize.py
+++ b/tools/bitbucket/src/magpie_bitbucket/normalize.py
@@ -191,7 +191,7 @@ def _datacenter_comment_tree(
     normalized = _datacenter_comment(raw, activity, parent_id)
 
     replies: list[dict[str, Any]] = []
-    for reply in raw.get("comments", []):
+    for reply in raw.get("comments") or []:
         if isinstance(reply, dict):
             replies.extend(_datacenter_comment_tree(reply, activity, normalized["id"]))
 

--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -557,6 +557,31 @@ def test_normalize_datacenter_discussion_includes_threaded_replies() -> None:
     assert result["participants"] == ["Asha", "Ravi"]
 
 
+def test_normalize_datacenter_discussion_allows_null_threaded_replies() -> None:
+    raw = {
+        "pull_request_id": "9",
+        "values": [
+            {
+                "action": "COMMENTED",
+                "comment": {
+                    "id": 1,
+                    "text": "Parent comment",
+                    "author": {"displayName": "Asha"},
+                    "createdDate": 1783428000000,
+                    "comments": None,
+                },
+            }
+        ],
+    }
+
+    result = pull_request_discussion("datacenter", raw)
+
+    assert len(result["comments"]) == 1
+    assert result["comments"][0]["body"] == "Parent comment"
+    assert result["comments"][0]["parent_id"] is None
+    assert result["participants"] == ["Asha"]
+
+
 def test_normalize_datacenter_discussion_filters_non_comment_activities() -> None:
     raw = {
         "pull_request_id": "9",


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

* Hardens Bitbucket Data Center threaded comment normalization when the API returns an explicit `comments: null` value.
* Treats both missing and null nested `comment.comments` fields as no replies by using `raw.get("comments") or []`.
* Adds a regression test for the `comments: null` case so the discussion normalizer does not crash on this payload shape.

## Type of change

* [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
* [ ] Tool / bridge contract (`tools/<system>/*.md`)
* [x] Python package (`tools/*/` with `pyproject.toml`)
* [ ] Groovy reference impl
* [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
* [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
* [ ] Project template (`projects/_template/`)
* [ ] CI / dev loop (`prek`, workflows, validators)
* [ ] Other:

## Test plan

* [x] `prek run --all-files` passes
* [x] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
* [ ] For Groovy bridges touched: command-line invocation tested end-to-end
* [ ] For skill changes: eval suite passes for the affected skill
  (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
* [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
  (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
* [x] Other: verified targeted Bitbucket tests with `PYTHONPATH=src uv run --group dev pytest tests/test_bitbucket.py`

## RFC-AI-0004 compliance

* [ ] **HITL** — any new mutation is gated on explicit user confirmation
* [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
* [x] **Vendor neutrality** — keeps the Bitbucket bridge within the existing vendor-neutral `contract:change-request` / partial read-only path without adding new Bitbucket-specific capability prose.
* [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
* [x] **Write-access discipline** — this is a read-only normalization hardening change and does not add any outbound write or mutation path.
* [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Refs #606

## Notes for reviewers
This follows up on the non-blocking robustness note from the merged Bitbucket discussion PR.

Bitbucket Data Center nested replies are already flattened through `_datacenter_comment_tree`; this PR only hardens that path for payloads where the API returns `"comments": null` instead of omitting the field or returning an empty list.

The behaviour is unchanged for normal threaded replies.
