### PR TITLE
docs(secure-agent-setup): allow-list two read-only REST gh api GETs (roster, ancestry)

### DIFF
--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -470,9 +470,18 @@ below, annotated.
   "permissions": {
     "allow": [
       "Bash(gh api graphql *)",                 // read-only GraphQL fetches (PR-triage paginated loop). MORE SPECIFIC than the `gh *` ask below, so it — and the read-only rules that follow — run WITHOUT a prompt. GraphQL mutations slip through; accepted, since the skills route mutations through REST, not graphql.
+      // Two read-only REST `gh api` GETs the skills need for read-only
+      // analysis (security-team / reviewer roster lookup; release-tag ↔
+      // fix-commit ancestry when verifying a fix shipped). Without these,
+      // read-only assessor subagents prompt mid-run for the roster/ancestry
+      // reads. Kept mutation-safe: the `collaborators --*` guard matches the
+      // list GET (`… /collaborators --paginate --jq …`) but NOT the add-member
+      // mutation (`… /collaborators/<user> -X PUT`, which has no ` --` prefix);
+      // `compare/…` is a GET-only endpoint with no mutating counterpart.
+      "Bash(gh api repos/*/*/collaborators --*)", "Bash(gh api repos/*/*/compare/*)",
       // Read-only gh, allow-listed so they don't trip the `gh *` ask below.
-      // Anything NOT listed here — every write/destructive gh, and REST `gh
-      // api` (GET included) — falls through to `gh *` and prompts.
+      // Anything NOT listed here — every write/destructive gh, and any other
+      // REST `gh api` (GET included) — falls through to `gh *` and prompts.
       "Bash(gh pr view *)", "Bash(gh pr list *)", "Bash(gh pr diff *)", "Bash(gh pr checks *)",
       "Bash(gh issue view *)", "Bash(gh issue list *)",
       "Bash(gh repo view *)", "Bash(gh repo list *)",


### PR DESCRIPTION
## Summary

Read-only assessor subagents (the `security-issue-sync` fan-out, PR-triage loops) need two REST `gh api` GETs that the template's `ask: Bash(gh *)` catch-all was prompting on mid-run:

- the security-team / reviewer **roster** (`repos/.../collaborators`), and
- release-tag ↔ fix-commit **ancestry** (`repos/.../compare/...`, used to verify a fix actually shipped).

Only `Bash(gh api graphql *)` was allow-listed; every REST `gh api` GET (roster, compare, …) fell through to `ask` and prompted. This adds the two above to the recommended allow-list, kept **mutation-safe**:

- the `collaborators --*` guard matches the list GET (`.../collaborators --paginate --jq ...`) but **not** the `.../collaborators/<user> -X PUT` add-member mutation (no ` --` prefix);
- `compare/...` is a GET-only endpoint with no mutating counterpart.

## Motivation

In a real security sync, read-only subagents kept prompting for the roster lookup and the ancestry check that confirms a provider fix has shipped — the same class of friction the read-only gh allow-list already removes for `gh pr/issue/... view`.

## Scope / note

Docs-only (the adopter-facing recommendation in `secure-agent-setup.md`). The magpie repo's **own** baseline — `.claude/settings.json` and the `tools/sandbox-lint/expected.json` mirror that sandbox-lint enforces per threat-model M.29 — is intentionally **not** agent-editable, so syncing the repo's own sandbox to this recommendation is left as a maintainer step.

## Test plan

- `prek run --files docs/setup/secure-agent-setup.md` — all hooks pass.
- `tools/sandbox-lint` pytest suite — green (fixture unchanged).

---
🤖 Authored with Claude Code (Opus 4.8).
