### PR TITLE
fix(security-issue-sync): make RM hand-off a reconciled invariant, not a transition side-effect

### DIFF
--- a/skills/security-issue-sync/apply-and-push.md
+++ b/skills/security-issue-sync/apply-and-push.md
@@ -59,7 +59,13 @@ before moving on to the next item. Use:
   `tools/<cve-tool>/release-manager-handoff-comment.md` (manual-paste)
   otherwise. Substitute the placeholders (per the *Release-manager
   hand-off comment* bullet in Step 2b; the OAuth-pushed variant also
-  takes `PUSH_TIMESTAMP`), write the result to a temp file. Then
+  takes `PUSH_TIMESTAMP`), write the result to a temp file. This
+  reconciliation fires whenever the tracker's proposal carries the
+  hand-off item — at the `pr merged` → `fix released` transition
+  **and** on the invariant-repair path for a tracker already at
+  `fix released` with a review-ready record but no hand-off marker
+  (see *Hand-off presence is an invariant* under **Assignees** in
+  [`signals-to-actions.md`](signals-to-actions.md)). Then
   decide POST vs PATCH by grepping the tracker's comment list for
   the marker:
 

--- a/skills/security-issue-sync/signals-to-actions.md
+++ b/skills/security-issue-sync/signals-to-actions.md
@@ -179,7 +179,7 @@ will change and *why*. Group them by category:
   active on the issue, and propose self-assigning a team member only
   if the user explicitly asks.
 
-  **Assignee hand-off at the `fix released` transition.** When the
+  **Assignee hand-off at the `fix released` transition (and its repair).** When the
   sync transitions an issue to `fix released` (Step 12 — the fix has
   shipped to PyPI / the Helm registry), ownership moves from the
   remediation developer to the release manager for Steps 13–15
@@ -198,13 +198,49 @@ will change and *why*. Group them by category:
   blocker and ask the user whether to invite them before assigning
   — GitHub silently ignores assignee writes for non-collaborators.
 
-  This swap is **only** appropriate at the `fix released`
-  transition. Earlier transitions (`pr created`, `pr merged`) keep
-  the remediation developer as assignee because the fix PR is still
-  their responsibility. Later transitions
+  This swap is appropriate at the `fix released` transition **and on
+  the repair path below** (a tracker already at `fix released` whose
+  swap never landed). Earlier transitions (`pr created`, `pr merged`)
+  keep the remediation developer as assignee because the fix PR is
+  still their responsibility. Later transitions
   (`announced - emails sent`, `announced`,
   `vendor-advisory`) keep the release manager because the advisory
-  lifecycle is theirs. Do **not** shuffle assignees back and forth.
+  lifecycle is theirs. Do **not** shuffle assignees back and forth —
+  the swap fires once, at (or in repair of) the `fix released`
+  hand-off.
+
+  **Hand-off presence is an invariant — repair trackers already at
+  `fix released`.** The release-manager hand-off comment and the
+  assignee swap above are normally fired as apply-actions of the
+  `pr merged` → `fix released` transition proposal. But a tracker can
+  arrive at `fix released` *without* a hand-off ever having been
+  posted — a prior run's POST failed, the `fix released` label was
+  applied by hand, or the CVE record only reached review-ready
+  (Vulnogram `REVIEW`) on a later run than the label flip. Because no
+  transition fires on those later syncs, the transition-scoped
+  proposal never regenerates and the hand-off is silently skipped,
+  leaving an advisory with **no named owner** — it stalls until a
+  human notices.
+
+  So treat the hand-off as a **reconciled invariant, checked on every
+  sync**, not a one-shot transition side-effect. On every sync of a
+  tracker at `fix released` whose CVE record is review-ready
+  (Vulnogram `REVIEW`), grep the tracker's comments for the marker
+  `<!-- apache-magpie: release-manager-handoff v1 -->` (the same grep
+  Step 5c already runs). If the marker is **absent**, generate the
+  hand-off proposal item — POST the hand-off comment and propose the
+  assignee swap — exactly as at the transition, regardless of whether
+  this run performed the flip. If present, skip (Step 5c's PATCH path
+  handles content drift). Resolve the release manager
+  **authoritatively — never guess a "plausible" name**: for a release
+  train that ships many packages in one wave (e.g. a providers /
+  plugins wave), the owning RM is the sender of *that specific wave's*
+  `[RESULT][VOTE]` / release `[ANNOUNCE]`, which is frequently a
+  different person from the core-release RM for the same period;
+  resolve it per the release-trains data and record the wave + RM
+  there if missing before posting. A generic *"Action (RM): send the
+  advisory …"* status line is **never** an acceptable substitute for
+  the hand-off comment.
 - **Issue title hygiene** — the GitHub issue title ships verbatim into
   the CVE record's `containers.cna.title` field (read by the
   `generate-cve-json` script on every regen) and from there into the


### PR DESCRIPTION
## Summary

- The release-manager hand-off comment + assignee swap currently fire **only** as apply-actions of the `pr merged` → `fix released` **transition** proposal.
- A tracker that reaches `fix released` **without** a hand-off — a prior run's POST failed, the label was applied by hand, or the CVE record only reaches review-ready on a later sync than the label flip — never gets one, because no transition fires on later syncs so the transition-scoped proposal never regenerates. The advisory is left with **no named owner** and stalls.
- This makes hand-off presence a **reconciled invariant** checked on every sync of a `fix released` tracker whose record is review-ready: if the `release-manager-handoff v1` marker is absent, generate the hand-off + assignee swap regardless of whether this run performed the flip. Step 5c's existing marker-grep / POST-vs-PATCH mechanics are unchanged.
- Also stresses resolving the RM **authoritatively**: for a release train that ships many packages in one wave, the owning RM is the sender of *that specific wave's* `[RESULT][VOTE]` / release `[ANNOUNCE]`, frequently a different person than the core-release RM. A generic "Action (RM)" status line is never a substitute for the hand-off.

## Motivation

Hit in a real security sync: a providers-scope tracker reached `fix released` (the fixing provider package shipped, CVE reserved) but never received a hand-off — a sync emitted only a generic "Action (RM)" line, so no release manager was named, tagged, or assigned and the advisory had no owner. The wave's RM (the sender of that providers `[ANNOUNCE]`) differed from the core-release RM for the same period. Verified by hand-posting the correct hand-off + assignee swap on the tracker; this change makes sync do it automatically. Originating adopter override: `.apache-magpie-overrides/security-issue-sync.md` in the Airflow security tracker.

## Changes

- `skills/security-issue-sync/signals-to-actions.md` — new **"Hand-off presence is an invariant — repair trackers already at `fix released`"** rule under **Assignees**; the assignee-swap paragraph now covers the transition **and** the repair path.
- `skills/security-issue-sync/apply-and-push.md` — Step 5c cross-references the invariant so the trigger is documented at the apply site.

## Migration / compat

No new config knob; no behaviour change for trackers already carrying the hand-off marker (idempotent skip). The only new behaviour is a repair post for `fix released` + review-ready trackers missing the marker — the intended fix.

## Test plan

- `prek run --files` on both changed files — all hooks pass (markdownlint, typos, lychee link-check, check-placeholders, vendor-neutrality, skill-and-tool-validate).
- Docs-only change to an agentic skill; no code/tests affected.

---
🤖 Authored with Claude Code (Opus 4.8).
