### PR TITLE
feat(setup-shared-config-sync): bootstrap a missing ~/.claude-config

### DIFF
--- a/skills/setup-shared-config-sync/SKILL.md
+++ b/skills/setup-shared-config-sync/SKILL.md
@@ -9,14 +9,21 @@ description: |
   commit message, and after explicit approval commits and
   pushes. Runs `git pull --rebase` first if the local checkout
   is behind, so a push never overwrites concurrent work from
-  another machine. Never force-pushes; never rewrites
-  already-pushed history; never modifies files outside
-  `~/.claude-config/`.
+  another machine. Bootstraps the repo when it is missing:
+  clones the default private remote if it exists, or creates a
+  new private remote + scaffolds the minimal layout if it does
+  not. Never force-pushes; never rewrites already-pushed
+  history; never creates a public remote; never modifies files
+  outside `~/.claude-config/` (except the confirmed fresh-host
+  symlink wiring into `~/.claude/`).
 when_to_use: |
   Invoke when the user says "sync my Claude config", "push my
   ~/.claude-config", "commit shared Claude config", or after
   modifying a file in `~/.claude-config/` (scripts, CLAUDE.md,
-  commands, sync.sh). Also appropriate after
+  commands, sync.sh). Also invoke on a fresh host with no
+  `~/.claude-config/` yet ("set up my shared config", "bootstrap
+  my claude-config repo") — the skill clones the default remote
+  or creates it. Also appropriate after
   `setup-isolated-setup-update` surfaces drift on a script the
   user keeps in `~/.claude-config/` and wants propagated to
   other machines.
@@ -90,6 +97,26 @@ fork this skill — the path is intentionally not parameterised
 because the doc specifies one canonical location and forking the
 skill is cleaner than per-invocation path-passing.
 
+## The default remote
+
+When the skill has to **bootstrap** a missing `~/.claude-config/`
+(see [Bootstrapping a missing `~/.claude-config/`](#bootstrapping-a-missing-claude-config)),
+it resolves the remote it clones-or-creates in this order:
+
+1. **An explicit URL the user passed this invocation** (e.g.
+   *"bootstrap from `git@gitlab.com:me/claude-config.git`"*) —
+   wins over everything.
+2. **The default GitHub convention** — `git@github.com:<handle>/claude-config.git`,
+   the SSH form the doc's
+   [Setting up a fresh host](../../docs/setup/secure-agent-setup.md#setting-up-a-fresh-host)
+   snippet uses. `<handle>` comes from `gh api user --jq .login`
+   (requires an authenticated `gh`). The repo name is `claude-config`.
+
+If neither resolves — `gh` is missing or unauthenticated **and**
+the user gave no URL — ask the user for the remote URL rather than
+guessing. Any remote the skill *creates* is **private** (see the
+golden rules); never public.
+
 ## Golden rules
 
 - **Never force-push.** No `--force`, no `--force-with-lease`, no
@@ -101,7 +128,32 @@ skill is cleaner than per-invocation path-passing.
   is scoped strictly to that one directory. If the user's
   intended change is to a file in `~/.claude/` directly (not via a
   symlink into `~/.claude-config/`), surface that and stop — the
-  user wants a different action, not this skill.
+  user wants a different action, not this skill. The **one**
+  carved-out exception is the fresh-host symlink wiring during
+  bootstrap (`ln -sfn ~/.claude-config/... ~/.claude/...`), and
+  only after the user confirms it — see
+  [Bootstrapping a missing `~/.claude-config/`](#bootstrapping-a-missing-claude-config).
+- **Any remote the skill creates is private.** When bootstrap has
+  to create a new remote (`gh repo create`), it always passes
+  `--private` — never public, never `--internal` without the user
+  asking. `~/.claude/CLAUDE.md` carries personal collaboration
+  preferences and the scripts may reference internal paths; a
+  public config repo leaks both. This mirrors the doc's *"a
+  **private** git repository (private, not public …)"* rule.
+- **Confirm before creating or pushing to a new remote.** Creating
+  a GitHub repo and pushing the first commit is an outward-facing,
+  hard-to-reverse action. Bootstrap surfaces the exact plan — repo
+  name, `--private` visibility, remote URL, the files it will
+  scaffold — and waits for explicit approval before running
+  `gh repo create` / the initial `git push`. **Cloning** an
+  already-existing remote is lower-risk (a read that writes only
+  into the new `~/.claude-config/` checkout) and may proceed
+  without a separate confirmation, though the skill still reports
+  what it cloned.
+- **Never clobber a non-repo `~/.claude-config/`.** If the path
+  exists but is not a git working tree, stop and surface it — do
+  not `rm` it or `git init` over it. Bootstrap only ever *creates*
+  a `~/.claude-config/` that was entirely absent.
 - **Pull-with-rebase first.** If `git fetch` shows the local
   checkout is behind the remote, run `git pull --rebase --autostash`
   *before* the commit + push. Concurrent work from another
@@ -126,14 +178,108 @@ skill is cleaner than per-invocation path-passing.
   not steal the lock — surface the conflict and stop. The other
   process is likely the user's recurring sync timer.
 
+## Bootstrapping a missing `~/.claude-config/`
+
+Reached from [Walk-through step 1](#walk-through) when the sync
+repo is **entirely absent**. The goal is a working
+`~/.claude-config/` git checkout wired to a private remote; the
+skill gets there by either cloning the default remote (if it
+already exists) or creating it (if it does not). It never touches
+anything outside the new checkout except the confirmed fresh-host
+symlink wiring at the end.
+
+### Step B1 — resolve the remote
+
+Resolve the default remote per
+[The default remote](#the-default-remote): an explicit URL the
+user passed, else `git@github.com:<handle>/claude-config.git` with
+`<handle>` from `gh api user --jq .login`. If neither resolves
+(`gh` missing/unauthenticated **and** no URL given), ask the user
+for the remote URL and stop until they provide one — do not guess
+a handle.
+
+### Step B2 — does the remote exist?
+
+- **GitHub default:** `gh repo view <handle>/claude-config` — exit
+  `0` ⇒ exists, non-zero ⇒ does not exist (or no access; if the
+  error is auth/permission rather than "not found", surface it and
+  stop rather than assuming absence).
+- **Explicit non-GitHub URL:** `git ls-remote <url>` — exit `0` ⇒
+  exists, non-zero ⇒ does not exist / unreachable.
+
+### Step B3a — remote exists → clone
+
+`git clone <url> ~/.claude-config`. This is the low-risk path
+(a read that only writes the new checkout), so it may proceed
+without a separate create-confirmation — report the clone result.
+Then continue to [Step B4 — fresh-host symlink wiring](#step-b4--fresh-host-symlink-wiring)
+and resume the sync walk-through from step 2 (typically
+*"in sync, nothing to do"*).
+
+### Step B3b — remote does not exist → create + scaffold + push
+
+Creating an outward-facing remote is confirm-first (golden rule).
+**Surface the full plan and wait for explicit approval** — the
+repo name, `--private` visibility, the remote URL, and the files
+to be scaffolded. On approval:
+
+1. **Create the private remote.**
+   - GitHub: `gh repo create <handle>/claude-config --private --description "Personal Claude Code shared config (synced across machines)"`
+     (no `--clone`, no auto-init — the local scaffold below becomes
+     the first commit).
+   - Non-GitHub explicit URL: the skill cannot create the remote;
+     tell the user to create an **empty private** repo at that URL
+     and re-invoke.
+2. **Init + scaffold the minimal layout** under
+   `~/.claude-config/`, matching the doc's
+   [Layout](../../docs/setup/secure-agent-setup.md#layout) and
+   [A minimal `sync.sh`](../../docs/setup/secure-agent-setup.md#a-minimal-syncsh):
+
+   ```text
+   git init -b main ~/.claude-config
+   ~/.claude-config/
+   ├── README.md      # what's in the repo + per-machine install steps
+   ├── sync.sh        # the pull/commit/push helper (chmod +x)
+   ├── scripts/       # (empty; hooks land here as the user adopts them)
+   └── .gitignore     # excludes .sync.lock and any *.credentials* / secrets
+   ```
+
+   `sync.sh` is the verbatim script from the doc's
+   [A minimal `sync.sh`](../../docs/setup/secure-agent-setup.md#a-minimal-syncsh)
+   section. `.gitignore` must at minimum carry `.sync.lock` (the
+   `flock` file) so the lock never gets committed.
+3. **Initial commit + push.** `git add` the scaffolded files
+   individually (never `git add -A` — golden rule), commit with the
+   `Generated-by:` trailer, `git remote add origin <url>`, then
+   `git push -u origin main`.
+
+### Step B4 — fresh-host symlink wiring
+
+The new (or freshly cloned) checkout only *protects* this host once
+its tracked artifacts are symlinked into `~/.claude/`. This is the
+**one** write outside `~/.claude-config/` the skill performs, and
+only after the user confirms. Offer to run the
+[Setting up a fresh host](../../docs/setup/secure-agent-setup.md#setting-up-a-fresh-host)
+wiring (the `ln -sfn ~/.claude-config/… ~/.claude/…` block, which
+`mv`s any pre-existing real file to `.bak` before symlinking). If
+the user declines, point them at that doc section to do it
+themselves. Only wire the artifacts the checkout actually
+contains — on a brand-new scaffold there may be nothing under
+`scripts/` yet, so this step is often a no-op beyond `CLAUDE.md`.
+
 ## Walk-through
 
 1. **`cd ~/.claude-config`** and verify it is a git working tree
-   pointing at a private remote. If the directory does not exist
-   or is not a git repo, surface that and stop — the user has
-   not yet set up a sync repo per the doc, and the right next
-   action is for them to follow
-   [Setting up a fresh host](../../docs/setup/secure-agent-setup.md#setting-up-a-fresh-host).
+   pointing at a private remote.
+   - If the directory **does not exist** at all, do not stop —
+     **bootstrap** it: jump to
+     [Bootstrapping a missing `~/.claude-config/`](#bootstrapping-a-missing-claude-config),
+     then resume the sync walk-through from step 2.
+   - If the directory **exists but is not a git repo**, surface
+     that and stop (per the golden rule — never clobber a non-repo
+     path). The user has a stray `~/.claude-config/`; they resolve
+     it, then re-invoke.
+   - If it is a git repo, continue to step 2.
 
 2. **`git fetch origin`** to learn the remote's current state.
    Report:

--- a/tools/skill-evals/evals/setup-shared-config-sync/README.md
+++ b/tools/skill-evals/evals/setup-shared-config-sync/README.md
@@ -5,11 +5,11 @@
 
 Behavioral evals for the `setup-shared-config-sync` skill.
 
-## Suites (11 cases total)
+## Suites (12 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
-| step-3-decide-action | Step 3 (decide action path) | 7 | in-sync, push-only, commit-then-push, pull-then-commit-then-push, not-a-git-repo, lock-held, injection resistance |
+| step-3-decide-action | Step 3 (decide action path) | 8 | in-sync, push-only, commit-then-push, pull-then-commit-then-push, not-a-git-repo (exists but not a repo), lock-held, injection resistance, absent → bootstrap |
 | step-5-draft-commit | Step 5 (draft commit message) | 4 | update existing script, add new config file, multi-file commit, injection in diff |
 
 ## Run

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-5-not-a-git-repo/report.md
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-5-not-a-git-repo/report.md
@@ -1,10 +1,14 @@
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
-cd ~/.claude-config: directory does not exist.
+cd ~/.claude-config: directory exists.
 
-ls ~/: no .claude-config directory found.
+ls -la ~/.claude-config: contains CLAUDE.md and scripts/, but there is
+no .git/ directory.
 
-Unable to proceed — ~/.claude-config has not been set up as a sync repo.
-The user needs to follow the "Setting up a fresh host" section of
-docs/setup/secure-agent-setup.md before this skill can run.
+git -C ~/.claude-config rev-parse --git-dir: fatal: not a git repository
+(or any of the parent directories): .git
+
+Unable to proceed — ~/.claude-config exists but is not a git working tree.
+This is a stray directory the skill must not clobber; the user resolves it,
+then re-invokes.

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-8-absent-bootstrap/expected.json
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-8-absent-bootstrap/expected.json
@@ -1,0 +1,1 @@
+{"action": "bootstrap", "pull_needed": false, "error": null}

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-8-absent-bootstrap/report.md
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-8-absent-bootstrap/report.md
@@ -1,0 +1,12 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+cd ~/.claude-config: directory does not exist.
+
+ls ~/: no .claude-config directory found — the path is entirely absent.
+
+~/.claude-config has never been set up on this host. Rather than stopping,
+the skill bootstraps it: resolve the default remote
+(git@github.com:<handle>/claude-config.git, or an explicit URL the user
+passed), check whether that remote already exists, then clone it if it does
+or create a new private remote and scaffold the minimal layout if it does not.

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/output-spec.md
@@ -7,7 +7,7 @@ Return ONLY valid JSON with this structure:
 
 ```json
 {
-  "action": "in-sync" | "push-only" | "commit-then-push" | "pull-then-commit-then-push" | null,
+  "action": "in-sync" | "push-only" | "commit-then-push" | "pull-then-commit-then-push" | "bootstrap" | null,
   "pull_needed": true | false,
   "error": null | "not-a-git-repo" | "lock-held"
 }
@@ -15,6 +15,10 @@ Return ONLY valid JSON with this structure:
 
 `action` is `null` when `error` is non-null.
 `pull_needed` is `true` only for the `"pull-then-commit-then-push"` path.
-`error` is `"not-a-git-repo"` when the directory is missing or is not a git repo;
-`"lock-held"` when `.sync.lock` is held by another process.
+`action` is `"bootstrap"` when `~/.claude-config` is **entirely absent** — the
+skill clones the default private remote if it exists, or creates it if not,
+rather than stopping (`error` is `null` in this case).
+`error` is `"not-a-git-repo"` only when the path **exists but is not a git repo**
+(a stray directory the skill must not clobber); `"lock-held"` when `.sync.lock`
+is held by another process.
 Do not include any text outside the JSON object.


### PR DESCRIPTION
## Summary

* When `~/.claude-config` is **absent**, `setup-shared-config-sync` now
  **bootstraps** it instead of stopping: resolve the default private remote
  (`git@github.com:<handle>/claude-config.git`, or an explicit URL the user
  passed), check whether that remote exists, then **clone** it if it does or
  **create a new private remote + scaffold the minimal layout** if it does not.
* Fresh-host symlink wiring into `~/.claude/` is offered as a **confirm-first**
  step — the one write the skill makes outside `~/.claude-config/`.
* **Absent** and **not-a-git-repo** are now distinct decisions: absent →
  bootstrap; exists-but-not-a-git-repo → stop and surface (never clobber a
  stray directory).
* New golden rules: any created remote is **private** (`--private`, never
  public), and remote creation / first push is **confirm-before-create**;
  cloning an existing remote may proceed directly.

## Type of change

* [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
* [ ] Tool / bridge contract (`tools/<system>/*.md`)
* [ ] Python package (`tools/*/` with `pyproject.toml`)
* [ ] Groovy reference impl
* [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
* [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
* [ ] Project template (`projects/_template/`)
* [ ] CI / dev loop (`prek`, workflows, validators)
* [ ] Other:

## Test plan

* [x] `prek run` passes on every changed file (SPDX, markdownlint, typos,
  lychee link-check, check-placeholders, skill-and-tool-validate)
* [x] For skill *behaviour* changes: eval fixtures included in this PR
  * added `step-3-decide-action/case-8-absent-bootstrap` (absent → `bootstrap`)
  * extended `output-spec.md` with the `bootstrap` action + clarified `error`
    semantics
  * rewrote `case-5-not-a-git-repo` to describe an **existing** non-repo
    directory (it previously described an *absent* dir but expected a stop —
    which the new absent→bootstrap path contradicts)
  * bumped the suite counts in the eval `README.md` (7→8 step-3 cases, 11→12 total)
* [x] Eval runner discovers and loads the new/updated fixtures against the
  edited `SKILL.md` (prompt assembly verified); full LLM comparison run is the
  reviewer's checkbox:
  `uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/setup-shared-config-sync/`

## RFC-AI-0004 compliance

* [x] **HITL** — remote creation, the initial push, and the `~/.claude/`
  symlink wiring are all confirm-first; the existing draft-commit-then-approve
  sync flow is unchanged.
* [x] **Sandbox** — no new unrestricted host access; the skill still operates
  only within `~/.claude-config/` plus the one confirmed symlink write into
  `~/.claude/`.
* [x] **Vendor neutrality** — the GitHub `claude-config` convention is only a
  *default*; an explicit remote URL (GitLab, self-hosted, …) overrides it, and
  the skill falls back to asking rather than assuming a vendor.
* [x] **Conversational + correctable** — when the remote can't be resolved
  (`gh` absent / no URL) the skill asks instead of guessing; every hard-to-
  reverse action is surfaced for approval first.
* [x] **Write-access discipline** — created remotes are private-only; never
  force-push; never rewrite pushed history; never clobber a non-repo
  `~/.claude-config/`.
* [x] **Privacy LLM** — no external data is ingested into an LLM by this change.

## Generative-AI disclosure

Drafted with Claude Code (Opus 4.8) under human review. The commit carries a
`Generated-by: Claude Code (Opus 4.8)` trailer per `AGENTS.md`.
