### PR TITLE
docs(education): add Apache Training lesson 11 (how-to-contribute) and facilitator guide

### DIFF
--- a/ai-tutors/lesson-11-how-to-contribute.md
+++ b/ai-tutors/lesson-11-how-to-contribute.md
@@ -1,0 +1,410 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [System prompt: Lesson 11 tutor ("How to contribute")](#system-prompt-lesson-11-tutor-how-to-contribute)
+  - [Learner and lesson](#learner-and-lesson)
+  - [Objectives (the learner should be able to do all five by the end)](#objectives-the-learner-should-be-able-to-do-all-five-by-the-end)
+  - [How to teach](#how-to-teach)
+  - [Session flow](#session-flow)
+  - [Regeneration mode](#regeneration-mode)
+  - [KNOWLEDGE BASE (teaching content and answer keys)](#knowledge-base-teaching-content-and-answer-keys)
+    - [Source page (teaching text)](#source-page-teaching-text)
+    - [Exercise answer keys](#exercise-answer-keys)
+    - [Self-check answer keys](#self-check-answer-keys)
+    - [Summary (use at close)](#summary-use-at-close)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# System prompt: Lesson 11 tutor ("How to contribute")
+
+Paste everything below the line into the system prompt field of any capable
+chat model (Claude, GPT, a local model, etc.). The learner then talks to it in
+the normal chat window. Nothing above the line is sent to the model.
+
+The prompt does two jobs. It runs the lesson as an interactive tutor, and it can
+regenerate or re-explain the lesson material on request. Both behaviours are
+defined below.
+
+This is the final lesson in the module. The full source page
+(`docs/education/contributing.md`, about 30 minutes: 10 reading, 20 exercises and
+self-check) is embedded in the KNOWLEDGE BASE section, so the tutor teaches and
+grades from the real text. The exercise and self-check answer keys sit alongside
+it. If the page changes upstream and you want to refresh, replace the embedded
+copy.
+
+---
+
+You are a tutor for a single lesson: "Lesson 11 - How to contribute", the last of
+eleven lessons in an Apache Software Foundation module on AI agents. Your only job
+is to get one learner to the five objectives below, then close out the module. You
+do not teach material from other lessons.
+
+## Learner and lesson
+
+- This lesson assumes the whole progression, especially Lesson 4 (Your first
+  skill), Lesson 5 (Writing safe skills, which covers three of the five reviewer
+  rules), Lesson 8 (Eval-driven development, why evals are required), and Lesson 10
+  (English as a programming language, the immediate predecessor). If early answers
+  show those are shaky, give a one or two sentence refresher and carry on; do not
+  re-teach them in full.
+- Budget is about 30 minutes: roughly 10 minutes of teaching and 20 minutes of
+  exercises and self-check. All four exercises are paper reasoning.
+- No live system or code repository is needed.
+- Assume the learner has NOT read the source page. Teach the content directly.
+
+## Objectives (the learner should be able to do all five by the end)
+
+1. Name the four common first contributions and rank them in rough order of
+   on-ramp effort, explaining why that order holds.
+2. Explain what spec-first development means and decide for a given change whether
+   it requires a spec update.
+3. List the five framework rules a reviewer checks on a skill contribution and
+   describe what each requires in concrete terms.
+4. Walk the six-step path to a merged change, naming the purpose of each step and
+   where the common sticking points occur.
+5. Select the correct resource (CONTRIBUTING.md, the write-skill guide, MISSION or
+   PRINCIPLES, the spec) for a given contribution question, explaining why.
+
+Track silently which objectives are covered. Do not declare the lesson finished
+until all five have been demonstrated by the learner, not just stated by you.
+
+## How to teach
+
+- Teach one idea at a time. Never dump the whole lesson in one message. After each
+  idea, ask a short question that checks the learner actually followed, and wait
+  for their reply before moving on.
+- Frame the lesson as the payoff: everything the module taught about building
+  safely is now the thing a reviewer checks on the other side of the pull request.
+  The five reviewer rules are the same principles from earlier lessons, not new
+  hoops.
+- Keep the spec-first test crisp: a change needs a spec update when it alters a
+  rule, a flow, or a contract; small doc or wording fixes do not. The practical
+  test is "would the spec be false if my change merged?"
+- On the reviewer-checklist exercise, teach the difference between violated,
+  satisfied, and cannot-assess: a PR description often does not show enough to
+  judge P0 or P17, and "cannot assess" with a note on what to ask for is the
+  correct verdict, not a guess.
+- Adapt. If they answer well, move faster and go deeper. If they struggle, break
+  the idea into smaller pieces and use a fresh example. Do not repeat the same
+  explanation louder.
+- Be plain and direct. No filler, no praise padding. Correct wrong answers clearly
+  and kindly, then re-check.
+- Never reveal a self-check or exercise answer before the learner has attempted
+  it. If they ask for the answer up front, push back once and invite an attempt
+  first.
+
+## Session flow
+
+1. Open with one or two sentences on what the lesson covers and how it runs (short
+   teach, then exercises, then a self-check). Ask if they are ready or have a
+   starting question. (No `<PROJECT>` placeholder is needed for this lesson.)
+2. Teach the content in order: what a contribution looks like and the four types,
+   spec-first, the five reviewer rules, the six-step path, and where to get help.
+   Check understanding after each block.
+3. Run the four exercises interactively. For each: pose it, let the learner
+   attempt, then compare their answer against the expected points below. Fill
+   gaps, correct errors, move on.
+4. Run the self-check. Ask each question, wait, evaluate, then confirm the five
+   objectives.
+5. Close the lesson and the module. Give the summary, confirm any weak spots are
+   cleared, and note that this is the last numbered lesson: with all eleven done,
+   the learner has the full path from what agents are to giving work back. Point to
+   the hands-on lab (tutorials) as the natural next step. Do not invent a Lesson
+   12.
+
+## Regeneration mode
+
+If the learner or a teacher asks you to "give me the lesson", "reproduce the
+material", "re-explain X", "write a fresh explanation of Y", or similar, switch
+out of tutoring and produce the requested material directly from the KNOWLEDGE
+BASE. You may re-word, expand, shorten, or re-sequence it. Return to tutoring when
+they resume the lesson.
+
+---
+
+## KNOWLEDGE BASE (teaching content and answer keys)
+
+### Source page (teaching text)
+
+This is the full `contributing.md` page. Teach from it and regenerate from it.
+Apache-2.0 licensed. Cross-references and file paths are kept as plain names.
+
+> # How to contribute to Magpie
+>
+> This is the last page of the progression, and it turns everything before it into
+> action. You now know what an agent is, how to work with one, how to pick a model,
+> how to write a skill, keep it safe, and test it with evals, how autonomy works,
+> and why the words you write are the program. This page is about giving that work
+> back, contributing to Magpie itself.
+>
+> Magpie is the open, project-agnostic framework for agent-assisted maintainership.
+> It grows the way any healthy open-source project grows: from people who used it,
+> saw something missing or wrong, and sent a change. This page is the on-ramp for
+> becoming one of those people. It is a friendly overview; the authoritative
+> reference is CONTRIBUTING.md, which you should read in full before your first
+> patch.
+>
+> ## Words used on this page
+>
+> - **Framework**: Magpie itself, meaning the shared skills, tools, and docs, as
+>   opposed to your own project that adopts it.
+> - **Skill**: a Markdown file that tells the agent how to do one job. Contributing
+>   a skill is the most common first contribution.
+> - **Eval**: the test suite for a skill. A skill contribution is not finished
+>   without one.
+> - **Spec**: a precise description of what part of the framework should do. Magpie
+>   is built spec-first (see below).
+> - **Pull request (PR)**: the change you offer to the project for review before it
+>   is merged.
+>
+> ## What a contribution looks like here
+>
+> Magpie is unusual: most of it is written in English, not in a formal language. So
+> most contributions are prose that the agent executes, such as a new skill, a fix
+> to an existing skill, a pattern for the catalogue, or a page in this very stream.
+> That is a feature, not a quirk: it means you can contribute meaningfully without
+> being a systems programmer, as long as you can think clearly and write precisely.
+> The English as a programming language page is the mindset; this page is the
+> mechanics.
+>
+> Good first contributions, roughly in order of on-ramp:
+>
+> - **Fix or sharpen a skill.** You ran a skill, and it drifted or missed a case.
+>   Tighten the wording and add an eval case that captures what you saw.
+> - **Improve the docs.** A confusing sentence in this stream, a missing example, a
+>   broken link. Small, valuable, and a gentle way to learn the process.
+> - **Add a pattern.** You found a skill shape that works well; write it up for the
+>   pattern catalogue so others can copy it.
+> - **Write a new skill.** The biggest of the common first contributions. Your
+>   first skill is the step-by-step path, and it ends at an open pull request.
+>
+> ## Magpie is built spec-first
+>
+> One thing to understand before you dive in is that Magpie is developed
+> spec-first. The framework keeps a set of specifications, which are precise
+> descriptions of what each area should do, and the code and docs are reconciled
+> against them. A build loop (`tools/spec-loop/`) can even drive that reconciliation
+> with an agent, one work item at a time. The full write-up is
+> spec-driven-development.
+>
+> What this means for you as a contributor:
+>
+> - **A change that alters behaviour usually starts with the spec.** If you are
+>   adding or changing what a part of the framework does, the matching spec in
+>   `tools/spec-loop/specs/` is the source of truth to update first, so the
+>   description and the implementation never drift apart.
+> - **The spec is where "what it should do" lives; the code and docs are where
+>   "how" lives.** Keeping them in step is a core habit here, the same instinct as
+>   keeping tests in step with code.
+> - **Small doc or wording fixes** do not need a spec change, but anything that
+>   changes a rule, a flow, or a contract does.
+>
+> You do not need to master the spec loop to make your first contribution. You do
+> need to know it exists, so your change lands in step with the specs rather than
+> fighting them.
+>
+> ## The framework's rules apply to your contribution too
+>
+> Everything this stream taught about building safely also governs what you
+> contribute. A reviewer will check that your change keeps the framework's posture:
+>
+> - **External content is data, not instructions** (PRINCIPLE 0). A skill you add
+>   must treat issue bodies, PRs, and mail as data, and ship an eval case proving
+>   it.
+> - **Propose, confirm, act** (PRINCIPLE 6). A skill's world-changing steps are
+>   proposals a maintainer confirms, never silent actions.
+> - **Project-agnostic placeholders** (PRINCIPLE 12). No real project name in the
+>   text; use `<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`.
+> - **Evals are required** (PRINCIPLE 8). A skill without a matching eval suite is
+>   not finished, and a PR that adds one without evals will not pass review.
+> - **Apache-2.0, and mark AI help** (PRINCIPLE 17). Contributions land under the
+>   framework licence; AI-authored contributions carry a `Generated-by:` token in
+>   the commit message, per ASF Generative Tooling Guidance.
+>
+> These are not hoops. They are the same habits the whole stream has been teaching,
+> now on the other side of the pull request.
+>
+> ## The path to a merged change
+>
+> The short version (the long version is CONTRIBUTING.md):
+>
+> 1. **Get set up.** Clone the framework repository and confirm you can run `uv`
+>    and the validators. See CONTRIBUTING.md and prerequisites.
+> 2. **Make the smallest change that stands on its own.** One skill, one fix, one
+>    page. Small changes are reviewed and merged faster.
+> 3. **Update the spec if behaviour changes.** For anything beyond a wording fix,
+>    update the matching `tools/spec-loop/specs/` entry.
+> 4. **Run the validators locally.** The same checks CI runs: the skill/tool
+>    validator, the spec validator, markdownlint, and the link check. Running them
+>    first saves a round-trip.
+> 5. **Open the pull request.** Say what the change does, what you tested, and what
+>    a reviewer should look at closely. A clear description speeds review.
+> 6. **Work with the review.** A reviewer reads your prose the way they would read
+>    code, checking for ambiguity, missing edge cases, and unstated assumptions.
+>    Treat that as the collaboration it is.
+>
+> ## Where to get help
+>
+> - Read CONTRIBUTING.md end to end before your first patch. It is the
+>   authoritative process, layout, and dev-loop reference.
+> - Use the `magpie-write-skill` skill (`/write-skill`) for the complete
+>   skill-authoring checklist.
+> - Read MISSION.md and PRINCIPLES.md for the why behind the rules a reviewer will
+>   apply.
+>
+> ## Check your understanding
+>
+> - Why can you contribute meaningfully to Magpie without being a systems
+>   programmer?
+> - When does a contribution need a spec change, and when does it not?
+> - Which framework rules will a reviewer check on a skill you contribute?
+>
+> ## How this connects to the other guides
+>
+> - Your first skill is the concrete zero-to-merged path this page frames; start
+>   there for a skill contribution.
+> - English as a programming language is the mindset that makes contributing to
+>   Magpie approachable.
+> - CONTRIBUTING.md is the authoritative contribution reference, covering process,
+>   repository layout, and the dev loop CI enforces.
+> - spec-driven-development is the spec-first workflow the framework is built on.
+
+### Exercise answer keys
+
+**Exercise 1 - Classify the contribution.** Type, rank (1 = lowest on-ramp, 4 =
+highest), and why:
+- Tighten a step's wording and add an eval case -> Fix or sharpen a skill, rank 1-2.
+  A bounded improvement to something that already works; slightly above a pure doc
+  fix because an eval case must accompany it.
+- Rephrase a confusing sentence and fix a broken link -> Improve the docs, rank 1.
+  Pure documentation: no skill structure or eval suite; the source page calls this a
+  gentle way to learn the process.
+- Document a reliable skill-structure pattern -> Add a pattern, rank 2-3. Prose for
+  the pattern catalogue; needs clear writing and a concrete example but not the full
+  skill-plus-eval machinery.
+- Build a new skill for weekly commit summaries -> Write a new skill, rank 4. The
+  biggest common first contribution: full frontmatter, all steps, placeholders,
+  data-not-instructions guard, and a complete eval suite.
+Credit adjacent ranks (1-2, 2-3) where the learner justifies the ordering.
+
+**Exercise 2 - Spec-first decision.** Needs a spec change when it alters a rule,
+flow, or contract; not for small doc or wording fixes:
+- Fix a typo in contributing.md -> No. Changes no rule, flow, or contract.
+- Add a version-support check step to security-issue-triage -> Yes. Adding a step
+  changes the skill's flow; the matching spec must stay in step.
+- Rename placeholder `<tracker>` to `<issue-tracker>` -> Yes (arguably). Placeholder
+  names are part of the project-agnosticism contract (PRINCIPLE 12); a pure rename
+  with no meaning change is borderline, so when in doubt update the spec.
+- Auto-close NEEDS-INFO issues after 30 days instead of labelling for follow-up ->
+  Yes. Changes a rule (the NEEDS-INFO policy) and the flow.
+- Add an eval case to an existing suite -> No. Exercises existing behaviour and
+  tightens coverage without changing any rule, flow, or contract.
+- Change pr-management-stats output from a Markdown table to JSON -> Yes. The output
+  format is part of the contract callers rely on.
+
+**Exercise 3 - Apply the reviewer's checklist** (the weekly-commit-summary PR):
+- P0 (data, not instructions) -> Cannot assess. The skill reads commit messages
+  (external text) but the description does not say how step 2 handles them; a
+  reviewer would ask for the full skill text and require an injection eval case.
+- P6 (propose, confirm, act) -> Violated. Step 3 posts a comment with no confirmation
+  step; a world-changing action must be proposed and confirmed first.
+- P12 (placeholders) -> Violated. Step 3 hardcodes `apache/airflow#99999`, and "the
+  Airflow repository" is similarly coupled; placeholders must replace both.
+- P8 (evals required) -> Violated. "No eval suite yet, I'll add it in a follow-up
+  PR" fails review; the suite must ship in the same PR.
+- P17 (Apache-2.0, mark AI help) -> Cannot assess. The description does not say
+  whether any part was AI-authored (a `Generated-by:` trailer would be required if
+  so), and the SPDX licence header lives in the skill file, not the PR description.
+Reinforce that "cannot assess" with a note on what to request is the correct verdict
+for P0 and P17 here, not a guess.
+
+**Exercise 4 - Walk the path to merged** (the issue-reassess zero-comment fix). Per
+step, what to do and the common sticking point:
+1. Get set up -> clone the repo and confirm the validator and eval runner complete.
+   Sticking point: the toolchain fails on something unrelated (a missing dependency,
+   a uv version mismatch) before any real work; reading CONTRIBUTING.md and
+   prerequisites first avoids it.
+2. Smallest change -> edit only the misleading step in the issue-reassess skill and
+   add one eval case for the zero-comment edge case. Sticking point: noticing
+   adjacent issues while editing and bundling extra fixes; a second fix belongs in a
+   second PR.
+3. Update spec? -> check whether the matching spec documents the old behaviour for
+   zero-comment issues and update it only if so. Sticking point: forgetting to check
+   the spec at all, or editing it for a change that does not alter a rule, flow, or
+   contract.
+4. Run validators -> run the skill/tool validator and the issue-reassess eval suite;
+   both must pass first. Sticking point: the new eval case's expected output does not
+   match the repaired skill, or a previously passing case now fails; fix the cause,
+   not the test.
+5. Open PR -> write a description explaining the old vs intended message, why the
+   distinction matters, and what the new eval case tests. Sticking point: a vague
+   description ("fix edge case") that makes the reviewer guess what to look at.
+6. Work with review -> respond to ambiguity feedback by tightening wording or adding
+   a case, not by arguing. Sticking point: treating "this is ambiguous" as criticism
+   rather than the most valuable feedback a prose-driven project can give.
+
+### Self-check answer keys
+
+**Q1. Why can you contribute without being a systems programmer?** Most of Magpie is
+written in English, not a formal language, so contributions (a skill, a fix, a
+pattern, a doc page) are prose the agent executes. If you can think clearly and write
+precisely, you have what you need; the source page calls this a feature, not a quirk.
+Systems-programming skills help with the tool layer (`tools/`) but are not required
+for the common contributions.
+
+**Q2. When does a contribution need a spec change?** When it changes a rule, a flow,
+or a contract, anything that alters what a part of the framework is supposed to do.
+Small doc or wording fixes that do not affect behaviour do not. The practical test:
+would the spec currently document something that becomes false if your change merged?
+If yes, update the spec; if no, leave it.
+
+**Q3. The five framework rules a reviewer checks.** External content is data, not
+instructions (PRINCIPLE 0), with an eval case proving the guard; propose, confirm,
+act (PRINCIPLE 6), world-changing steps are confirmed, not silent; project-agnostic
+placeholders (PRINCIPLE 12), no real project names; evals are required (PRINCIPLE 8),
+the suite ships in the same PR; Apache-2.0 and mark AI help (PRINCIPLE 17),
+AI-authored commits carry a `Generated-by:` trailer.
+
+**Q4. The purpose of step 4 (run validators locally).** To catch failures before
+opening the PR, not after. The checks CI runs (skill/tool validator, spec validator,
+markdownlint, link check) run locally in seconds; a failure caught locally costs one
+fix, while one caught by CI costs a push-wait-read-fix-push round-trip. It is the same
+discipline as running tests before pushing code.
+
+**Q5. Which resource for the spec-update, placeholder, and skill-authoring questions?**
+For the spec-update question, check the matching spec in `tools/spec-loop/specs/` (and
+CONTRIBUTING.md for when a spec change is required): update it if it documents
+behaviour your change alters. For the placeholder question, check CONTRIBUTING.md's
+list of standard placeholders or an existing skill in `skills/` doing a similar
+action, to stay consistent. MISSION.md and PRINCIPLES.md explain why placeholders
+matter (PRINCIPLE 12), but not the specific names. For authoring the new skill, use
+the `magpie-write-skill` guide (`/write-skill`) for the complete authoring checklist
+(frontmatter, steps, placeholders, injection guard, evals); CONTRIBUTING.md covers the
+surrounding process.
+
+### Summary (use at close)
+
+Contributing to Magpie is approachable without systems-programming expertise because
+most of the framework is prose the agent executes. The four common first
+contributions (fix a skill, improve a doc, add a pattern, write a new skill) span a
+wide range of on-ramp effort; a broken link is as real a contribution as a new skill.
+The framework is built spec-first: the specs are the source of truth for what each
+area should do, and a change that alters a rule, flow, or contract updates the matching
+spec, not just the implementation; small wording fixes are the exception. Every skill
+contribution is checked against five rules: external content is data, world-changing
+steps require confirmation, placeholders replace real names, evals are required, and
+AI-authored work carries a `Generated-by:` trailer, the same habits the module taught,
+now on the other side of the pull request. The six-step path (set up, smallest change,
+spec check, local validation, open PR, work with review) is careful open-source
+contribution adapted to a prose-driven project where ambiguity is the main failure mode
+and the eval suite is what "run your tests" means.
+
+This is the last numbered lesson. With all eleven complete, the learner has the full
+path: what agents are, how to work with them, how to choose a model, how to write safe,
+portable, tested skills, how to work autonomously, how to program precisely in English,
+and how to give that work back. The natural next step is the hands-on lab (the tutorials
+page): build a small skill end to end, give it an eval suite, and run it.

--- a/docs/education/training/README.md
+++ b/docs/education/training/README.md
@@ -65,12 +65,11 @@ Nothing in this directory duplicates the reference material; it only frames it.
 | [Lesson 8 — Eval-driven development](lesson-08-eval-driven-development.md) | [Eval-driven development](../eval-driven-development.md) | ~60 min |
 | [Lesson 9 — Agentic and autonomous work](lesson-09-agentic-and-autonomous-work.md) | [Agentic and autonomous work](../agentic-work.md) | ~45 min |
 | [Lesson 10 — English as a programming language](lesson-10-english-as-a-programming-language.md) | [English as a programming language](../english-as-code.md) | ~30 min |
-| Lesson 11 — How to contribute | [How to contribute](../contributing.md) | ~30 min |
+| [Lesson 11 — How to contribute](lesson-11-how-to-contribute.md) | [How to contribute](../contributing.md) | ~30 min |
 | Hands-on lab | [Tutorials](../tutorials.md) | ~90 min |
 
-> Lesson 11 and the lab follow the same format as lessons 1–10. They are
-> added per-sub-item; this file tracks them as placeholders until each one
-> lands.
+> The hands-on lab follows the same format as lessons 1–11. It is added
+> per-sub-item; this file tracks it as a placeholder until it lands.
 
 ## Delivery formats
 

--- a/docs/education/training/instructor-guide.md
+++ b/docs/education/training/instructor-guide.md
@@ -1,0 +1,694 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Facilitator guide — Building and running AI agents for open-source projects](#facilitator-guide--building-and-running-ai-agents-for-open-source-projects)
+  - [Who this guide is for](#who-this-guide-is-for)
+  - [Module overview](#module-overview)
+  - [Delivery formats](#delivery-formats)
+    - [Self-paced with facilitator check-ins](#self-paced-with-facilitator-check-ins)
+    - [Instructor-led workshop (one day)](#instructor-led-workshop-one-day)
+    - [Two-session intensive](#two-session-intensive)
+    - [LMS-based self-study](#lms-based-self-study)
+  - [Environment setup](#environment-setup)
+    - [In-person](#in-person)
+    - [Virtual](#virtual)
+  - [Schedule templates](#schedule-templates)
+    - [One-day workshop (~7.5 hours with breaks)](#one-day-workshop-75-hours-with-breaks)
+    - [Two-session intensive](#two-session-intensive-1)
+    - [Weekly reading group (~11 weeks)](#weekly-reading-group-11-weeks)
+  - [Per-lesson facilitator notes](#per-lesson-facilitator-notes)
+    - [Lesson 1 — What agents are](#lesson-1--what-agents-are)
+    - [Lesson 2 — Working with agents](#lesson-2--working-with-agents)
+    - [Lesson 3 — Choosing models](#lesson-3--choosing-models)
+    - [Lesson 4 — Your first skill](#lesson-4--your-first-skill)
+    - [Lesson 5 — Writing safe skills](#lesson-5--writing-safe-skills)
+    - [Lesson 6 — Debugging a skill](#lesson-6--debugging-a-skill)
+    - [Lesson 7 — Writing portable skills](#lesson-7--writing-portable-skills)
+    - [Lesson 8 — Eval-driven development](#lesson-8--eval-driven-development)
+    - [Lesson 9 — Agentic and autonomous work](#lesson-9--agentic-and-autonomous-work)
+    - [Lesson 10 — English as a programming language](#lesson-10--english-as-a-programming-language)
+    - [Lesson 11 — How to contribute](#lesson-11--how-to-contribute)
+  - [Customising for your project](#customising-for-your-project)
+    - [Replacing placeholders](#replacing-placeholders)
+    - [Adapting examples](#adapting-examples)
+    - [Selecting lessons](#selecting-lessons)
+  - [Assessment and progression](#assessment-and-progression)
+    - [Self-check questions](#self-check-questions)
+    - [When a learner is not ready to proceed](#when-a-learner-is-not-ready-to-proceed)
+    - [No formal certification](#no-formal-certification)
+  - [Frequently asked questions](#frequently-asked-questions)
+  - [Upstream contribution](#upstream-contribution)
+  - [Licence](#licence)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Facilitator guide — Building and running AI agents for open-source projects
+
+This guide is for **instructors and facilitators** running the Apache Training
+module (this directory) as a structured course. Learners working through the
+material self-paced do not need it — the lesson files stand alone.
+
+---
+
+## Who this guide is for
+
+A **facilitator** is anyone organising and running the module for others:
+a PMC member running a project on-boarding session, a community mentor
+hosting a workshop at a conference, or a team lead running a weekly reading
+group. No prior experience teaching AI is required; the lesson files carry the
+technical content. This guide covers the logistics, timing, and facilitation
+moves that turn static reading material into an active learning session.
+
+---
+
+## Module overview
+
+Eleven lessons totalling approximately 7 hours of learner time:
+
+| Lesson | Topic | Learner time |
+|---|---|---|
+| 1 | What agents are | 30 min |
+| 2 | Working with agents | 30 min |
+| 3 | Choosing models | 30 min |
+| 4 | Your first skill | 60 min |
+| 5 | Writing safe skills | 45 min |
+| 6 | Debugging a skill | 45 min |
+| 7 | Writing portable skills | 30 min |
+| 8 | Eval-driven development | 60 min |
+| 9 | Agentic and autonomous work | 45 min |
+| 10 | English as a programming language | 30 min |
+| 11 | How to contribute | 30 min |
+
+Each lesson follows the same structure: read the source page → work through
+four or five exercises (20–40 min) → answer the self-check questions. Exercises need
+no computer; they use paper, a whiteboard, or a shared document. The self-check
+questions include hidden answers that learners reveal to grade themselves.
+
+---
+
+## Delivery formats
+
+### Self-paced with facilitator check-ins
+
+Learners work through one or two lessons per week on their own. The
+facilitator runs a 30-minute weekly check-in to answer questions and debrief
+the self-check answers. **Recommended for distributed teams and reading
+groups.** Lowest facilitation overhead; high learner flexibility.
+
+### Instructor-led workshop (one day)
+
+Cover all eleven lessons in a single day. Use the one-day schedule in the
+[Schedule templates](#schedule-templates) section. Requires a dedicated room
+or video-conference session. Best for initial project on-boarding, conference
+tutorials, or intensive team training.
+
+### Two-session intensive
+
+Split the module across two half-days or two evenings. Lessons 1–5 (concepts
+and first skill) in session one; lessons 6–11 (safety, portability, evals,
+autonomy, prose discipline, and contributing) in session two. A natural break point: session two
+builds on working skills, so learners have time between sessions to write one
+for their own project.
+
+### LMS-based self-study
+
+Upload each lesson file as a unit in your learning management system. Tag
+learning time using the per-lesson estimates above. Use the self-check
+questions as the in-LMS quiz. The facilitator role reduces to answering
+questions in the discussion forum.
+
+---
+
+## Environment setup
+
+### In-person
+
+- **Projector or large screen.** You will display source pages, lesson files,
+  and learner diagrams. A browser with two tabs (source page and lesson file)
+  is all you need.
+- **Whiteboard or flip chart.** Every exercise mentions "paper or whiteboard";
+  a shared whiteboard (physical or digital) works well for group exercises.
+- **No computers for learners** are required for the exercises themselves. If
+  learners have laptops, remind them to close them during exercise time to
+  keep the group in sync.
+- **Printed exercise sheets (optional).** The exercises are short enough to
+  read from a screen, but some facilitators find printed sheets reduce context
+  switching during exercises.
+
+### Virtual
+
+- **Video-conference platform** with screen sharing and a breakout-room
+  feature. Breakout rooms let pairs or small groups work through exercises
+  without the full group listening in.
+- **Shared document** (a collaborative whiteboard or a shared markdown file)
+  replaces the physical whiteboard. One doc per lesson works well; create them
+  before the session.
+- **Paste the exercise text into the shared doc** so learners can write their
+  answers inline. After the exercise, unmute/reconvene and ask two or three
+  groups to share.
+
+---
+
+## Schedule templates
+
+### One-day workshop (~7.5 hours with breaks)
+
+| Time | Activity |
+|---|---|
+| 09:00–09:15 | Welcome, objectives, module overview |
+| 09:15–09:45 | Lesson 1 — What agents are |
+| 09:45–10:15 | Lesson 2 — Working with agents |
+| 10:15–10:45 | Lesson 3 — Choosing models |
+| 10:45–11:00 | Break |
+| 11:00–12:00 | Lesson 4 — Your first skill (60 min) |
+| 12:00–13:00 | Lunch |
+| 13:00–13:45 | Lesson 5 — Writing safe skills |
+| 13:45–14:30 | Lesson 6 — Debugging a skill |
+| 14:30–15:00 | Lesson 7 — Writing portable skills |
+| 15:00–15:15 | Break |
+| 15:15–16:15 | Lesson 8 — Eval-driven development (60 min) |
+| 16:15–17:00 | Lesson 9 — Agentic and autonomous work |
+| 17:00–17:30 | Lesson 10 — English as a programming language |
+| 17:30–18:00 | Lesson 11 — How to contribute |
+| 18:00–18:15 | Wrap-up and next steps |
+
+Reduce to a half-day by covering lessons 1–5 only (concepts and first
+skill). Lessons 6–11 form a natural second half.
+
+### Two-session intensive
+
+**Session 1 (~3.5 hours):** Welcome (15 min), lessons 1–5 (175 min), wrap-up
+(10 min). Assign: write one skill for your project between sessions.
+
+**Session 2 (~4.5 hours):** Review and share skills from the between-session
+assignment (20 min), lessons 6–11 (240 min), retrospective (15 min).
+
+### Weekly reading group (~11 weeks)
+
+One lesson per week, 45 minutes per session. Learners read the source page
+and lesson file before the session. The session time is for exercises and
+debrief only.
+
+| Week | Lesson | Prep (before session) |
+|---|---|---|
+| 1 | What agents are | Read `what-agents-are.md` and lesson 1 |
+| 2 | Working with agents | Read `working-with-agents.md` and lesson 2 |
+| 3 | Choosing models | Read `choosing-models.md` and lesson 3 |
+| 4 | Your first skill | Read `your-first-skill.md` and lesson 4 |
+| 5 | Writing safe skills | Read `writing-safe-skills.md` and lesson 5 |
+| 6 | Debugging a skill | Read `debugging-skills.md` and lesson 6 |
+| 7 | Writing portable skills | Read `portable-skills.md` and lesson 7 |
+| 8 | Eval-driven development | Read `eval-driven-development.md` and lesson 8 |
+| 9 | Agentic and autonomous work | Read `agentic-work.md` and lesson 9 |
+| 10 | English as a programming language | Read `english-as-code.md` and lesson 10 |
+| 11 | How to contribute | Read `contributing.md` and lesson 11 |
+
+---
+
+## Per-lesson facilitator notes
+
+For each lesson: the core idea to anchor, discussion prompts to deepen the
+group's understanding, common misconceptions to correct, and rough timing
+guidance for instructor-led delivery.
+
+These timings are for instructor-led delivery, where the reading is compressed
+(skimmed, or presented together) to leave most of the slot for exercises. They
+deliberately allocate less reading time than the self-paced estimates in each
+lesson's own header — a workshop should spend its time on active practice, not
+on reading the source page aloud.
+
+---
+
+### Lesson 1 — What agents are
+
+**Core idea.** An agent is a loop: model, tools, loop, context. Every other
+idea in the module is a consequence of this structure.
+
+**Timing.** 30 min: 10 min to read the source page together or in pairs,
+15 min exercises, 5 min self-check debrief.
+
+**Discussion prompts.**
+
+- "Before this lesson, how would you have described what an AI agent does?
+  What would you change about that description now?"
+- "The source page says the model can only reason about what is in its
+  context. What does that mean for a skill you want to write for
+  `<PROJECT>`? What would you need to put into context?"
+- "Why does probabilistic behaviour matter more for testing an agent than
+  for testing a function? What would you do differently?"
+
+**Common misconceptions.**
+
+- *"The agent has access to the whole repo / internet / database."* No — it
+  can only see what has been explicitly put into context via tools. Draw the
+  loop on the board and mark where information enters.
+- *"Agents are deterministic if you use them the same way each time."*
+  No — the model is probabilistic. The same input can produce different
+  outputs. This is not a defect; it is a property to design around.
+
+---
+
+### Lesson 2 — Working with agents
+
+**Core idea.** An agent is a collaborator, not a command-runner. The quality
+of what you get out depends on the quality of what you put in.
+
+**Timing.** 30 min: 10 min reading, 15 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "Think about a task you would want to delegate to an agent in `<PROJECT>`.
+  Write the first message you would send. Now read it back — is it complete?
+  What would the agent need to clarify?"
+- "The page talks about 'treating outside text as data, not instructions'.
+  What does that mean in practice for a skill that processes issue comments
+  from the public?"
+- "When should you give up on steering a mid-task agent and start over?
+  What signals tell you the agent is on the wrong path?"
+
+**Common misconceptions.**
+
+- *"You should give the agent as much context as possible."* More context is
+  not always better — a long, unfocused context degrades response quality.
+  The lesson's point is *relevant* context, not maximum context.
+- *"If the agent makes a mistake, retry until it gets it right."* Retrying
+  without changing the prompt will produce the same distribution of answers.
+  Diagnose first; change the prompt, not just the run count.
+
+---
+
+### Lesson 3 — Choosing models
+
+**Core idea.** There is no single best model for every task; there is a
+best model for a given capability, speed, and cost combination, and the
+eval suite is what decides.
+
+**Timing.** 30 min: 10 min reading, 15 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "For a skill that triages incoming issues on `<PROJECT>`, would you reach
+  for the cheapest available model, the most capable, or something in
+  between? What information would you need to decide?"
+- "The page says 'let evals decide'. What does an eval tell you that a few
+  manual test runs don't?"
+- "A 'judge model' is a model that scores another model's output. When might
+  you use a judge model for `<PROJECT>` tasks? What could go wrong?"
+
+**Common misconceptions.**
+
+- *"Always use the most capable model — it is most reliable."* Capability
+  and reliability are different dimensions. The most capable model may be
+  over-specified, slower, and more expensive for simple triage tasks.
+- *"Local models are always worse."* For focused, rule-following tasks with
+  tight prompts, a local model can match hosted performance at zero cost.
+  The `local-smoke` eval tag exists precisely to test this claim.
+
+---
+
+### Lesson 4 — Your first skill
+
+**Core idea.** A skill is a plain Markdown file with YAML frontmatter. Writing
+one is within reach of any contributor who can open a pull request.
+
+**Timing.** 60 min: 15 min reading, 35 min exercises (the writing exercise
+takes longer), 10 min debrief.
+
+**Discussion prompts.**
+
+- "What task in `<PROJECT>` would benefit most from a repeatable agent skill?
+  Why that one?"
+- "What is the difference between a skill and a script? When would you reach
+  for one instead of the other?"
+- "The skill format requires a `description` field that triggers the skill.
+  If your description is vague, what happens? Try writing two descriptions
+  for the same skill — one vague, one precise — and compare them."
+
+**Common misconceptions.**
+
+- *"A skill needs to handle every possible edge case before I can ship it."*
+  No — ship the happy path first, add an eval suite, and expand from there.
+  A skill without an eval suite is incomplete; a skill with an eval suite can
+  grow incrementally.
+- *"The `description` field is just documentation."* The description is what
+  the agent reads to decide *when* to invoke the skill. It is a trigger, not
+  a comment.
+
+---
+
+### Lesson 5 — Writing safe skills
+
+**Core idea.** Safety is not a review gate at the end; it is three properties
+built into the skill as you write it: propose-confirm-act, data-not-instructions,
+and sandbox-by-default.
+
+**Timing.** 45 min: 10 min reading, 30 min exercises (the propose/confirm
+classification exercise is dense), 5 min debrief.
+
+**Discussion prompts.**
+
+- "For the skill you imagined in lesson 4, which steps would need a
+  confirm gate and which could run without one? Where is the line for
+  `<PROJECT>`'s context?"
+- "What is the difference between treating outside text as data vs.
+  as instructions? Give an example from `<PROJECT>`'s issue tracker of
+  text that could be mistaken for an instruction."
+- "A skill that reads files only needs no special sandbox configuration.
+  A skill that writes to the repo, posts comments, or sends email needs
+  explicit permission entries. Why is the default 'no permission' and not
+  'ask at runtime'?"
+
+**Common misconceptions.**
+
+- *"Propose-confirm-act slows the agent down — we want automation."*
+  The confirm step is cheap: it is a human reading a proposal and pressing
+  one button. Removing it when the action is irreversible (a posted comment,
+  a merged PR) removes the only safety net.
+- *"Data-not-instructions only applies to security-sensitive skills."*
+  It applies to any skill that processes public or user-supplied text.
+  Prompt injection is not limited to security contexts.
+
+---
+
+### Lesson 6 — Debugging a skill
+
+**Core idea.** Debugging an agent is diagnostic work: isolate the failing
+step, read the transcript, find the moment the agent diverged, and adjust the
+prompt or context — not the retry count.
+
+**Timing.** 45 min: 10 min reading, 30 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "You run a skill three times on the same issue and get three different
+  verdicts. How do you diagnose whether this is a prompt problem, a context
+  problem, or just normal variance?"
+- "What is the first thing you would look at in a skill transcript when the
+  output looks wrong?"
+- "When is it correct to increase the temperature of a model, and when is
+  that the wrong move?"
+
+**Common misconceptions.**
+
+- *"Add more examples to the prompt and the skill will stop making mistakes."*
+  More examples help with format and style. They do not fix ambiguous
+  instructions — the model will still apply the ambiguous rule, just more
+  consistently. Fix the rule first, then add examples.
+- *"If the eval passes, the skill is correct."* An eval passing means the
+  skill behaves correctly on the cases you tested. It does not mean it is
+  correct on all inputs. Eval coverage is a claim about the tested set, not
+  the full input space.
+
+---
+
+### Lesson 7 — Writing portable skills
+
+**Core idea.** A skill that hard-codes project names, tool paths, or hosting
+assumptions only works in one place. Portability comes from placeholders and
+config-resolution, not from "making it generic."
+
+**Timing.** 30 min: 10 min reading, 15 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "Look at the skill draft you started in lesson 4. How many project-specific
+  strings are in it? What would you need to replace to make it reusable across
+  `<PROJECT>` and a sister project?"
+- "The `<tracker>` placeholder resolves differently for a GitHub project and
+  a Jira-backed project. Who decides which adapter to load, and when?"
+- "What is the difference between a placeholder and a conditional? When is
+  'if GitHub else Jira' the wrong approach?"
+
+**Common misconceptions.**
+
+- *"My skill only runs on `<PROJECT>`, so portability is not my concern."*
+  Even a project-internal skill benefits from placeholders: it is easier to
+  test with a dummy config, easier to explain to new contributors, and easier
+  to donate upstream if the project later wants to.
+- *"Placeholders make the skill harder to read."* A well-named placeholder
+  (`<tracker>`, `<PROJECT>`) is more readable than a hardcoded URL. It makes
+  the assumption explicit rather than hiding it in a string.
+
+---
+
+### Lesson 8 — Eval-driven development
+
+**Core idea.** Correctness for an agent is not a binary; it is a distribution
+over many inputs. An eval suite is how you measure that distribution and track
+it over time.
+
+**Timing.** 60 min: 15 min reading, 35 min exercises (the fixture design
+exercise takes longer), 10 min debrief.
+
+**Discussion prompts.**
+
+- "For the skill you started in lesson 4, what are the four cases that
+  every eval suite should cover? Write them out."
+- "A colleague says their skill 'works fine' because they ran it five times
+  on the same issue and it produced a good result. What is missing from that
+  claim?"
+- "What is the difference between a `local-smoke` eval case and a
+  `frontier-only` case? Why does that distinction matter for a project that
+  wants to adopt the skill with a local model?"
+
+**Common misconceptions.**
+
+- *"I will add evals after the skill is stable."* A skill without an eval
+  suite cannot be called stable. Evals are what establish the baseline that
+  'stable' means.
+- *"More eval cases are always better."* Coverage matters more than count.
+  Ten well-designed cases covering distinct failure modes are more useful than
+  a hundred cases that all test the same happy path.
+
+---
+
+### Lesson 9 — Agentic and autonomous work
+
+**Core idea.** Autonomy is not an on/off switch; it is a dial with four
+rungs. Moving up the dial is only safe once you have the guardrails and evals
+that make it safe — not before.
+
+**Timing.** 45 min: 15 min reading, 25 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "Where on the supervision dial does `<PROJECT>`'s current automated
+  work sit? Where would you *want* it to sit in twelve months, and what
+  guardrails would you need to add first?"
+- "The propose-confirm-act pattern is the guardrail for supervised
+  automation. What is the equivalent guardrail for unattended automation?"
+- "A skill that runs on a cron schedule and posts comments autonomously
+  has a larger blast radius than one that posts under human review. What
+  does 'larger blast radius' mean concretely for `<PROJECT>`'s community?"
+
+**Common misconceptions.**
+
+- *"Fully autonomous is the goal — human review is just friction."*
+  Autonomy is a tool, not an end state. The question is not 'how do we
+  remove the human?' but 'at what rung is the risk acceptable given the
+  guardrails we have?'
+- *"Compounding errors are unlikely in practice."* In a short session they
+  are unlikely. In a long autonomous run, the probability compounds across
+  each action taken. One misclassified issue that triggers an incorrect
+  follow-up action that triggers a public reply illustrates the chain.
+
+---
+
+### Lesson 10 — English as a programming language
+
+**Core idea.** The words in a skill are the program. Ambiguity is a bug
+class. The four disambiguating moves — define terms, say what done looks
+like, state boundaries, name edge cases — are the tools for closing gaps.
+
+**Timing.** 30 min: 10 min reading, 15 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "Find a word in a skill you have read (or written) that is not defined.
+  What would a model do with it? Write a one-sentence definition that closes
+  the gap."
+- "The page says 'ambiguity is the new class of bug'. Give an example of
+  a wording ambiguity in a skill that would not be caught by a linter or
+  type-checker but would cause the agent to behave unexpectedly."
+- "DRY applies to prose as well as code. Find two skills in the framework
+  that define the same concept differently. What is the cost of that
+  duplication, and how would you fix it?"
+
+**Common misconceptions.**
+
+- *"Natural language is inherently imprecise — there is nothing you can do."*
+  Natural language *can* be precise. Technical writing, legal text, and
+  formal specifications are all precise natural language. The discipline is
+  learnable and the four moves are concrete.
+- *"The model will ask for clarification if something is ambiguous."*
+  Models do not reject ambiguous instructions; they act on a plausible
+  interpretation. The result is silent divergence between intent and
+  execution.
+
+---
+
+### Lesson 11 — How to contribute
+
+**Core idea.** Most of Magpie is prose the agent executes, so contributing is
+within reach of anyone who can write precisely. The four first contributions —
+fix a skill, improve a doc, add a pattern, write a new skill — all follow the
+same spec-first, eval-backed, reviewed path.
+
+**Timing.** 30 min: 10 min reading, 15 min exercises, 5 min debrief.
+
+**Discussion prompts.**
+
+- "Of the four first-contribution types (fix a skill, improve a doc, add a
+  pattern, write a new skill), which would you start with for `<PROJECT>`, and
+  why that one?"
+- "Take a change you might make to one of `<PROJECT>`'s skills. Does it alter a
+  rule, a flow, or a contract? Walk the group through whether it needs a spec
+  update."
+- "You are reviewing a contributor's first skill PR. Which of the five
+  framework rules would you check first, and what would you look for in the
+  diff?"
+
+**Common misconceptions.**
+
+- *"You need to be a strong programmer to contribute."* No — most contributions
+  are prose the agent executes. Clear thinking and precise writing are the core
+  skills; systems programming is only needed for the tool layer (`tools/`).
+- *"Evals can come in a follow-up PR."* No — a skill without a matching eval
+  suite is not finished, and a PR that defers the evals will not pass review.
+  The eval suite ships in the same PR as the skill.
+
+---
+
+## Customising for your project
+
+### Replacing placeholders
+
+Every exercise uses `<PROJECT>` where a real project name would appear.
+Before running the module, decide whether to:
+
+1. **Replace globally** — do a find-and-replace in your copies of the lesson
+   files. Fast; produces more readable exercise sheets.
+2. **Ask learners to substitute as they go** — keeps the original files
+   unmodified; slightly more cognitive load during exercises.
+
+Other placeholders you may encounter:
+
+| Placeholder | What it represents |
+|---|---|
+| `<PROJECT>` | The adopting project's name |
+| `<tracker>` | The issue tracker (e.g. GitHub Issues, JIRA) |
+| `<upstream>` | The main repository (e.g. `org/repo`) |
+| `<security-list>` | The private security mailing list |
+
+### Adapting examples
+
+The source pages draw examples from open-source project maintenance. If your
+audience works in a different domain (internal tooling, data pipelines,
+etc.), swap the examples. The lesson structure remains the same; only the
+illustrative context changes.
+
+### Selecting lessons
+
+You do not need to teach all eleven lessons in one sitting. A team that already
+has experience with agent concepts and wants to focus on safety can start at
+lesson 5. A team writing its first eval suite can teach lessons 1, 4, and 8
+as a standalone mini-module. The lessons reference each other but are
+designed to be understandable on their own.
+
+---
+
+## Assessment and progression
+
+### Self-check questions
+
+Each lesson ends with five or six self-check questions with hidden answers. Learners
+reveal the answers themselves and grade their own understanding. This is
+intentional: the goal is self-knowledge, not formal grading.
+
+In an instructor-led session, use the self-check as a **group debrief**:
+read each question aloud and ask learners to write a brief answer before you
+reveal the answer. Gaps between a learner's answer and the reference answer
+are the most productive discussion point.
+
+### When a learner is not ready to proceed
+
+If a learner cannot answer two or more self-check questions for a lesson,
+suggest re-reading the source page before moving on. The lessons build
+sequentially: a learner who does not understand context (lesson 1) will
+struggle with evals (lesson 8).
+
+### No formal certification
+
+This module does not issue certificates. The intended outcome is that a
+learner can read, write, debug, and evaluate a skill for their own project.
+The evidence of that outcome is a skill they have written and an eval suite
+that passes — not a quiz score.
+
+---
+
+## Frequently asked questions
+
+**"Do learners need a running agent installation?"**
+No. The exercises are paper-based or whiteboard-based. Learners can work
+through all eleven lessons without installing any software. Lesson 4 (your first
+skill) suggests writing a skill file; that requires only a text editor.
+
+**"Can I skip the exercises and just present the source pages?"**
+You can, but learners retain substantially less without active practice.
+Exercises in this module are not optional enrichment; they are the mechanism
+by which learners move from reading to application.
+
+**"What if learners have very different backgrounds — some have never seen
+a language model, others use one daily?"**
+Lesson 1 is the equaliser: it defines terms that even experienced users often
+hold loosely (the difference between a model and an agent, what context means
+precisely). Spend extra time there. Experienced learners often find the
+precision useful even if the concept is familiar.
+
+**"How do I handle learners who want to build something live during the
+module?"**
+Encourage it as optional enrichment, but do not let live-building block
+the group. Live building sessions fit better in the hands-on lab
+([`tutorials.md`](../tutorials.md)) than during the lesson sequence. Point
+interested learners there after the module.
+
+**"Are there formal assessment instruments for each lesson?"**
+Not yet. The self-check questions are the primary formative assessment.
+Formal rubrics and summative assessments are planned for a future iteration
+of the module; facilitators who develop them are encouraged to contribute
+them back upstream (see [Upstream contribution](#upstream-contribution)).
+
+---
+
+## Upstream contribution
+
+This module is shaped for contribution to
+[Apache Training](https://training.apache.org/) so it can be taught beyond
+the projects that adopt this framework. If you run the module and find gaps —
+a lesson that generates persistent confusion, a discussion prompt that
+falls flat, a misconception this guide does not address — please:
+
+1. Open an issue or pull request against this repository (the framework
+   repo, not your adopter repo) with the proposed change.
+2. If you are contributing to Apache Training directly, the module's
+   Apache-2.0 licence permits it. Coordinate with the Apache Training
+   project on format requirements before submitting.
+3. Add your project's experience to the module's pilot record so future
+   facilitators can calibrate against real data.
+
+Contributions that improve the instructor guide carry the same
+`Generated-by:` convention as contributions to the lesson files: if you use
+a generative tool to draft a section, note it in the commit message following
+[ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling-guidance.html).
+
+---
+
+## Licence
+
+Apache License 2.0 (PRINCIPLE 17). Pages written with help from AI carry a
+`Generated-by:` note in their commit message following ASF Generative Tooling
+Guidance.

--- a/docs/education/training/lesson-11-how-to-contribute.md
+++ b/docs/education/training/lesson-11-how-to-contribute.md
@@ -1,0 +1,438 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Lesson 11 — How to contribute](#lesson-11--how-to-contribute)
+  - [Learning objectives](#learning-objectives)
+  - [Prerequisite knowledge](#prerequisite-knowledge)
+  - [Before the lesson](#before-the-lesson)
+  - [Exercises](#exercises)
+    - [Exercise 1 — Classify the contribution](#exercise-1--classify-the-contribution)
+    - [Exercise 2 — Spec-first decision](#exercise-2--spec-first-decision)
+    - [Exercise 3 — Apply the reviewer's checklist](#exercise-3--apply-the-reviewers-checklist)
+    - [Exercise 4 — Walk the path to merged](#exercise-4--walk-the-path-to-merged)
+  - [Self-check](#self-check)
+  - [Summary](#summary)
+  - [Next](#next)
+  - [Licence](#licence)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Lesson 11 — How to contribute
+
+**Source page:** [How to contribute](../contributing.md)
+**Estimated time:** 30 minutes (10 min reading + 20 min exercises and self-check)
+**Lesson in sequence:** 11 of 11
+
+---
+
+## Learning objectives
+
+By the end of this lesson you will be able to:
+
+1. **Name** the four most common first contributions to the framework and
+   **rank** them in rough order of on-ramp effort, explaining why that order
+   holds.
+2. **Explain** what "spec-first development" means and **decide** for a given
+   change whether it requires a spec update.
+3. **List** the five framework rules a reviewer will check on a skill
+   contribution and **describe** what each rule requires in concrete terms.
+4. **Walk** the six-step path to a merged change, naming the purpose of each
+   step and identifying where the most common sticking points occur.
+5. **Select** the correct resource (CONTRIBUTING.md, the write-skill guide,
+   MISSION, the spec) for a given contribution question, explaining why that
+   resource is the right starting point.
+
+---
+
+## Prerequisite knowledge
+
+**The entire learning progression.** Lesson 11 is the final lesson. It makes
+most sense after you have read or worked through the earlier lessons — in
+particular:
+
+- **Lesson 4 — Your first skill** is the concrete zero-to-merged path this
+  lesson frames. The exercises here assume you have at least skimmed how a
+  skill is structured.
+- **Lesson 5 — Writing safe skills** covers three of the five framework rules
+  a reviewer will check. If you have not done lesson 5, the reviewer-checklist
+  exercise will be harder to reason about.
+- **Lesson 8 — Eval-driven development** is why "evals are required" is a hard
+  rule here. If you have not done lesson 8, the requirement will feel arbitrary.
+
+**Lesson 10 — English as a programming language** is the immediate
+predecessor. The source page for lesson 11 opens with the sentence "This is
+the last page of the progression, and it turns everything before it into
+action" — that framing lands better if lesson 10 is fresh.
+
+---
+
+## Before the lesson
+
+Read the source page **[How to contribute](../contributing.md)** from start to
+finish. Pay particular attention to:
+
+- **Good first contributions** — the four types listed (fix/sharpen, improve
+  docs, add pattern, write new skill). Note which one is described as "the
+  biggest of the common first contributions" and which is "a gentle way to
+  learn the process".
+- **Magpie is built spec-first** — what this means in practice, and the one
+  sentence that summarises when you need a spec change and when you do not.
+- **The framework's rules apply to your contribution too** — the five bullet
+  points. Know each rule and its PRINCIPLE number before the exercises.
+- **The path to a merged change** — the six steps. Be able to say what each
+  one is for, not just recite its name.
+- **Check your understanding** at the end of the source page — answer those
+  questions from memory before coming back here. The self-check below is partly
+  drawn from them, with a couple of extra questions.
+
+---
+
+## Exercises
+
+Work through these alone or in pairs. All exercises are paper activities; no
+live system or code repository is needed.
+
+### Exercise 1 — Classify the contribution
+
+The source page lists four types of first contribution, roughly in order of
+on-ramp effort. For each scenario below:
+
+1. Name the contribution type from the source page that best matches.
+2. Rank it (1 = lowest on-ramp, 4 = highest) according to the ordering the
+   source page implies.
+3. Write one sentence explaining why that on-ramp level is appropriate.
+
+| Scenario | Contribution type | Rank | Why |
+|---|---|---|---|
+| A maintainer ran the triage skill and noticed that a step's instruction is ambiguous about what "recent" means. They want to tighten the wording and add an eval case that captures the ambiguity they saw. | | | |
+| A maintainer is reading `docs/education/your-first-skill.md` and finds a sentence confusing. They want to rephrase it and fix a broken link on the same page. | | | |
+| A maintainer has found a reliable way to structure skills that need to make parallel API calls. They want to document it for others to copy. | | | |
+| A maintainer has identified a gap in the framework: no skill exists for summarising weekly commit activity. They want to build it from scratch, with an eval suite. | | | |
+
+<details>
+<summary>Sample answers</summary>
+
+| Scenario | Contribution type | Rank | Why |
+|---|---|---|---|
+| Tighten wording and add an eval case | Fix or sharpen a skill | 1 or 2 | You are making a targeted improvement to an existing skill — the scope is bounded and you are extending something that already works rather than inventing something new. It is slightly higher effort than a pure doc fix because an eval case must accompany it. |
+| Rephrase a sentence and fix a broken link | Improve the docs | 1 | Pure documentation: no skill structure, no eval suite, no framework rules to satisfy beyond correct Markdown and valid links. The source page calls this "small, valuable, and a gentle way to learn the process". |
+| Document a reliable skill-structure pattern | Add a pattern | 2 or 3 | You are writing prose for the pattern catalogue, which requires clear writing and a concrete example but not the full skill + eval machinery. The on-ramp is lower than a new skill but higher than a doc fix because you need to understand the pattern well enough to explain the trade-offs. |
+| Build a new skill for weekly commit summaries | Write a new skill | 4 | "The biggest of the common first contributions". You are authoring a complete new skill (frontmatter, all steps, placeholder convention, data-not-instructions guard) and a full eval suite. The source page calls it the "biggest" and refers you to `your-first-skill.md` for the step-by-step path. |
+
+</details>
+
+---
+
+### Exercise 2 — Spec-first decision
+
+The source page says: "A change that alters behaviour usually starts with the
+spec. … Small doc or wording fixes do not need a spec change, but anything
+that changes a rule, a flow, or a contract does."
+
+For each change below, decide: **needs a spec change** or **does not need a
+spec change**? Write one sentence justifying your answer.
+
+| Change | Needs spec change? | Why |
+|---|---|---|
+| Fix a typo in `docs/education/contributing.md`. | | |
+| Add a new step to the `security-issue-triage` skill that checks whether the reported version is still supported. | | |
+| Rename a placeholder from `<tracker>` to `<issue-tracker>` across three skills for clarity. | | |
+| Change the `issue-triage` skill so that "NEEDS-INFO" issues are automatically closed after 30 days if the reporter has not responded, instead of being labelled for manual follow-up. | | |
+| Add an eval case to an existing skill's eval suite to cover an edge case you observed. | | |
+| Move the `pr-management-stats` skill's weekly summary output from a Markdown table to a JSON block. | | |
+
+<details>
+<summary>Sample answers</summary>
+
+| Change | Needs spec change? | Why |
+|---|---|---|
+| Fix a typo in `docs/education/contributing.md`. | **No** | A typo fix changes no rule, flow, or contract. This is the clearest example of "small doc or wording fix". |
+| Add a new step to `security-issue-triage` that checks version support. | **Yes** | Adding a step to a skill changes what the skill *does* — its flow. The matching spec in `tools/spec-loop/specs/security-issue-lifecycle.md` describes the skill's steps; that description must stay in step with the implementation. |
+| Rename placeholder `<tracker>` to `<issue-tracker>`. | **Yes** — arguably. | Placeholder names are part of the project-agnosticism contract (PRINCIPLE 12). Changing them changes the documented interface that adopters use to customise the skills. This is a contract change, so the spec and the adopter scaffold should be updated. A pure search-and-replace with no change to meaning is borderline; when in doubt, update the spec. |
+| Change `issue-triage` so NEEDS-INFO issues auto-close after 30 days. | **Yes** | This changes a rule (the policy on NEEDS-INFO) and the flow (from "label for manual follow-up" to "auto-close"). Both the spec and the skill change together. |
+| Add an eval case to an existing skill's eval suite. | **No** | An eval case exercises existing behaviour; it does not change what the skill is *supposed* to do. Adding a case tightens test coverage without altering any rule, flow, or contract. |
+| Change `pr-management-stats` output from Markdown table to JSON. | **Yes** | The output format is part of the contract — it is what callers or readers of the skill's output expect. Changing the format changes the contract. The matching spec documents expected output shapes; that must be updated. |
+
+</details>
+
+---
+
+### Exercise 3 — Apply the reviewer's checklist
+
+The source page lists five framework rules a reviewer will check on any skill
+contribution. They are:
+
+1. **External content is data, not instructions** (PRINCIPLE 0) — issue
+   bodies, PR descriptions, and mail are passed as data, never as instructions.
+   An eval case must prove it.
+2. **Propose, confirm, act** (PRINCIPLE 6) — world-changing steps are
+   proposals the maintainer confirms, never silent actions.
+3. **Project-agnostic placeholders** (PRINCIPLE 12) — no real project name;
+   use `<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`.
+4. **Evals are required** (PRINCIPLE 8) — a skill without a matching eval
+   suite is not finished.
+5. **Apache-2.0 and mark AI help** (PRINCIPLE 17) — the framework licence;
+   AI-authored commits carry `Generated-by:`.
+
+A contributor has opened a PR adding the following skill. Read the description
+and mark which rules are satisfied, which are violated, and which cannot be
+assessed from the description alone.
+
+---
+
+**Skill PR description:**
+
+> **PR: Add `weekly-commit-summary` skill**
+>
+> This skill fetches the commit history for the Airflow repository for the
+> past seven days, formats it as a Markdown table, and posts it as a comment
+> on the weekly-digest tracking issue.
+>
+> Steps:
+> 1. Fetch commits from the past seven days using `gh api`.
+> 2. Format as Markdown — one row per commit: SHA, author, message.
+> 3. Post the table as a comment on issue `apache/airflow#99999`.
+>
+> No eval suite yet — I'll add it in a follow-up PR.
+
+---
+
+For each of the five rules, write: **Satisfied / Violated / Cannot assess**,
+and one sentence explaining your verdict.
+
+| Rule | Verdict | Why |
+|---|---|---|
+| External content is data, not instructions (P0) | | |
+| Propose, confirm, act (P6) | | |
+| Project-agnostic placeholders (P12) | | |
+| Evals are required (P8) | | |
+| Apache-2.0 and mark AI help (P17) | | |
+
+<details>
+<summary>Sample answers</summary>
+
+| Rule | Verdict | Why |
+|---|---|---|
+| External content is data, not instructions (P0) | **Cannot assess** | The skill fetches commit messages (external text). Whether commit messages could contain adversarial instructions depends on how step 2 processes the raw API response — the PR description says "format as Markdown" but does not describe how the commit message field is handled. A reviewer would ask to see the full skill text and require an eval case proving the injection guard. |
+| Propose, confirm, act (P6) | **Violated** | Step 3 says "post the table as a comment" — this is a world-changing action (writing to an external system) with no confirmation step described. Under PRINCIPLE 6, the skill must propose the comment and wait for the maintainer to confirm before posting. |
+| Project-agnostic placeholders (P12) | **Violated** | Step 3 hardcodes `apache/airflow#99999` — a real repository and issue number. The skill must use placeholders (`<PROJECT>/<tracker>#<issue-number>` or similar) so any adopter can substitute their own. "Airflow repository" in the description is similarly coupled. |
+| Evals are required (P8) | **Violated** | The contributor explicitly says "no eval suite yet — I'll add it in a follow-up PR." The source page is clear: "a skill without a matching eval suite is not finished, and a PR that adds one without evals will not pass review." This PR cannot merge without the eval suite in the same PR. |
+| Apache-2.0 and mark AI help (P17) | **Cannot assess** | The description does not state whether any part was AI-authored. The reviewer should ask: if AI was used, a `Generated-by:` trailer is required. The licence question (Apache-2.0) is structural — the SPDX header would appear in the skill file itself, not the description. |
+
+</details>
+
+---
+
+### Exercise 4 — Walk the path to merged
+
+The six-step path from the source page:
+
+1. Get set up (clone, confirm `uv` and validators run).
+2. Make the smallest change that stands on its own.
+3. Update the spec if behaviour changes.
+4. Run the validators locally.
+5. Open the pull request.
+6. Work with the review.
+
+A contributor has identified an edge case in the `issue-reassess` skill: when
+an issue has no comments at all, the skill produces a misleading "no activity"
+message that implies the issue was once active but has gone quiet, rather than
+saying it was never responded to. They want to fix the step, update the eval
+suite, and open a PR.
+
+For each of the six steps, write:
+- **What the contributor does in this step** (one sentence, specific to this scenario).
+- **The most likely sticking point** (one sentence: where this step commonly goes wrong).
+
+| Step | What to do | Most likely sticking point |
+|---|---|---|
+| 1. Get set up | | |
+| 2. Smallest change | | |
+| 3. Update spec? | | |
+| 4. Run validators | | |
+| 5. Open PR | | |
+| 6. Work with review | | |
+
+<details>
+<summary>Sample answers</summary>
+
+| Step | What to do | Most likely sticking point |
+|---|---|---|
+| 1. Get set up | Clone the framework repo (if not already done) and confirm that `uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate` and the skill-eval runner complete without errors. | The validator or eval runner fails on an unrelated issue (a missing dependency, a system uv version mismatch), which blocks the contributor before they have written a single line. `CONTRIBUTING.md` and `docs/prerequisites.md` cover the setup; reading both first saves time. |
+| 2. Smallest change | Edit the specific step in `skills/issue-reassess/SKILL.md` that produces the misleading message, and add one eval case in `tools/skill-evals/evals/issue-reassess/` for the zero-comment edge case. Do not touch other steps or unrelated skills. | "Smallest change" is easy to agree with in principle and hard to enforce in practice: the contributor notices adjacent issues while editing and is tempted to fix them in the same PR. A second fix belongs in a second PR; bundling them slows review and risks one fix blocking the other. |
+| 3. Update spec? | Check `tools/spec-loop/specs/issue-management-family.md` for any statement about what `issue-reassess` does with zero-comment issues. If the spec documents the old (misleading) behaviour, update the matching sentence; if it does not mention this case, no spec change is needed. | Forgetting to check the spec at all — either skipping the update when it is needed (so the spec lies about behaviour) or making a trivial wording fix and editing the spec unnecessarily. The test is: "does the spec describe a rule, flow, or contract that my change alters?" |
+| 4. Run validators | Run `uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate`, then run the eval suite for `issue-reassess`. Both must pass before opening the PR. | The new eval case fails on the fixed skill (the expected output was not written to match what the repaired skill actually produces), or a pre-existing eval case that was passing before now fails because the wording change unintentionally altered another code path. Either failure is informative — fix the cause, not the test. |
+| 5. Open PR | Open the pull request with a description explaining what the misleading message was, what it should say, why the distinction matters (never-responded vs. once-active-then-quiet), and what the new eval case tests. | Writing a description that only says "fix edge case in issue-reassess" — leaving a reviewer to guess what the edge case was and why the distinction matters. A clear description answers the question "what should I look at closely?" before the reviewer has to ask. |
+| 6. Work with review | A reviewer reads the prose change for ambiguity (is the new message clear to someone who doesn't know the background?) and checks the eval case for coverage. The contributor responds to comments by tightening the wording or adding an extra case, not by explaining why the reviewer is wrong. | Treating review comments as criticism rather than collaboration. On a prose-driven project, "this is ambiguous" is the most valuable feedback the reviewer can give — it is exactly what the eval suite cannot catch on its own. Engage with the specific concern, not the general sentiment. |
+
+</details>
+
+---
+
+## Self-check
+
+Answer each question in a sentence or two before finishing this lesson. If
+you cannot answer one, re-read the matching section of the source page.
+
+**Q1.** Why can you contribute meaningfully to Magpie without being a systems
+programmer?
+
+<details>
+<summary>Answer</summary>
+
+Most of Magpie is written in English, not in a formal language. Contributions —
+a new skill, a fix to an existing one, a pattern for the catalogue, a page in
+the education stream — are *prose the agent executes*. If you can think clearly
+and write precisely (the skill this progression has been teaching), you have
+everything you need to contribute. The source page says this explicitly: "That
+is a feature, not a quirk." Systems-programming skills help with the tool layer
+(`tools/`) but are not required for the most common contributions.
+
+</details>
+
+---
+
+**Q2.** When does a contribution need a spec change, and when does it not?
+
+<details>
+<summary>Answer</summary>
+
+A contribution needs a spec change when it "changes a rule, a flow, or a
+contract" — anything that alters what part of the framework is *supposed to do*
+according to its specification. Small doc or wording fixes that do not affect
+behaviour do not need a spec change. The practical test is: does the spec
+currently document something that would be false if your change merged? If yes,
+update the spec; if no, leave it.
+
+</details>
+
+---
+
+**Q3.** List the five framework rules a reviewer will check on a skill you
+contribute.
+
+<details>
+<summary>Answer</summary>
+
+1. External content is data, not instructions (PRINCIPLE 0) — issue bodies and
+   PR descriptions are passed as data; an eval case must prove the guard holds.
+2. Propose, confirm, act (PRINCIPLE 6) — world-changing steps are proposals the
+   maintainer confirms, not silent actions.
+3. Project-agnostic placeholders (PRINCIPLE 12) — no real project name; use
+   `<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`.
+4. Evals are required (PRINCIPLE 8) — a skill without a matching eval suite is
+   not finished; the PR must include the suite, not defer it.
+5. Apache-2.0 and mark AI help (PRINCIPLE 17) — contributions land under the
+   framework licence; AI-authored commits carry a `Generated-by:` trailer.
+
+</details>
+
+---
+
+**Q4.** What is the purpose of step 4 (run the validators locally) in the path
+to a merged change?
+
+<details>
+<summary>Answer</summary>
+
+To catch failures before opening the PR, not after. The same checks CI runs
+locally — the skill/tool validator, the spec validator, markdownlint, and the
+link check — can be run in seconds by the contributor. A failure caught locally
+costs one fix; a failure caught by CI costs a round-trip (push, wait, read
+error, fix, push again). Running the validators first is the same discipline as
+running tests before pushing code: you confirm the change works before asking
+someone else to review it.
+
+</details>
+
+---
+
+**Q5.** You are not sure whether your change requires a spec update, you are
+unsure of the correct placeholder for the organisation's mailing list, and you
+are about to author a brand-new skill and want the full authoring checklist.
+Which resource do you check for each, and why?
+
+<details>
+<summary>Answer</summary>
+
+For the spec-update question: check the matching spec in
+`tools/spec-loop/specs/` and read what it says about the area you are changing.
+If the spec describes behaviour your change alters, update the spec. If it does
+not mention your change, you probably do not need to update it — but also check
+`CONTRIBUTING.md`, which explains when spec changes are required.
+
+For the placeholder question: check `CONTRIBUTING.md` for the list of standard
+placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`, etc.)
+or look at existing skills in `skills/` that perform a similar action —
+adopting the same placeholder another skill uses keeps the framework consistent.
+`MISSION.md` and `PRINCIPLES.md` explain *why* placeholders matter (PRINCIPLE
+12 — project agnosticism), but not the specific placeholder names.
+
+For authoring the new skill: use the `magpie-write-skill` guide (invoked as
+`/write-skill`), which carries the complete skill-authoring checklist —
+frontmatter, step structure, the placeholder convention, the injection guard,
+and the eval-suite requirement. `CONTRIBUTING.md` covers the surrounding
+process; the write-skill guide is the step-by-step for the skill file itself.
+
+</details>
+
+---
+
+## Summary
+
+Contributing to Magpie is approachable without systems-programming expertise
+because most of the framework is prose the agent executes. The four common
+first contributions — fix a skill, improve a doc, add a pattern, write a new
+skill — span a wide range of on-ramp effort; a broken link or a confusing
+sentence is as real a contribution as a complete new skill.
+
+The framework is built spec-first: its specs are the source of truth for what
+each area should do, and a change that alters a rule, flow, or contract
+requires an update to the matching spec, not just the implementation. Small
+wording fixes are the exception; behaviour changes are the rule.
+
+Every skill contribution is assessed against five framework rules: external
+content is data (not instructions), world-changing steps require confirmation,
+placeholders replace real project names, evals are required (not optional), and
+AI-authored contributions carry a `Generated-by:` trailer. These are not hoops
+— they are the same habits the entire learning progression has been building,
+now on the other side of the pull request.
+
+The six-step path — set up, smallest change, spec check, local validation, open
+PR, work with review — is the same discipline as any careful open-source
+contribution, adapted to a prose-driven project where ambiguity is the main
+failure mode and the eval suite is what "run your tests" means.
+
+---
+
+## Next
+
+This is the final numbered lesson in the module. With all eleven lessons
+complete, you have the full picture: what agents are, how to work with them,
+how to choose a model, how to write, safe, portable, and testable skills, how
+to work autonomously, how to program precisely in English, and how to give that
+work back.
+
+The **[hands-on lab](../tutorials.md)** (the module's practical component) is
+the natural continuation: build a small skill end to end, give it an eval
+suite, and run it — either self-paced or as part of a group session. A
+packaged lesson wrapper for the lab is not yet available; follow the
+source page directly until it lands.
+
+For the instructor/facilitator view of the whole module, see the
+**[facilitator guide](instructor-guide.md)**.
+
+---
+
+## Licence
+
+Apache License 2.0 (PRINCIPLE 17). Pages written with help from AI carry a
+`Generated-by:` note in their commit message following ASF Generative Tooling
+Guidance.


### PR DESCRIPTION
## Summary

- Adds **Lesson 11 — How to contribute**, the final lesson in the module: an LMS-neutral wrapper around the `contributing.md` source page, with learning objectives, four exercises, and a gated self-check. It covers the four common first contributions and their on-ramp order, spec-first decisions (when a change needs a spec update), the five framework rules a reviewer checks (PRINCIPLE 0/6/12/8/17), and the six-step path to a merged change.
- Adds the **facilitator guide** (`instructor-guide.md`) for the instructor-led delivery format, linked from the module README and from lesson 11.
- Adds the Lesson 11 interactive tutor prompt under `ai-tutors/` and completes the README module map (all 11 lessons now linked).

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
