### PR TITLE
docs(tools): add **MCP:** marker to MCP-wrapper tools

### DIFF
--- a/docs/labels-and-capabilities.md
+++ b/docs/labels-and-capabilities.md
@@ -332,9 +332,24 @@ backend the adopter wired in. The framework consumes four:
 | PonyMail MCP (`apache/comdev`) | `mcp__ponymail__*` | [`tools/ponymail`](../tools/ponymail/) | `contract:mail-archive` + `contract:mail-source` | ASF |
 | apache-projects MCP (`apache/comdev`) | `mcp__apache-projects__*` | [`tools/apache-projects`](../tools/apache-projects/) | `contract:project-metadata` | ASF |
 
+Each wrapping tool declares this relationship in its own README with an
+`**MCP:** <server> (mcp__<prefix>__*)` marker (see
+[`tools/AGENTS.md`](../tools/AGENTS.md)) — that per-tool marker is the
+source of truth; this table mirrors it for a one-glance overview.
+
 Non-MCP backends fulfil the same contracts: JIRA is reached over REST
 and `gh` is the CLI fallback, both `contract:tracker`. See
 [`docs/prerequisites.md`](prerequisites.md) for connection setup.
+
+**MCP servers are installed for the user, not the project.** They are
+registered at **user scope** (`claude mcp add … -s user`), so a single
+registration serves every repository on the machine. Consequently they
+are usable by **any** agent session — not only Magpie-adopting projects
+or Magpie-related work. Magpie surfaces the registration command and
+verifies it during setup, but the server itself is a plain,
+project-agnostic MCP: once registered it is available to any agentic
+session the same way a globally-installed CLI would be. Nothing about
+using one ties a session to Magpie.
 
 ---
 

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -81,6 +81,25 @@ declares, up front:
    `organization:` frontmatter key; skill families with an
    `organization:` scope banner in `docs/<family>/README.md`.
 
+4. **(Optional) its MCP backing** — when a tool wraps a
+   [Model Context Protocol](https://modelcontextprotocol.io) server as a
+   concrete backend, declare it with a line of the exact form
+
+   ```markdown
+   **MCP:** <server> (mcp__<prefix>__*)
+   ```
+
+   e.g. `**MCP:** PonyMail — apache/comdev (mcp__ponymail__*)`. The value
+   names the human-readable server (optionally with `— <org>`) and, in
+   parentheses, the `mcp__<prefix>__*` tool namespace it exposes. Omit the
+   line for tools with no MCP backend — absence means "wraps no MCP". This
+   marker is the per-tool source of truth for the "wraps an MCP"
+   classification: it is mirrored in the
+   [`docs/labels-and-capabilities.md`](../docs/labels-and-capabilities.md#mcp-servers-classified-by-capability)
+   MCP table and read by the project website's tool index to drive its
+   "Wraps an MCP" filter. An MCP is transport, not a capability axis — the
+   `**Capability:**` line still states the contract the tool provides.
+
 The capability and prerequisites are **HARD** checks in
 [`tools/skill-and-tool-validator`](skill-and-tool-validator/) — a tool
 README missing either the `**Capability:**` line or the

--- a/tools/apache-projects/README.md
+++ b/tools/apache-projects/README.md
@@ -17,6 +17,8 @@
 
 **Kind:** implementation
 
+**MCP:** apache-projects — apache/comdev (mcp__apache-projects__*)
+
 **Vendor:** ASF
 
 **Organization:** ASF

--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -17,6 +17,8 @@
 
 **Kind:** implementation
 
+**MCP:** GitHub MCP (mcp__github__*)
+
 **Vendor:** GitHub
 
 GitHub REST + GraphQL substrate. Pure read/write wrapper used by every lifecycle phase (triage / intake / fix / resolve / stats). See [`tool.md`](tool.md) for the operation catalogue and the per-area files ([`issue-template.md`](issue-template.md), [`labels.md`](labels.md), [`operations.md`](operations.md), [`project-board.md`](project-board.md), [`status-rollup.md`](status-rollup.md)) for specifics.

--- a/tools/gmail/README.md
+++ b/tools/gmail/README.md
@@ -17,6 +17,8 @@
 
 **Kind:** implementation
 
+**MCP:** Gmail — claude.ai (mcp__claude_ai_Gmail__*)
+
 **Vendor:** Google
 
 Gmail API substrate. Read + draft-only — never sends. Provides two

--- a/tools/ponymail/README.md
+++ b/tools/ponymail/README.md
@@ -18,6 +18,8 @@
 
 **Kind:** implementation
 
+**MCP:** PonyMail — apache/comdev (mcp__ponymail__*)
+
 **Vendor:** ASF
 
 **Organization:** ASF


### PR DESCRIPTION
## What

Introduces a per-tool README marker — `**MCP:** <server> (mcp__prefix__*)`
— as the source of truth for the "wraps an MCP" classification, applied to
the four MCP-wrapper tools: github, gmail, ponymail, apache-projects.

## Why

The "wraps an MCP" fact lived only in a hand-maintained table in
`docs/labels-and-capabilities.md`, which the website parses. Making it a
regular per-tool metadata marker (alongside `**Capability:**` / `**Kind:**`
/ `**Organization:**`) keeps the fact next to the tool it describes and lets
the site read it per-README.

## Changes

- `**MCP:**` marker on the 4 wrapper tools' READMEs
- Documented the field convention in `tools/AGENTS.md`
- `docs/labels-and-capabilities.md`: the per-tool marker is the source of
  truth (the MCP table now mirrors it), plus a note that MCP servers install
  at **user scope** and are usable by **any** agent session, not just
  Magpie-adopting projects

## Note

The magpie-site generator is updated in a separate PR to read this marker.
Until that lands the table remains the site's source, so there is no
behavior change on the website from this PR alone.
