### PR TITLE
docs(license): reconcile LICENSE/NOTICE attributions after #778

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -202,30 +202,12 @@
    limitations under the License.
 
 ================================================================================
-Contributions from other Apache Software Foundation projects
-================================================================================
-
-This product incorporates project-agnostic code contributed from
-other Apache Software Foundation projects:
-
-- Apache Airflow (https://airflow.apache.org/) — the framework that
-  became this project was first developed and proven within Apache
-  Airflow, already structured under Apache License 2.0 for reuse
-  inside and outside the ASF.
-- Apache Groovy (https://groovy.apache.org/) — contributions from
-  the Groovy PMC at the early stage of this project.
-
-Apache Airflow
-Copyright 2016-2026 The Apache Software Foundation
-
-Apache Groovy
-Copyright 2003-2026 The Apache Software Foundation
-
-================================================================================
 Third-party content
 ================================================================================
 
 This product includes substantially-modified content adapted from the
 "skill-creator" skill in the awesome-claude-skills repository by
 Julius Brussee (https://github.com/JuliusBrussee/awesome-claude-skills),
-licensed under the Apache License, Version 2.0.
+licensed under the Apache License, Version 2.0. See
+skills/write-skill/SKILL.md § "Provenance" for the specific upstream
+commit and the scope of the framework's modifications.

--- a/NOTICE
+++ b/NOTICE
@@ -3,3 +3,13 @@ Copyright 2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
+
+Portions of this product originated in other Apache Software Foundation
+projects. The required attribution lines from their NOTICE files are
+reproduced below.
+
+Apache Airflow
+Copyright 2016-2026 The Apache Software Foundation
+
+Apache Groovy
+Copyright 2003-2026 The Apache Software Foundation

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   - [Skill families](#skill-families)
     - [External skill sources](#external-skill-sources)
   - [Maintenance](#maintenance)
+  - [Acknowledgements](#acknowledgements)
   - [Cross-references](#cross-references)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -207,6 +208,17 @@ maintenance:
   intact, symlinks live, `.gitignore` correct, etc.).
 - `/magpie-setup override <framework-skill>` — open or
   scaffold an override file for a framework skill.
+
+## Acknowledgements
+
+Apache Magpie was first developed and proven inside **Apache Airflow**, and was
+maintained for a time as the `apache/airflow-steward` repository under the
+Airflow PMC before being renamed and established as its own project. It also
+incorporates early skill work contributed by way of the **Apache Groovy**
+community. All of that code carries the same rightsholder — Copyright The Apache
+Software Foundation, under the Apache License 2.0 — so it is not a third-party
+inclusion; the required attribution lines from the originating projects' NOTICE
+files are reproduced in [`NOTICE`](NOTICE).
 
 ## Cross-references
 


### PR DESCRIPTION
Follow-up to the #778 discussion. #778 moved the Airflow/Groovy attributions from NOTICE into LICENSE; the thread converged on that being the wrong home for them. This puts them back where ASF convention wants each piece:

- **NOTICE** carries the required *copyright attribution* lines for the ASF-project code that originated this framework (Airflow, Groovy) — minimal, copyright-lines-only, no descriptive prose. Only the top-level product copyright line is bubbled, per [licensing-howto#bundle-asf-product](https://infra.apache.org/licensing-howto.html#bundle-asf-product); we do not copy those projects' own bundled third-party notices, which do not pertain to Magpie.
- **LICENSE** drops the "Contributions from other ASF projects" block (it is neither a license grant nor third-party license text) and keeps the "Third-party content" block for the one genuine non-ASF inclusion (Julius Brussee / awesome-claude-skills), with the provenance pointer restored.
- **README** gains an Acknowledgements section for the lineage narrative (airflow-steward heritage, Groovy contributions) — same rightsholder (Copyright ASF, AL 2.0), so documentation rather than a legal notice.

Note: the Airflow `2016-2026` / Groovy `2003-2026` copyright spans match the current upstream NOTICE files (verified), so they are accurate, not invented.

cc @justinmclean @CalvinKirs @paulk-asert — does this settle everyone's concerns?

## Type of change

- [X] Other: LICENSE / NOTICE / attribution reconciliation

## Test plan

- [X] `prek run --all-files` passes (markdownlint, TOC, link check on the touched files)