### PR TITLE
fix(agent-guard): make the fresh-clone hook guard cross-platform (Windows)

### DIFF
--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -1292,16 +1292,17 @@ Four passes, in this order:
 
      ```json
      { "matcher": "Bash", "hooks": [ { "type": "command",
-       "command": "[ -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" ] && python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" || true",
+       "command": "python3 -c \"import os,sys,subprocess; p=os.path.join(os.environ.get('CLAUDE_PROJECT_DIR',''),'.claude','hooks','agent-guard.py'); sys.exit(subprocess.call([sys.executable,p]) if os.path.isfile(p) else 0)\"",
        "timeout": 30 } ] }
      ```
 
-     The `[ -f … ] && … || true` guard makes the hook a **no-op on a
-     fresh clone** — before `/magpie-setup` has synced `agent-guard.py`
-     in (the script is gitignored framework code, not committed), so
-     without the guard the committed hook would exec a missing file on
-     every Bash call and a `PreToolUse` error can block the tool. Once
-     the script is present the guard passes and the hook runs normally.
+     The command no-ops when `agent-guard.py` is absent (a **fresh
+     clone**, before `/magpie-setup` has synced the gitignored script in)
+     and runs the guard otherwise — so the committed hook never execs a
+     missing file on a Bash call (a `PreToolUse` error can block the
+     tool). It is written as an inline `python3 -c` existence check
+     rather than a shell one-liner (`[ -f … ] && … || true`) so it works
+     on **Windows** (PowerShell) too, not only POSIX shells.
 
      Wiring happens **only once**; thereafter guards are
      added/removed purely by syncing `guards.d` — no settings.json

--- a/tools/agent-guard/README.md
+++ b/tools/agent-guard/README.md
@@ -111,7 +111,7 @@ The guard is registered as a `PreToolUse` hook on the `Bash` matcher in
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "[ -f \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" ] && python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\" || true", "timeout": 30 }
+          { "type": "command", "command": "python3 -c \"import os,sys,subprocess; p=os.path.join(os.environ.get('CLAUDE_PROJECT_DIR',''),'.claude','hooks','agent-guard.py'); sys.exit(subprocess.call([sys.executable,p]) if os.path.isfile(p) else 0)\"", "timeout": 30 }
         ]
       }
     ]


### PR DESCRIPTION
## Summary

Follow-up to #786 (merged): that PR guarded the committed agent-guard hook command with a POSIX shell conditional — `[ -f … ] && python3 … || true` — so the hook no-ops on a fresh clone before `/magpie-setup` has synced `agent-guard.py` in. But that form only works in a POSIX shell; on **Windows** (PowerShell, no Git Bash) the committed hook breaks.

Replace it with an inline `python3 -c` existence check that is cross-platform and needs no shell conditional:

```
python3 -c "import os,sys,subprocess; p=os.path.join(os.environ.get('CLAUDE_PROJECT_DIR',''),'.claude','hooks','agent-guard.py'); sys.exit(subprocess.call([sys.executable,p]) if os.path.isfile(p) else 0)"
```

- no-ops (exit 0) when the script is absent (fresh clone);
- runs the guard and propagates its exit code (so a deny still blocks) when present;
- reads `CLAUDE_PROJECT_DIR` from the environment in Python, so it doesn't depend on `$VAR` vs `%VAR%` shell expansion.

Updated in the two places that ship the snippet: `skills/setup/adopt.md` and `tools/agent-guard/README.md`.

Found by an adopter (Apache JMeter) reviewing the same change downstream — the reviewer asked "Does this work with windows?" on the adoption PR.

## Type of change

- [x] Bug fix (docs / committed template)

## Test plan

Doc / template change. The guarded command is valid on both POSIX and Windows (pure `python3 -c`, no shell conditional); it no-ops when the script is missing and runs + propagates the guard's exit code when present.
