### PR TITLE
build(prek): exclude sandbox write-denied paths from in-place fixers

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,12 +91,29 @@ repos:
         name: Check that merge conflicts are not being committed
       - id: detect-private-key
         name: Detect if private key is added to the repository
+      # The next three hooks are *fixers*: they open every matched file
+      # in read-write mode (to normalise it in place) before checking
+      # whether a fix is even needed. The secure-agent sandbox
+      # write-denies two tracked path sets — the agent's own config
+      # (`.claude/settings.json`) and the self-adoption skill relays
+      # (`.claude/skills/*` symlinks) — because agents must never modify
+      # them. So on `prek run --all-files` (which `agent-pre-commit.sh`
+      # and the CI mirror both run) the read-write `open()` on those
+      # paths is denied and the whole run aborts, even though the files
+      # need no fix. Exclude them: `.claude/settings.json` is gated by
+      # the sandbox-lint baseline and the skill symlinks are validated by
+      # `symlink-lint`, so neither loses coverage by skipping EOF /
+      # whitespace / line-ending normalisation here. This keeps prek a
+      # single invocation that runs cleanly in-sandbox with no bypass.
       - id: end-of-file-fixer
         name: Make sure that there is an empty line at the end
+        exclude: &sandbox_write_denied ^\.claude/(settings\.json|skills/)
       - id: mixed-line-ending
         name: Detect if mixed line ending is used (\r vs. \r\n)
+        exclude: *sandbox_write_denied
       - id: trailing-whitespace
         name: Remove trailing whitespace at end of line
+        exclude: *sandbox_write_denied
   # markdownlint — catches structurally-bad markdown. Config in
   # `.markdownlint.json` enables only the rules that catch real bugs
   # (broken anchors via MD051, dangling link references via MD053);


### PR DESCRIPTION
## What

Exclude `.claude/settings.json` and the `.claude/skills/*` symlinks from
the three in-place fixer hooks (`end-of-file-fixer`, `mixed-line-ending`,
`trailing-whitespace`) via a shared `exclude` anchor.

## Why

These fixers open every matched file in **read-write** mode before
deciding whether a fix is even needed. On `prek run --all-files` — which
`tools/dev/agent-pre-commit.sh` and the CI workflow both run — that
read-write `open()` hits two path sets the secure-agent sandbox
deliberately **write-denies**:

- `.claude/settings.json` — the agent's own config
- `.claude/skills/*` — the self-adoption skill relay symlinks

The denied open aborts the whole run with `Operation not permitted`, so
agents had to **disable the sandbox** just to run prek. This defeats the
point of the sandbox and adds friction to every agent commit.

## No coverage lost

- `.claude/settings.json` is already gated by the sandbox-lint baseline
  (`tools/sandbox-lint/expected.json`).
- The `.claude/skills/*` symlinks are already validated by `symlink-lint`.

Neither needs EOF / whitespace / line-ending normalisation from these
fixers, so excluding them removes the sandbox friction without weakening
any check.

## Result

prek is now a single invocation that runs cleanly **in-sandbox** on
`git commit`, on `prek run --all-files`, and in CI — no bypass needed.
Verified locally: full `prek run --all-files` passes under the sandbox
with every hook green (previously aborted on the first fixer).
