### PR TITLE
docs(projects/_template): genericise remaining Airflow-specific residue

### DIFF
--- a/projects/_template/cve-allocation-config.md
+++ b/projects/_template/cve-allocation-config.md
@@ -48,8 +48,8 @@ by ecosystem:
    (`cve_authority.reviewer_channel`).
 
 All three are capability flags: an ASF TLP adopter leaves them at their
-defaults and the skill behaves identically to how it runs today in
-`airflow-s/airflow-s`. A non-ASF adopter overrides one or more flags to
+defaults and the skill behaves identically to how it runs in the reference
+`<org>/<repo>` adopter. A non-ASF adopter overrides one or more flags to
 match their CNA program, and the skill emits backend-appropriate recipes
 without any skill-body edits.
 

--- a/projects/_template/pr-management-quick-merge-config.md
+++ b/projects/_template/pr-management-quick-merge-config.md
@@ -115,12 +115,11 @@ scripts/ci/**
 **/security/**
 **/auth*/**
 **/jwt*/**
-airflow-core/src/airflow/jobs/**
-airflow-core/src/airflow/models/**
-airflow-core/src/airflow/executors/**
-airflow-core/src/airflow/api_fastapi/**
-airflow-core/src/airflow/serialization/**
-task-sdk/src/airflow/sdk/execution_time/**
+# Core application code — replace with your project's security-sensitive
+# module paths. Example (Apache Airflow monorepo):
+#   airflow-core/src/airflow/{jobs,models,executors,api_fastapi,serialization}/**
+#   task-sdk/src/airflow/sdk/execution_time/**
+<core-src-path>/**
 ```
 
 Tune `deny_globs` toward over-inclusion: a false deny just means a PR waits for

--- a/projects/_template/security-tracker-stats.md
+++ b/projects/_template/security-tracker-stats.md
@@ -52,7 +52,7 @@ tracker_stats_output: tmp/tracker_stats.html
 The skill writes the rendered HTML to this path (relative to the
 adopter repo root, or absolute) when the user does not pass an
 explicit `<output-path>` argument. The
-`airflow-s/airflow-s` adopter uses `tmp/airflow_s_monthly.html`
+reference `<org>/<repo>` adopter uses `tmp/<project>_monthly.html`
 (committed into `tmp/` as the canonical artefact for security-team
 review).
 
@@ -96,7 +96,7 @@ markers to produce a *rejected (no tracker)* count (a per-bucket area
 series plus a `<dated> + <historical> = <total>` headline).
 
 Set to `null` to disable the stat entirely (no ledger issue needed).
-The ASF/Airflow default is `rejections-ledger`, matching
+The ASF default is `rejections-ledger`, matching
 `tracker.labels.rejections_ledger` in `project.md`. To turn the stat
 on, create the open ledger issue, label it, and keep this knob
 pointed at the same label.
@@ -118,7 +118,7 @@ milestones:
     label: handover to PMC sec team
 ```
 
-A bigger overlay that renames the scope labels for a non-Airflow
+A bigger overlay that renames the scope labels for a non-ASF
 adopter and removes the upstream-PR charts entirely (because fixes
 land in many repos, not a single `<upstream>`):
 


### PR DESCRIPTION
The `/magpie-setup upgrade` Step 6d template-genericity audit (run in an
adopter repo) flagged a few `projects/_template/` configs that still carry
**unmarked** Airflow-specific values as defaults — as opposed to the many
correctly annotated with `Example:` / `e.g.` / `(filled example)`, which
are fine.

## Changes
- **`pr-management-quick-merge-config.md`** — the default `deny_globs`
  block listed literal `airflow-core/...` + `task-sdk/...` paths. Replaced
  with a `<core-src-path>/**` placeholder plus a commented Airflow-monorepo
  example, so a fresh adopter starts from a project-agnostic scaffold
  rather than inheriting Airflow-shaped globs.
- **`security-tracker-stats.md`** — genericised the `airflow-s/airflow-s`
  adopter reference to `<org>/<repo>` and dropped "Airflow" from the
  ASF-default / non-ASF overlay prose.
- **`cve-allocation-config.md`** — genericised the `airflow-s/airflow-s`
  reference-adopter mention to `<org>/<repo>`.

Correctly-marked example values elsewhere (`release-management-config`,
`mentoring-*`, `onboarding-concierge`, `committer-onboarding`,
`pr-management-config`, `pr-management-code-review-criteria`) are left as-is.

Surfaced by the Step 6d audit; docs-only, `prek` green.
