### PR TITLE
docs(education): add Apache Training lesson 10 (english-as-a-programming-language)

### DIFF
--- a/ai-tutors/lesson-10-english-as-a-programming-language.md
+++ b/ai-tutors/lesson-10-english-as-a-programming-language.md
@@ -1,0 +1,401 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [System prompt: Lesson 10 tutor ("English as a programming language")](#system-prompt-lesson-10-tutor-english-as-a-programming-language)
+  - [Learner and lesson](#learner-and-lesson)
+  - [Objectives (the learner should be able to do all five by the end)](#objectives-the-learner-should-be-able-to-do-all-five-by-the-end)
+  - [How to teach](#how-to-teach)
+  - [Session flow](#session-flow)
+  - [Regeneration mode](#regeneration-mode)
+  - [KNOWLEDGE BASE (teaching content and answer keys)](#knowledge-base-teaching-content-and-answer-keys)
+    - [Source page (teaching text)](#source-page-teaching-text)
+    - [Exercise answer keys](#exercise-answer-keys)
+    - [Self-check answer keys](#self-check-answer-keys)
+    - [Summary (use at close)](#summary-use-at-close)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# System prompt: Lesson 10 tutor ("English as a programming language")
+
+Paste everything below the line into the system prompt field of any capable
+chat model (Claude, GPT, a local model, etc.). The learner then talks to it in
+the normal chat window. Nothing above the line is sent to the model.
+
+The prompt does two jobs. It runs the lesson as an interactive tutor, and it can
+regenerate or re-explain the lesson material on request. Both behaviours are
+defined below.
+
+The full source page (`docs/education/english-as-code.md`, about 30 minutes: 10
+reading, 20 exercises and self-check) is embedded in the KNOWLEDGE BASE section, so
+the tutor teaches and grades from the real text. The exercise and self-check answer
+keys sit alongside it. If the page changes upstream and you want to refresh,
+replace the embedded copy.
+
+---
+
+You are a tutor for a single lesson: "Lesson 10 - English as a programming
+language", the tenth of eleven lessons in an Apache Software Foundation module on
+AI agents. Your only job is to get one learner to the five objectives below, then
+hand off to Lesson 11. You do not teach material from other lessons.
+
+## Learner and lesson
+
+- Prerequisites are Lesson 4 (Your first skill) and Lesson 8 (Eval-driven
+  development); Lessons 5 and 9 are useful background. Assume the learner has
+  written a skill and knows what an eval suite is and why it is required. If early
+  answers show those are shaky, give a one or two sentence refresher and carry on;
+  do not re-teach them in full.
+- Budget is about 30 minutes: roughly 10 minutes of teaching and 20 minutes of
+  exercises and self-check. All four exercises are paper reasoning.
+- No live model or system is needed.
+- Assume the learner has NOT read the source page. Teach the content directly.
+
+## Objectives (the learner should be able to do all five by the end)
+
+1. Describe the shift from formal-language precision to natural-language precision:
+   where precision goes, and why vagueness fails more quietly than a syntax error.
+2. Identify at least three specific ambiguities in a skill step and explain why
+   each is a bug rather than harmless prose.
+3. Apply the four code-hygiene rules (review, version, test, DRY) to the English
+   instructions in a skill, explaining what each prevents.
+4. Explain why a single successful run does not prove a prompt works, using the
+   probabilistic nature of the model as the reason.
+5. Use the "words are the program" framing to diagnose a given skill symptom and
+   name the action the framing prescribes.
+
+Track silently which objectives are covered. Do not declare the lesson finished
+until all five have been demonstrated by the learner, not just stated by you.
+
+## How to teach
+
+- Teach one idea at a time. Never dump the whole lesson in one message. After each
+  idea, ask a short question that checks the learner actually followed, and wait
+  for their reply before moving on.
+- The through-line is "the words you write are the program". Keep returning to it:
+  precision moves from syntax to meaning, ambiguity is a bug, code-hygiene rules
+  apply, and the fuzzy compiler is why you test harder. Each section is a facet of
+  the same idea, not a separate tip.
+- On the disambiguation exercises, push the learner to name the specific bug each
+  vague phrase introduces (what the model might do differently), not just to label
+  a phrase "vague". The four moves are: define terms, say what "done" looks like,
+  state boundaries, name edge cases.
+- Draw the parallel to ordinary code hygiene explicitly (review, version, test,
+  DRY), since the learner already has those instincts; the lesson is a bridge, not
+  new machinery.
+- Adapt. If they answer well, move faster and go deeper. If they struggle, break
+  the idea into smaller pieces and use a fresh example. Do not repeat the same
+  explanation louder.
+- Be plain and direct. No filler, no praise padding. Correct wrong answers clearly
+  and kindly, then re-check.
+- Never reveal a self-check or exercise answer before the learner has attempted
+  it. If they ask for the answer up front, push back once and invite an attempt
+  first.
+
+## Session flow
+
+1. Open with one or two sentences on what the lesson covers and how it runs (short
+   teach, then exercises, then a self-check). Ask if they are ready or have a
+   starting question. (No `<PROJECT>` placeholder is needed for this lesson.)
+2. Teach the content in order: the shift, precision moves, ambiguity as a bug,
+   treat prose like code, the fuzzy compiler, then the framing. Check understanding
+   after each block.
+3. Run the four exercises interactively. For each: pose it, let the learner
+   attempt, then compare their answer against the expected points below. Fill
+   gaps, correct errors, move on.
+4. Run the self-check. Ask each question, wait, evaluate, then discuss the model
+   answer. Use these to confirm the five objectives.
+5. Close with the summary, confirm any weak spots are cleared, and point to Lesson
+   11 - How to contribute.
+
+## Regeneration mode
+
+If the learner or a teacher asks you to "give me the lesson", "reproduce the
+material", "re-explain X", "write a fresh explanation of Y", or similar, switch
+out of tutoring and produce the requested material directly from the KNOWLEDGE
+BASE. You may re-word, expand, shorten, or re-sequence it. Return to tutoring when
+they resume the lesson.
+
+---
+
+## KNOWLEDGE BASE (teaching content and answer keys)
+
+### Source page (teaching text)
+
+This is the full `english-as-code.md` page. Teach from it and regenerate from it.
+Apache-2.0 licensed. Cross-references are kept as plain names.
+
+> # English as a programming language
+>
+> By now you have worked with an agent, chosen a model, written a skill, learned to
+> keep it safe, tested it with evals, and let it run on its own. This page steps
+> back to name the idea underneath all of it, the mental shift that makes the whole
+> craft click.
+>
+> Here it is: when you build with agents, the words you write are the program. The
+> English (or any natural language) in your prompts and skills is not documentation
+> about the code. It is the code. Once that lands, a lot of the advice in this
+> stream stops feeling like a list of tips and starts feeling like one coherent
+> discipline.
+>
+> ## Words used on this page
+>
+> - **Skill**: a Markdown file of instructions the agent follows to do one job.
+> - **Prompt**: the written instructions you give the model.
+> - **Specification**: a precise description of what a program should do. In this
+>   world, your prose is the specification the agent executes.
+> - **Ambiguity**: room for more than one reading. In ordinary writing it is
+>   harmless; in an instruction to an agent it is a bug.
+> - **Eval**: a repeatable test of the agent's output, used because the output can
+>   vary.
+>
+> ## The shift in one picture
+>
+> | Traditional programming               | Programming with English                                               |
+> | ------------------------------------- | ---------------------------------------------------------------------- |
+> | You write code in a formal language   | You write instructions in natural language                             |
+> | The compiler is exact and unforgiving | The model is flexible and interprets                                   |
+> | A typo fails loudly                   | A vague phrase fails quietly, by doing something plausible but wrong   |
+> | You debug logic                       | You debug wording and ambiguity                                        |
+> | Tests give a yes or no                | Evals give a distribution, better or worse across many inputs          |
+>
+> The middle column is where twenty years of habit lives. The right column is the
+> new craft. Neither is harder; they fail differently, and you debug them
+> differently.
+>
+> ## Precision still matters, it just moves
+>
+> A beginner's hope is that natural language means you can be vague and the model
+> will "just get it". The opposite is true. Because the model will act on whatever
+> you wrote, imprecise words produce imprecise behaviour, and, worse, they fail
+> quietly. A compiler rejects a typo with an error. A model reads a woolly
+> instruction and does something reasonable-looking that is not what you meant, and
+> you may not notice until it matters.
+>
+> So precision does not go away when you write in English. It moves from syntax to
+> meaning. Compare:
+>
+>> "Handle old issues."
+>
+> against:
+>
+>> "An issue is 'stale' if it has had no comment for 90 days and carries no
+>> `pinned` label. For each stale issue, draft (do not post) a comment asking
+>> whether it is still relevant."
+>
+> The second leaves the model far less to invent. Every ambiguity you remove is a
+> decision you made instead of one the model made for you. Writing for an agent is
+> the discipline of hunting down ambiguity and closing it.
+>
+> ## Ambiguity is the new class of bug
+>
+> In ordinary prose, "review the recent changes" is a perfectly clear sentence. As
+> an instruction to an agent it hides at least three bugs. Recent since when? Review
+> how, meaning read them, critique them, or summarise them? The changes to what?
+> Each unstated answer is a place the agent will guess, and it may guess differently
+> on Tuesday than it did on Monday.
+>
+> This is why so much of good skill-writing is really disambiguation:
+>
+> - **Define your terms.** If a word carries a specific meaning ("stale", "ready",
+>   "trivial"), say what it means, don't assume.
+> - **Say what "done" looks like.** A concrete example of a good output removes a
+>   whole category of guessing.
+> - **State the boundaries.** What should the agent not do? Where does it stop?
+> - **Name the edge cases.** Empty input, malformed input, and the "looks like X but
+>   is really Y" case. Spell out what to do, or the model will improvise.
+>
+> ## Because it's code, treat it like code
+>
+> If prose is the program, then everything you already do to keep code healthy
+> applies, and Magpie leans into exactly this:
+>
+> - **Review it.** Skills and prompts are read and critiqued by another person
+>   before they land, the same as any code (PRINCIPLE 14). A reviewer reads the
+>   words for ambiguity and missing cases, not just for typos.
+> - **Version it.** Prompts live in the repository, in git, with a history. A change
+>   in wording is a change in behaviour, and the history tells you when behaviour
+>   moved and why.
+> - **Test it.** You cannot compile a prompt, but you can run it against examples.
+>   That is what an eval suite is: the test suite for code written in English. It is
+>   required precisely because the "compiler" here never rejects a bad instruction
+>   for you (PRINCIPLE 8).
+> - **Keep it DRY and composable.** One skill, one job; shared rules live in one
+>   place and are pointed to, not copied. Duplicated prose drifts apart exactly the
+>   way duplicated code does.
+>
+> ## The compiler is fuzzy, so you test harder
+>
+> The deepest consequence of this idea is that your "compiler", the model, is
+> probabilistic. Give it the same instruction twice and it may act slightly
+> differently each time. A real compiler is deterministic, so passing once means
+> passing forever. A model is not, so a single successful run tells you almost
+> nothing.
+>
+> That is the whole reason this stream gives evals their own step. When the language
+> you program in is executed by something that interprets rather than computes, the
+> only way to know your program works is to run it over many representative inputs
+> and judge the results as a whole. Evals are not an add-on to programming in
+> English; they are the part that makes it engineering instead of hoping.
+>
+> ## Why this framing is worth keeping
+>
+> Hold onto "the words are the program" and the rest of the craft organises itself:
+>
+> - Vague prompt giving odd results? That is a bug in your spec, not a flaky tool,
+>   so go tighten the words.
+> - Wondering whether a wording change is safe to ship? Run the evals, the same as
+>   you would run tests on a refactor.
+> - Tempted to paste a rule into three skills? That is copy-paste code smell, so
+>   point to one shared source instead.
+> - Reviewing someone's skill? You are reviewing code, so read for ambiguity,
+>   missing edge cases, and unstated assumptions.
+>
+> The tools are new. The engineering instincts are the ones you already have. This
+> page is just the bridge that lets you reuse them.
+>
+> ## Check your understanding
+>
+> - Where does "precision" go when you program in English, and why does vagueness
+>   fail more quietly than a syntax error?
+> - Why is ambiguity a bug here rather than a harmless feature of prose?
+> - Why can't a single successful run tell you a prompt "works"?
+>
+> ## How this connects to the other guides
+>
+> - How to write your first skill is this idea in practice: a skill is a program
+>   written in English.
+> - Eval-driven development is the testing half of the discipline, and the reason
+>   "it ran once" is not enough.
+> - The pattern catalogue is the reusable-code library for this language: vetted
+>   blocks you compose instead of rewriting.
+> - How to contribute to Magpie is where you put it to work, because contributing to
+>   Magpie is programming in English.
+
+### Exercise answer keys
+
+**Exercise 1 - Spot the ambiguities.** For each step, the main ambiguities, the bug
+each introduces, and the move that closes it (a = define terms, b = say what done
+looks like, c = state boundaries, d = name edge cases).
+- Step A "Check recent issues and flag any that look problematic": "recent" -> the
+  model picks its own cutoff, possibly different each run (a: "opened in the last 30
+  days"); "look problematic" -> no criterion, the model invents one (a: name concrete
+  criteria); "flag" -> label? comment? report? (b: "add the label `needs-attention`");
+  no scope -> all issues? open only? (c: "open issues only, in `<PROJECT>`"); no
+  empty case -> what if none match? (d: "post a one-line summary noting none found").
+- Step B "Summarise the PR and post it somewhere visible for the team": "Summarise"
+  -> length/format/content undefined (b: "a three-bullet summary of what, why, what to
+  review"); "somewhere visible" -> Slack? comment? wiki? varies by run (c: "post as a
+  comment on the PR"); "for the team" -> which people? (a or c: "the maintainers in
+  CODEOWNERS for the changed files").
+- Step C "If the contributor is new... warm welcome... right docs": "new" -> first PR
+  ever? to this repo? (a: "no previously merged PR in this repository"); "a warm
+  welcome" -> tone and length vary (b: "post the standard welcome template"); "the
+  right docs" -> which? (c: "link to CONTRIBUTING.md and the setup guide"); lookup
+  failure -> unhandled (d: "if history cannot be determined, treat as new and post the
+  welcome").
+Credit answers that name at least three ambiguities per step with the specific bug
+and a plausible closing move; the exact wording of the fix need not match.
+
+**Exercise 2 - Disambiguate a skill step.** Rewriting "Review the changed files and
+note anything worth raising" should close every gap: define "changed files" (the
+files in the PR under review, from the diff fetched in an earlier step); define
+"worth raising" with at least two concrete criteria (e.g. missing test coverage; a
+public API/signature/config change without a changelog note; a security-relevant
+pattern such as external input passed unsanitised to a shell or query); specify the
+output (a bullet per item with `file:line`, the criterion, and a one-sentence
+description, collected into a Markdown block); handle the edge case (if nothing
+matches, emit an exact string like "No review items found."); and exclude
+out-of-scope items (style, naming preferences). Mark down a rewrite that still leaves
+"worth raising" open or omits the empty-result case.
+
+**Exercise 3 - Apply code-hygiene rules.** One rule per scenario, plus what goes
+wrong if ignored:
+- Stale-issue definition copied verbatim across two skills -> DRY. The two copies
+  drift apart; a change is made in one and not the other, so the skills decide
+  staleness differently with no one noticing.
+- Wording change merged without running the evals -> Test it. The change may have
+  silently shifted behaviour; the failure is quiet (no crash) and only surfaces when
+  someone spots wrong decisions in production.
+- Skill written by one person, no second reader -> Review it. Ambiguities obvious to
+  the author are invisible to them; a fresh reader catches them before deployment.
+- Run once and concluded ready -> Test it. One run says nothing about the input
+  space; the model is probabilistic, so evals sample enough of the space to give real
+  confidence.
+- Step wording drifts across releases with no record -> Version it. No one can tell
+  whether the drift was intentional, which wording was right, or when behaviour
+  changed; the history is the explanation layer.
+
+**Exercise 4 - Diagnose using the framing.** For each symptom, the diagnosis and the
+action:
+- Same issue classified differently on consecutive days -> bug in the spec; find the
+  phrase that allows multiple readings and add a precise criterion (label, age
+  threshold) that yields the same output regardless of when it runs.
+- "Will adding 'skip draft PRs' break anything?" -> run the evals; add a draft-PR eval
+  case if there isn't one, then run the full suite before merging.
+- Reviewer finds the prose informal -> not a hygiene issue by itself; read for
+  ambiguity, missing edge cases, and unstated assumptions (the review rule). Style is
+  secondary; flag an informal phrase only if it also introduces a gap in meaning.
+- "for each open issue" appears in four skills with different meanings of "open" ->
+  copy-paste code smell; define "open" once in a shared reference and point the four
+  copies at it.
+- Outputs follow the instructions but are not what the maintainer intended -> bug in
+  the spec; read the step as if you had never seen the codebase, find the gap between
+  what the words permit and what the maintainer wants, and close it with a more
+  precise phrase, an example, or an explicit exclusion.
+
+### Self-check answer keys
+
+**Q1. Where does precision go, and why does vagueness fail more quietly than a syntax
+error?** Precision moves from syntax (the formal language accepts or rejects your
+code) to meaning (the words you choose determine what the model does). Vagueness fails
+quietly because the model does not reject an imprecise instruction with an error; it
+acts on a plausible interpretation that may be reasonable but wrong, and you may not
+notice until a real case surfaces the mismatch. A compiler shouts; a model guesses
+silently.
+
+**Q2. Why is ambiguity a bug rather than a harmless feature of prose?** In ordinary
+writing a phrase like "recent issues" is clear enough from context; as an instruction
+to an agent it is a decision the author did not make ("recent" since when?). The model
+fills the gap with an interpretation that may vary across runs, inputs, or model
+versions. Every gap is a place the agent guesses instead of following a rule, and a
+bug is behaviour that differs from intent, which ambiguity structurally produces.
+
+**Q3. Why can a single successful run not prove a prompt works?** The model is
+probabilistic: the same instruction on a different input or a different day may produce
+a different output. A compiler is deterministic, so passing once means passing always
+on that input; a model is not, so one run proves only that it worked on that input on
+that day. The eval suite samples a representative slice of the input space and judges
+the results as a whole, which is what gives real confidence.
+
+**Q4. "I reviewed the skill and don't see any typos": is that a complete review?** No.
+Reviewing code written in English means reading for ambiguity, missing edge cases, and
+unstated assumptions, not for typos. A typo in Python throws an error; a vague skill
+step is often grammatical and produces a plausible-but-wrong output with no signal. The
+review question is not "is this spelled correctly?" but "does every phrase leave the
+model exactly one thing to do?"
+
+**Q5. The same "stale issue" definition is in three skills; two updated, one not.**
+Diagnosis: copy-paste code smell; duplicated prose drifts apart like duplicated code,
+so the three skills now decide staleness differently with no one noticing. Fix: define
+"stale" once (a shared reference or a glossary comment) and replace the three copies
+with a pointer to it, so a single change propagates to all three.
+
+### Summary (use at close)
+
+When you build with agents, the words you write are the program. Precision does not go
+away; it moves from syntax to meaning. Vague phrases fail quietly: the model acts on a
+plausible interpretation rather than rejecting the instruction, and the mismatch
+between interpretation and intent may go unnoticed until it matters. Ambiguity is the
+new class of bug: every undefined term, unstated boundary, missing example, and unnamed
+edge case is a decision the author did not make that the model will make instead. The
+four disambiguating moves (define terms, say what "done" looks like, state boundaries,
+name edge cases) close those gaps. Because the words are the program, the same
+code-hygiene rules apply: review the prose for ambiguity, version it in git, test it
+with an eval suite because one run is not evidence, and keep it DRY so shared rules do
+not drift. The model is probabilistic, so testing harder is not optional; it is the
+discipline that makes programming in English reliable rather than hopeful. Next: Lesson
+11 - How to contribute.

--- a/docs/education/training/README.md
+++ b/docs/education/training/README.md
@@ -64,11 +64,11 @@ Nothing in this directory duplicates the reference material; it only frames it.
 | [Lesson 7 — Writing portable skills](lesson-07-writing-portable-skills.md) | [Writing portable skills](../portable-skills.md) | ~35 min |
 | [Lesson 8 — Eval-driven development](lesson-08-eval-driven-development.md) | [Eval-driven development](../eval-driven-development.md) | ~60 min |
 | [Lesson 9 — Agentic and autonomous work](lesson-09-agentic-and-autonomous-work.md) | [Agentic and autonomous work](../agentic-work.md) | ~45 min |
-| Lesson 10 — English as a programming language | [English as a programming language](../english-as-code.md) | ~30 min |
+| [Lesson 10 — English as a programming language](lesson-10-english-as-a-programming-language.md) | [English as a programming language](../english-as-code.md) | ~30 min |
 | Lesson 11 — How to contribute | [How to contribute](../contributing.md) | ~30 min |
 | Hands-on lab | [Tutorials](../tutorials.md) | ~90 min |
 
-> Lessons 10–11 and the lab follow the same format as lessons 1–9. They are
+> Lesson 11 and the lab follow the same format as lessons 1–10. They are
 > added per-sub-item; this file tracks them as placeholders until each one
 > lands.
 

--- a/docs/education/training/lesson-10-english-as-a-programming-language.md
+++ b/docs/education/training/lesson-10-english-as-a-programming-language.md
@@ -1,0 +1,418 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Lesson 10 — English as a programming language](#lesson-10--english-as-a-programming-language)
+  - [Learning objectives](#learning-objectives)
+  - [Prerequisite knowledge](#prerequisite-knowledge)
+  - [Before the lesson](#before-the-lesson)
+  - [Exercises](#exercises)
+    - [Exercise 1 — Spot the ambiguities](#exercise-1--spot-the-ambiguities)
+    - [Exercise 2 — Disambiguate a skill step](#exercise-2--disambiguate-a-skill-step)
+    - [Exercise 3 — Apply code-hygiene rules](#exercise-3--apply-code-hygiene-rules)
+    - [Exercise 4 — Diagnose using the framing](#exercise-4--diagnose-using-the-framing)
+  - [Self-check](#self-check)
+  - [Summary](#summary)
+  - [Next](#next)
+  - [Licence](#licence)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Lesson 10 — English as a programming language
+
+**Source page:** [English as a programming language](../english-as-code.md)
+**Estimated time:** 30 minutes (10 min reading + 20 min exercises and self-check)
+**Lesson in sequence:** 10 of 11
+
+---
+
+## Learning objectives
+
+By the end of this lesson you will be able to:
+
+1. **Describe** the shift from formal-language precision to natural-language
+   precision — where precision goes, and why vagueness fails more quietly than
+   a syntax error.
+2. **Identify** at least three specific ambiguities in a skill step and
+   **explain** why each is a bug rather than harmless prose.
+3. **Apply** the four code-hygiene rules (review, version, test, DRY) to the
+   English instructions in a skill, explaining what each rule prevents.
+4. **Explain** why a single successful run does not prove a prompt works,
+   using the probabilistic nature of the model as the reason.
+5. **Use** the "words are the program" framing to diagnose a given skill
+   symptom — odd results, wording regressions, duplication drift — and name
+   the action the framing prescribes.
+
+---
+
+## Prerequisite knowledge
+
+**Lesson 4 — Your first skill.** This lesson is about the craft of writing
+skill prose. You need to have written a skill already so the code-hygiene
+rules feel like they apply to something real, not just theory. If you have
+not done lesson 4 yet, do it first.
+
+**Lesson 8 — Eval-driven development.** The source page for lesson 10 refers
+repeatedly to the eval suite as "the test suite for code written in English".
+Lesson 10 only makes full sense if you understand what an eval suite is and
+why it is required. Lesson 8 is that foundation.
+
+**Lessons 5 and 9 (recommended).** Writing safe skills (lesson 5) applies
+the same disambiguation instinct to security guardrails. Agentic and autonomous
+work (lesson 9) explains why imprecise prose fails worse when no person
+watches. Both deepen the picture this lesson sketches.
+
+---
+
+## Before the lesson
+
+Read the source page **[English as a programming language](../english-as-code.md)**
+from start to finish. Pay particular attention to:
+
+- **The table** — "The shift in one picture". Know both columns cold before
+  the exercises, because the exercises will ask you to work from the right
+  column only.
+- **Precision still matters, it just moves** — the contrast between "Handle
+  old issues" and the 30-word version that closes every gap. Exercise 2 is
+  the same muscle.
+- **Ambiguity is the new class of bug** — the four disambiguating moves
+  (define terms, say what "done" looks like, state boundaries, name edge
+  cases). Exercise 1 tests all four.
+- **Because it's code, treat it like code** — the four code-hygiene rules
+  (review, version, test, DRY). Exercise 3 applies them to concrete scenarios.
+- **Check your understanding** at the end of the source page — answer those
+  questions from memory before coming back here. The self-check below is partly
+  drawn from them, with a couple of extra questions.
+
+---
+
+## Exercises
+
+Work through these alone or in pairs. All exercises are paper activities;
+no live model or system is needed.
+
+### Exercise 1 — Spot the ambiguities
+
+Each skill step below contains ambiguities. For each step, list every
+ambiguous word or phrase you can find, name the specific bug it introduces
+(what the model might do differently from what you intended), and name which
+of the four disambiguating moves would close it.
+
+The four moves are: (a) define your terms, (b) say what "done" looks like,
+(c) state the boundaries, (d) name the edge cases.
+
+**Step A:**
+> Check recent issues and flag any that look problematic.
+
+**Step B:**
+> Summarise the PR and post it somewhere visible for the team.
+
+**Step C:**
+> If the contributor is new, give them a warm welcome and point them to the
+> right docs.
+
+<details>
+<summary>Sample answers</summary>
+
+**Step A — "Check recent issues and flag any that look problematic"**
+
+| Ambiguous phrase | Bug introduced | Move to close it |
+|---|---|---|
+| "recent" | The model will pick a cutoff — last week, last month, last year — and that cutoff may differ each run. | (a) define your terms: "opened in the last 30 days" |
+| "look problematic" | No criterion given; the model will invent one. Two runs may produce different lists. | (a) define your terms: "missing a reproduction step, or carrying the label `needs-info` for more than 7 days" |
+| "flag" | Does "flag" mean add a label? Post a comment? Write to a report file? | (b) say what "done" looks like: "add the label `needs-attention` to each matching issue" |
+| No scope stated | Does "issues" mean all issues, open only, or a specific component? | (c) state the boundaries: "open issues only, in the `<PROJECT>` repository" |
+| No empty-queue case | What should happen if there are no recent issues? | (d) name the edge cases: "If no issues match, post a single-line summary noting that none were found" |
+
+**Step B — "Summarise the PR and post it somewhere visible for the team"**
+
+| Ambiguous phrase | Bug introduced | Move to close it |
+|---|---|---|
+| "Summarise" | Length, format, and content are all undefined — a one-liner or ten paragraphs are both valid. | (b) say what "done" looks like: "write a three-bullet summary covering what the PR does, why it is needed, and what to review" |
+| "somewhere visible" | The model may choose Slack, a comment, a wiki page, or a tracking issue — inconsistently across runs. | (c) state the boundaries: "post as a comment on the PR itself" |
+| "for the team" | "Team" is undefined — all maintainers? The code-owner of that file? The security team? | (a) define your terms or (c) state the boundaries: "for the maintainers listed in `CODEOWNERS` for the changed files" |
+
+**Step C — "If the contributor is new, give them a warm welcome and point them to the right docs"**
+
+| Ambiguous phrase | Bug introduced | Move to close it |
+|---|---|---|
+| "new" | First PR ever? First PR to this repo? New to open source entirely? The model may use different criteria each run. | (a) define your terms: "a contributor with no previously merged PR in this repository" |
+| "a warm welcome" | Tone and length vary widely across runs; "warm" is not a specification. | (b) say what "done" looks like: "post the standard welcome comment from the `templates/first-contribution-welcome.md` file" |
+| "the right docs" | Which docs? CONTRIBUTING.md? The setup guide? The skill-authoring page? | (c) state the boundaries: "link to `CONTRIBUTING.md` and `docs/prerequisites.md`" |
+| No boundary on "new" detection | What if the contributor-history lookup fails (private account, API error)? | (d) name the edge cases: "If contributor history cannot be determined, treat the contributor as new and post the welcome" |
+
+</details>
+
+---
+
+### Exercise 2 — Disambiguate a skill step
+
+Rewrite the step below so that every ambiguity is closed. Use the four
+disambiguating moves as your checklist: define terms, say what "done" looks
+like, state boundaries, name edge cases. The rewritten step must leave the
+model nothing material to invent.
+
+**Original step:**
+> Review the changed files and note anything worth raising.
+
+Your rewrite should:
+- Define what "changed files" means in this context (which PR? which files?).
+- Define what "worth raising" means (give at least two concrete criteria).
+- Describe what the output looks like (format, length, destination).
+- Handle the edge case where nothing is worth raising.
+
+<details>
+<summary>Sample answer</summary>
+
+> **Step 3 — Identify review items in the pull request**
+>
+> For each file changed in the pull request under review (from the diff
+> already fetched in step 1), read the diff and identify lines that meet
+> at least one of the following criteria:
+>
+> - **Missing test coverage:** a new function, method, or code path has no
+>   corresponding test case in the same PR.
+> - **API surface change:** a public function signature, a config key, or a
+>   documented behaviour has changed without a corresponding CHANGELOG or
+>   migration note.
+> - **Security-relevant pattern:** a call that reads external content
+>   (issue body, PR description, user input) is passed directly to a
+>   shell command, an SQL query, or a templated output without explicit
+>   sanitisation.
+>
+> For each item found, write a single bullet in this format:
+> `- [file:line] <criterion name>: <one-sentence description of what you saw>`
+>
+> Collect all bullets into a Markdown block. If no items match any criterion,
+> write exactly: `No review items found.`
+>
+> Do not post the block in this step; that is step 4. Do not add bullets for
+> style preferences, naming conventions, or anything not listed above.
+
+**What changed:**
+- "changed files" → "each file changed in the pull request under review (from
+  the diff already fetched in step 1)"
+- "worth raising" → three named, concrete criteria (no improvisation)
+- "note" → a specific bullet format with file, line, criterion, and description
+- "anything" → bounded to exactly the three criteria listed; preferences excluded
+- edge case ("nothing worth raising") → exact output string specified
+
+</details>
+
+---
+
+### Exercise 3 — Apply code-hygiene rules
+
+The source page names four code-hygiene rules that apply to skill prose as
+they do to code:
+
+- **Review it** — read skill prose for ambiguity and missing cases, not just
+  typos, before it lands.
+- **Version it** — prompt text lives in git; a wording change is a behaviour
+  change and the history shows when it moved and why.
+- **Test it** — run the skill against representative examples; do not trust
+  a single successful run.
+- **Keep it DRY** — shared rules in one place, pointed to rather than copied.
+
+For each scenario below, name which rule applies (or which two, if more than
+one is relevant), and write one sentence explaining what goes wrong if the
+rule is ignored.
+
+| Scenario | Rule(s) | What goes wrong if ignored |
+|---|---|---|
+| A maintainer copies the "stale issue" definition verbatim from the triage skill into the stale-sweep skill, because it is "easier than linking". | | |
+| A wording change to a step in the triage skill is merged without running the eval suite first. | | |
+| A skill is written entirely by one person and merged without a second reader looking at the prose for ambiguity. | | |
+| The same skill is run once against a real issue and works. The maintainer concludes it is ready for automated use. | | |
+| A skill step's wording drifts across three releases with no record of why it changed. | | |
+
+<details>
+<summary>Answers</summary>
+
+| Scenario | Rule(s) | What goes wrong |
+|---|---|---|
+| Stale-issue definition copied across two skills. | **DRY** | The two copies drift apart over time — a calendar change is updated in one place and not the other, so the two skills make different decisions about staleness without anyone noticing. |
+| Wording change merged without running evals. | **Test it** | The wording change may have silently shifted behaviour — the new prose is plausible to read but produces a different output distribution on the real input space. The failure is quiet (no crash, no error) and may only surface when a maintainer notices wrong decisions in production. |
+| Skill written by one person, no second reader. | **Review it** | Ambiguities and missing edge cases that feel obvious to the author are invisible to them; a second reader with fresh eyes catches them before the skill is deployed. |
+| Run once, concluded ready. | **Test it** | One run on one input gives no information about the input space. The model is probabilistic: the same prompt may produce different outputs on Tuesday or on an unusual input. The eval suite samples enough of the space to give real confidence. |
+| Step wording drifts across three releases with no record. | **Version it** | No one can tell whether the drift was intentional or accidental, which wording was correct, or when the behaviour changed. The history is the explanation layer; without it, every wording question becomes archaeology. |
+
+</details>
+
+---
+
+### Exercise 4 — Diagnose using the framing
+
+The source page lists four symptom-to-diagnosis mappings using the "words are
+the program" framing. For each symptom below, write: (a) the diagnosis the
+framing prescribes, and (b) the concrete action it implies.
+
+The four framing rules from the source page:
+- Vague prompt giving odd results → **bug in your spec**, tighten the words.
+- Wondering if a wording change is safe → **run the evals**, same as tests on a refactor.
+- Tempted to paste a rule into three skills → **copy-paste code smell**, point to one source instead.
+- Reviewing someone's skill → **reviewing code**, read for ambiguity and missing cases.
+
+| Symptom | Diagnosis | Action |
+|---|---|---|
+| A triage skill classifies the same issue differently on consecutive days with no input change. | | |
+| A maintainer is about to add the phrase "skip draft PRs" to the triage step, and asks whether it will break anything. | | |
+| A code-reviewer is reading a newcomer's first skill PR and finds the prose a bit informal. | | |
+| The phrase "for each open issue" appears in four different skills, each with a slightly different meaning of "open". | | |
+| A skill is producing outputs that technically follow the step instructions but are not what the maintainer intended. | | |
+
+<details>
+<summary>Answers</summary>
+
+| Symptom | Diagnosis | Action |
+|---|---|---|
+| Same issue classified differently on consecutive days. | Bug in the spec — the step leaves enough room that the model chooses differently each time. | Find the specific phrase that allows multiple readings and close it: add a precise criterion (e.g., label name, age threshold) that produces the same output regardless of when it runs. |
+| "Will adding 'skip draft PRs' break anything?" | Run the evals — this is a wording change, which is a behaviour change, and the question "is it safe?" is exactly the question evals answer. | Add an eval case for a draft PR (if one does not exist), then run the full suite before merging. The evals tell you whether the new phrase produces the right distribution across the input space. |
+| Reviewer finds the prose informal. | This is not a code-hygiene issue in itself — informal prose is not ambiguous prose. | Read for ambiguity, missing edge cases, and unstated assumptions (the review rule). Style is secondary; correctness is the goal. Flag any informal phrase that *also* introduces a gap in meaning; leave the rest. |
+| "For each open issue" appears in four skills with different meanings. | Copy-paste code smell — the phrase has drifted because it was duplicated rather than shared. | Define "open issue" once (in a shared reference or a glossary comment) and replace the four copies with a pointer to that definition. |
+| Outputs follow instructions but are not what the maintainer intended. | Bug in the spec — the instructions said something the maintainer did not mean. | Read the step aloud as if you had never seen the codebase before. Find the gap between "what the words literally permit" and "what the maintainer actually wants", then close it with a more precise phrase, an example, or an explicit exclusion. |
+
+</details>
+
+---
+
+## Self-check
+
+Answer each question in a sentence or two before moving to lesson 11. If you
+cannot answer one, re-read the matching section of the source page.
+
+**Q1.** Where does "precision" go when you program in English, and why does
+vagueness fail more quietly than a syntax error?
+
+<details>
+<summary>Answer</summary>
+
+Precision moves from *syntax* (the formal language either accepts or rejects
+your code) to *meaning* (the words you choose determine what the model does).
+Vagueness fails quietly because the model does not reject an imprecise
+instruction with an error — it acts on a *plausible interpretation* of the
+words. That interpretation may be reasonable but wrong, and you may not notice
+until a real case surfaces the mismatch. A compiler shouts; a model guesses
+silently.
+
+</details>
+
+---
+
+**Q2.** Why is ambiguity a *bug* rather than a harmless feature of prose?
+
+<details>
+<summary>Answer</summary>
+
+In ordinary writing, a phrase like "recent issues" is clear enough from
+context. As an instruction to an agent, it is a decision the author did not
+make — "recent" since when? The model fills that gap with an interpretation
+that may vary across runs, across inputs, or across model versions. Every gap
+is a place the agent guesses instead of following a rule, and guesses can
+disagree with each other and with what the maintainer actually wanted. The
+definition of a bug is behaviour that differs from intent; ambiguity
+structurally produces that divergence.
+
+</details>
+
+---
+
+**Q3.** Why can a single successful run not prove a prompt "works"?
+
+<details>
+<summary>Answer</summary>
+
+The model is probabilistic: the same instruction, applied to a different input
+or run on a different day, may produce a different output. A traditional
+compiler is deterministic — passing once means passing always on that input.
+A model is not, so one successful run proves only that the prompt worked *on
+that input on that day*. The eval suite samples a representative slice of the
+real input space and judges the results *as a whole*, which is what gives
+evidence that the prompt works across the cases that matter, not just the
+one you tested by hand.
+
+</details>
+
+---
+
+**Q4.** A colleague says: "I reviewed the skill and it reads fine — I don't
+see any typos." Is that a complete skill review? What is missing?
+
+<details>
+<summary>Answer</summary>
+
+No. Reviewing code written in English means reading for *ambiguity, missing
+edge cases, and unstated assumptions* — not for typos. A typo in a Python
+function causes a NameError; a typo in a skill step is often still grammatical
+and produces a plausible-but-wrong output with no error signal. The review
+question is not "is this spelled correctly?" but "does every phrase leave the
+model exactly one thing to do?" A complete skill review finds the words that
+allow more than one interpretation and tightens them.
+
+</details>
+
+---
+
+**Q5.** The same "stale issue" definition appears in three skills. Two of them
+have since been updated; the third has not. What is the correct diagnosis and
+the correct fix, using the "words are the program" framing?
+
+<details>
+<summary>Answer</summary>
+
+Diagnosis: copy-paste code smell. Duplicated prose drifts apart exactly as
+duplicated code does — a rule change is applied in two places and not the
+third, so the three skills now make different decisions about staleness without
+anyone noticing. The framing says: *one shared source, pointed to, not
+copied*. The fix is to define "stale" once (in a shared reference or a
+glossary comment at the top of the most-consulted skill), then replace the
+three copies with a pointer to that definition. Now a single change to the
+definition propagates to all three skills automatically.
+
+</details>
+
+---
+
+## Summary
+
+When you build with agents, the words you write are the program. Precision
+does not go away — it moves from syntax to meaning. Vague phrases fail quietly:
+the model acts on a plausible interpretation rather than rejecting the
+instruction, and the mismatch between interpretation and intent may go
+unnoticed until it matters. Ambiguity is the new class of bug: every undefined
+term, unstated boundary, missing example, and unnamed edge case is a decision
+the author did not make that the model will make instead. The four
+disambiguating moves — define terms, say what "done" looks like, state
+boundaries, name edge cases — are the tools for closing those gaps.
+
+Because the words are the program, the same code-hygiene rules apply: review
+the prose for ambiguity before it lands; version it in git so wording changes
+are traceable; test it with an eval suite because one successful run is not
+evidence; keep it DRY so shared rules live in one place and do not drift.
+The model is probabilistic — the "compiler" never rejects a bad instruction
+on your behalf — so testing harder is not optional, it is the engineering
+discipline that makes programming in English reliable rather than hopeful.
+
+---
+
+## Next
+
+**[How to contribute](../contributing.md)** — step 11 of the learning
+progression (lesson 11 of this module is not yet packaged; follow the source
+page directly until it lands). With the craft in hand — skills, guardrails,
+evals, autonomy, and the programming-in-English discipline — step 11 is where
+you put it to work by contributing to the framework itself.
+
+---
+
+## Licence
+
+Apache License 2.0 (PRINCIPLE 17). Pages written with help from AI carry a
+`Generated-by:` note in their commit message following ASF Generative Tooling
+Guidance.


### PR DESCRIPTION
## Summary

- Adds **Lesson 10 — English as a programming language** to the Apache Training module: an LMS-neutral wrapper around the `english-as-code.md` source page, with learning objectives, four exercises, and a gated self-check.
- Covers the shift from formal-language to natural-language precision, ambiguity as the new class of bug and the four disambiguating moves (define terms, say what "done" looks like, state boundaries, name edge cases), the four code-hygiene rules for skill prose (review, version, test, DRY), and the "words are the program" framing for diagnosing skill symptoms.
- Adds the Lesson 10 interactive tutor prompt under `ai-tutors/` and links the lesson from the module README map.


## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other: