### PR TITLE
feat(setup): offer all skill families + MCP servers at adopt/upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,25 +162,31 @@ for the full flow.
 
 ## Skill families
 
-Eight skill families ship in the framework, all at `experimental` or
-`stable`. Pick whichever families the adopter wants to use; symlinks for
-the picked families land in the adopter's skill directory.
+Ten skill families ship in the framework, all at `experimental` or
+`stable`, and each skill declares its family in a `family:` frontmatter
+key. At adoption (and on every upgrade), `/magpie-setup` offers the
+**opt-in** families — and the optional **MCP servers** (`ponymail`,
+`apache-projects`, `gmail-plaintext`) — in a single install choice;
+symlinks for the picked families land in the adopter's skill directory.
+The two **always-on** families (`setup`, `utilities`) are wired
+unconditionally and never prompted for.
 
 The **Modes** column maps each family to the MISSION agent-assistance
 taxonomy — see [`docs/modes.md`](docs/modes.md) for what each mode
 means and which modes are still proposed vs. shipping today.
 
-| Family | Modes | Purpose | Detail |
-|---|---|---|---|
-| [**setup**](docs/setup/README.md) | (infra) | Isolated agent setup, framework adoption + maintenance, shared-config sync. The prerequisite — at minimum the `setup` skill itself runs out of this family. | 9 skills, [`docs/setup/`](docs/setup/) |
-| [**security**](docs/security/README.md) | Triage, Drafting | 16-step security-issue handling lifecycle — from `security@` import through CVE publication, including state sync. Maintainer-only. | 12 skills, [`docs/security/`](docs/security/) |
-| [**pr-management**](docs/pr-management/README.md) | Triage | Maintainer-facing PR-queue management — triage, stats, deep code review, and express-lane merge surfacing. | 4 skills, [`docs/pr-management/`](docs/pr-management/README.md) |
-| [**release-management**](docs/release-management/README.md) | Triage, Drafting | 14-step ASF release lifecycle, planning issue, RC cut + sign, `[VOTE]` thread, tally, promote, `[ANNOUNCE]`, archive, audit log. Agent never holds the RM's signing key and never publishes the release. **Experimental**, all 10 skills shipped. | 10 skills, [`docs/release-management/`](docs/release-management/) |
-| [**mentoring**](docs/mentoring/README.md) | Mentoring | Contributor mentoring — first-contact welcome, teaching-register PR/issue comments, newcomer-ready backlog curation, and readiness tracking along the contributor-to-committer path. **Experimental** — shape may change as adopter pilots and contributor-sentiment evaluation land. | 5 skills, [`docs/mentoring/`](docs/mentoring/README.md) |
-| [**issue**](docs/issue-management/README.md) | Triage, Drafting | General-issue lifecycle: triage, reproduction, fix drafting, stale-sweep, deduplication, and backlog reporting. | 8 skills, [`docs/issue-management/`](docs/issue-management/README.md) |
-| [**contributor-growth**](docs/contributor-growth/README.md) | Triage, Mentoring | Skills spanning the contributor-to-committer path: first-contact welcome, on-ramp issue authoring, activity tracking, nomination brief, post-vote onboarding. | 5 skills, [`docs/contributor-growth/`](docs/contributor-growth/README.md) |
-| [**repo-health**](docs/repo-health/README.md) | Triage | Read-only repository-health audits: obsolete runner labels, Actions workflow security, dependency vulnerabilities, license/NOTICE compliance, flaky-test patterns. | 5 skills, [`docs/repo-health/`](docs/repo-health/) |
-| **utilities** | (meta) | Framework meta-skills: author or update skills (`write-skill`), restructure existing skills (`optimize-skill`), print a live index of all available skills (`list-skills`). | 3 skills |
+| Family | Type | Modes | Purpose | Detail |
+|---|---|---|---|---|
+| [**setup**](docs/setup/README.md) | always-on | (infra) | Isolated agent setup, framework adoption + maintenance, shared-config sync. The prerequisite — at minimum the `setup` skill itself runs out of this family. | 9 skills, [`docs/setup/`](docs/setup/) |
+| **utilities** | always-on | (meta) | Framework meta-skills: author skills (`write-skill`), restructure them (`optimize-skill`), reconcile skill state (`skill-reconciler`), and print a live index (`list-skills`). | 4 skills |
+| [**security**](docs/security/README.md) | opt-in | Triage, Drafting | 16-step security-issue handling lifecycle — from `security@` import through CVE publication, including state sync. Maintainer-only. | 12 skills, [`docs/security/`](docs/security/) |
+| [**pr-management**](docs/pr-management/README.md) | opt-in | Triage | Maintainer-facing PR-queue management — triage, stats, deep code review, express-lane merge, stale-sweep, reviewer routing, and pre-first-PR checks. | 8 skills, [`docs/pr-management/`](docs/pr-management/README.md) |
+| [**issue**](docs/issue-management/README.md) | opt-in | Triage, Drafting | General-issue lifecycle: triage, reproduction, fix drafting, reassess, stale-sweep, deduplication, and backlog reporting. | 8 skills, [`docs/issue-management/`](docs/issue-management/README.md) |
+| [**release-management**](docs/release-management/README.md) | opt-in | Triage, Drafting | 14-step ASF release lifecycle, planning issue, RC cut + sign, `[VOTE]` thread, tally, promote, `[ANNOUNCE]`, archive, audit log. Agent never holds the RM's signing key and never publishes the release. **Experimental**, all 10 skills shipped. | 10 skills, [`docs/release-management/`](docs/release-management/) |
+| [**repo-health**](docs/repo-health/README.md) | opt-in | Triage | Read-only repository-health audits: obsolete runner labels, Actions workflow security, dependency vulnerabilities, license/NOTICE compliance, flaky-test patterns, plus audit-finding fixes. | 6 skills, [`docs/repo-health/`](docs/repo-health/) |
+| [**pairing**](docs/pairing/README.md) | opt-in | Pairing | Pair a change with a structured self-review or a multi-agent adversarial review before it lands. | 2 skills, [`docs/pairing/`](docs/pairing/README.md) |
+| [**mentoring**](docs/mentoring/README.md) | opt-in | Mentoring | Newcomer-facing mentoring — first-contact welcome, newcomer-issue explanations, and good-first-issue authoring + backlog curation. **Experimental**. | 4 skills, [`docs/mentoring/`](docs/mentoring/README.md) |
+| [**contributor-growth**](docs/contributor-growth/README.md) | opt-in | Triage, Mentoring | The path-to-committer track: activity sweeps, nomination briefs, contributor-sentiment signals, readiness tracking, and committer / post-vote onboarding. | 6 skills, [`docs/contributor-growth/`](docs/contributor-growth/README.md) |
 
 ### External skill sources
 

--- a/skills/audit-finding-fix/SKILL.md
+++ b/skills/audit-finding-fix/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-audit-finding-fix
+family: repo-health
 mode: Drafting
 description: |
   For a batch of findings from a non-security audit tool

--- a/skills/ci-runner-audit/SKILL.md
+++ b/skills/ci-runner-audit/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-ci-runner-audit
+family: repo-health
 mode: Triage
 description: |
   Read-only audit of GitHub Actions workflow runner compatibility

--- a/skills/committer-onboarding/SKILL.md
+++ b/skills/committer-onboarding/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-committer-onboarding
+family: contributor-growth
 organization: ASF
 description: |
   Post-vote committer and PMC onboarding for Apache projects.

--- a/skills/contributor-activity-sweep/SKILL.md
+++ b/skills/contributor-activity-sweep/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-contributor-activity-sweep
+family: contributor-growth
 organization: ASF
 mode: Triage
 description: |

--- a/skills/contributor-nomination/SKILL.md
+++ b/skills/contributor-nomination/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-contributor-nomination
+family: contributor-growth
 organization: ASF
 mode: Triage
 description: |

--- a/skills/contributor-sentiment/SKILL.md
+++ b/skills/contributor-sentiment/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-contributor-sentiment
+family: contributor-growth
 mode: Triage
 description: |
   Measures contributor-sentiment signals on <upstream> over a

--- a/skills/contributor-to-committer/SKILL.md
+++ b/skills/contributor-to-committer/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-contributor-to-committer
+family: contributor-growth
 organization: ASF
 mode: Mentoring
 description: |

--- a/skills/dependency-audit/SKILL.md
+++ b/skills/dependency-audit/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-dependency-audit
+family: repo-health
 mode: Triage
 description: |
   Read-only dependency vulnerability audit for one repository or a local

--- a/skills/flaky-test-triage/SKILL.md
+++ b/skills/flaky-test-triage/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-flaky-test-triage
+family: repo-health
 mode: Triage
 description: |
   Read-only flaky-test detection from GitHub Actions CI run history for one

--- a/skills/good-first-issue-author/SKILL.md
+++ b/skills/good-first-issue-author/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-good-first-issue-author
+family: mentoring
 mode: Mentoring
 description: |
   Draft a single net-new *good first issue* on the configured

--- a/skills/good-first-issue-sweep/SKILL.md
+++ b/skills/good-first-issue-sweep/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-good-first-issue-sweep
+family: mentoring
 mode: Mentoring
 description: |
   Sweep the open `<issue-tracker>` backlog for existing issues that

--- a/skills/issue-backlog-stats/SKILL.md
+++ b/skills/issue-backlog-stats/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-backlog-stats
+family: issue
 mode: Triage
 description: |
   Read-only maintainer dashboard for the open general-issue backlog of

--- a/skills/issue-deduplicate/SKILL.md
+++ b/skills/issue-deduplicate/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-deduplicate
+family: issue
 mode: Triage
 description: |
   Merge two open `<issue-tracker>` issues that describe the same

--- a/skills/issue-fix-workflow/SKILL.md
+++ b/skills/issue-fix-workflow/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-fix-workflow
+family: issue
 mode: Drafting
 description: |
   For a single triaged `<issue-tracker>` issue confirmed as a

--- a/skills/issue-reassess-stats/SKILL.md
+++ b/skills/issue-reassess-stats/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-reassess-stats
+family: issue
 description: |
   Read-only dashboard over a directory of `verdict.json` files
   produced by `issue-reassess` campaigns. Surfaces a health

--- a/skills/issue-reassess/SKILL.md
+++ b/skills/issue-reassess/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-reassess
+family: issue
 mode: Triage
 description: |
   Sweep a configured pool of resolved or end-of-life

--- a/skills/issue-reproducer/SKILL.md
+++ b/skills/issue-reproducer/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-reproducer
+family: issue
 description: |
   For a single `<issue-tracker>` issue identifying a code-level
   bug, extract the reporter's example code from the issue body,

--- a/skills/issue-stale-sweep/SKILL.md
+++ b/skills/issue-stale-sweep/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-stale-sweep
+family: issue
 mode: Triage
 description: |
   Sweep open `<issue-tracker>` issues for inactivity past a

--- a/skills/issue-triage/SKILL.md
+++ b/skills/issue-triage/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-triage
+family: issue
 mode: Triage
 description: |
   For each open `<issue-tracker>` issue in the configured

--- a/skills/license-compliance-audit/SKILL.md
+++ b/skills/license-compliance-audit/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-license-compliance-audit
+family: repo-health
 mode: Triage
 description: |
   Read-only license compliance audit for one repository or a local

--- a/skills/list-skills/SKILL.md
+++ b/skills/list-skills/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-list-skills
+family: utilities
 description: |
   Print a human-readable index of every skill in this repository,
   grouped by family prefix (`pr-management`, `security`, `setup`,

--- a/skills/mentoring-welcome/SKILL.md
+++ b/skills/mentoring-welcome/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-mentoring-welcome
+family: mentoring
 mode: Mentoring
 description: |
   Draft a first-contact orientation comment for a first-time contributor

--- a/skills/newcomer-issue-explainer/SKILL.md
+++ b/skills/newcomer-issue-explainer/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-newcomer-issue-explainer
+family: mentoring
 mode: Mentoring
 description: |
   Given an open good-first-issue on the configured `<upstream>` repo,

--- a/skills/onboarding-concierge/SKILL.md
+++ b/skills/onboarding-concierge/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-onboarding-concierge
+family: contributor-growth
 mode: Mentoring
 description: |
   Answer a newcomer's "how do I contribute here" question by grounding the

--- a/skills/optimize-skill/SKILL.md
+++ b/skills/optimize-skill/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-optimize-skill
+family: utilities
 description: |
   Optimize an existing framework skill (or sweep a set of them) by
   applying the restructuring patterns proven on the security-skill

--- a/skills/pairing-multi-agent-review/SKILL.md
+++ b/skills/pairing-multi-agent-review/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pairing-multi-agent-review
+family: pairing
 mode: Pairing
 status: experimental
 description: |

--- a/skills/pairing-self-review/SKILL.md
+++ b/skills/pairing-self-review/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pairing-self-review
+family: pairing
 mode: Pairing
 description: |
   Run a structured pre-flight self-review on local changes before opening a PR.

--- a/skills/pr-management-code-review/SKILL.md
+++ b/skills/pr-management-code-review/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-code-review
+family: pr-management
 mode: Triage
 description: |
   Walk a maintainer through deep, sequential code review of open pull requests on the configured `<upstream>` repo.

--- a/skills/pr-management-mentor/SKILL.md
+++ b/skills/pr-management-mentor/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-mentor
+family: pr-management
 mode: Mentoring
 description: |
   Draft a teaching-register comment on a single GitHub issue

--- a/skills/pr-management-quick-merge/SKILL.md
+++ b/skills/pr-management-quick-merge/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-quick-merge
+family: pr-management
 description: |
   Identify trivial, low-risk pull requests in the `ready for maintainer review`
   queue of <upstream> that pass every quality gate and touch only supplementary

--- a/skills/pr-management-stats/SKILL.md
+++ b/skills/pr-management-stats/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-stats
+family: pr-management
 description: |
   Read-only maintainer dashboard for the open-PR backlog of <upstream>.
   Surfaces a health rating, prioritised action recommendations, weekly closure

--- a/skills/pr-management-triage/SKILL.md
+++ b/skills/pr-management-triage/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-triage
+family: pr-management
 mode: Triage
 description: |
   Sweep open pull requests on the configured `<upstream>` repo,

--- a/skills/pr-stale-sweep/SKILL.md
+++ b/skills/pr-stale-sweep/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-stale-sweep
+family: pr-management
 mode: Triage
 description: |
   Sweep open pull requests on the configured `<upstream>` repo for

--- a/skills/pre-first-pr-check/SKILL.md
+++ b/skills/pre-first-pr-check/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pre-first-pr-check
+family: pr-management
 mode: Pairing
 description: |
   Run a newcomer-focused pre-flight checklist on a local branch before opening a pull

--- a/skills/release-announce-draft/SKILL.md
+++ b/skills/release-announce-draft/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-announce-draft
+family: release-management
 organization: ASF
 mode: Drafting
 description: |

--- a/skills/release-archive-sweep/SKILL.md
+++ b/skills/release-archive-sweep/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-archive-sweep
+family: release-management
 organization: ASF
 mode: Triage
 description: |

--- a/skills/release-audit-report/SKILL.md
+++ b/skills/release-audit-report/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-audit-report
+family: release-management
 organization: ASF
 mode: Triage
 description: |

--- a/skills/release-keys-sync/SKILL.md
+++ b/skills/release-keys-sync/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-keys-sync
+family: release-management
 organization: ASF
 mode: Drafting
 description: |

--- a/skills/release-prepare/SKILL.md
+++ b/skills/release-prepare/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-prepare
+family: release-management
 organization: ASF
 mode: Drafting
 description: |

--- a/skills/release-promote/SKILL.md
+++ b/skills/release-promote/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-promote
+family: release-management
 organization: ASF
 mode: Drafting
 description: |

--- a/skills/release-rc-cut/SKILL.md
+++ b/skills/release-rc-cut/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-rc-cut
+family: release-management
 organization: ASF
 mode: Drafting
 description: |

--- a/skills/release-verify-rc/SKILL.md
+++ b/skills/release-verify-rc/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-verify-rc
+family: release-management
 organization: ASF
 mode: Triage
 description: |

--- a/skills/release-vote-draft/SKILL.md
+++ b/skills/release-vote-draft/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-vote-draft
+family: release-management
 organization: ASF
 mode: Drafting
 description: |

--- a/skills/release-vote-tally/SKILL.md
+++ b/skills/release-vote-tally/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-release-vote-tally
+family: release-management
 organization: ASF
 mode: Triage
 description: |

--- a/skills/reviewer-routing/SKILL.md
+++ b/skills/reviewer-routing/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-reviewer-routing
+family: pr-management
 mode: Triage
 description: |
   Given an open issue or PR, scores the project's configured reviewer roster

--- a/skills/security-cve-allocate/SKILL.md
+++ b/skills/security-cve-allocate/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-cve-allocate
+family: security
 mode: Triage
 description: |
   Walk a security team member through allocating a CVE for an

--- a/skills/security-issue-deduplicate/SKILL.md
+++ b/skills/security-issue-deduplicate/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-deduplicate
+family: security
 mode: Triage
 description: |
   Merge two <tracker> tracking issues that describe the same

--- a/skills/security-issue-fix/SKILL.md
+++ b/skills/security-issue-fix/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-fix
+family: security
 mode: Drafting
 description: |
   Attempt to fix a security issue tracked in `<tracker>` by

--- a/skills/security-issue-import-from-md/SKILL.md
+++ b/skills/security-issue-import-from-md/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-import-from-md
+family: security
 mode: Triage
 description: |
   Open one or more `<tracker>` tracking issues from a markdown

--- a/skills/security-issue-import-from-pr/SKILL.md
+++ b/skills/security-issue-import-from-pr/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-import-from-pr
+family: security
 mode: Triage
 description: |
   Open a tracking issue in <tracker> for a security-relevant fix that

--- a/skills/security-issue-import-from-scan/SKILL.md
+++ b/skills/security-issue-import-from-scan/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-import-from-scan
+family: security
 mode: Triage
 description: |
   Triage a security scanner's multi-finding output (read via a

--- a/skills/security-issue-import-via-forwarder/SKILL.md
+++ b/skills/security-issue-import-via-forwarder/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-import-via-forwarder
+family: security
 description: |
   Optional sub-skill of `security-issue-import`,
   `security-issue-invalidate`, and `security-issue-sync` that

--- a/skills/security-issue-import/SKILL.md
+++ b/skills/security-issue-import/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-import
+family: security
 mode: Triage
 description: |
   Scan <security-list> for reports that have not yet been

--- a/skills/security-issue-invalidate/SKILL.md
+++ b/skills/security-issue-invalidate/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-invalidate
+family: security
 mode: Triage
 description: |
   Close an `<tracker>` tracking issue as invalid: apply the

--- a/skills/security-issue-sync/SKILL.md
+++ b/skills/security-issue-sync/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-sync
+family: security
 mode: Triage
 description: |
   Synchronize a security issue in <tracker> with the state of its

--- a/skills/security-issue-triage/SKILL.md
+++ b/skills/security-issue-triage/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-triage
+family: security
 mode: Triage
 description: |
   For each open `<tracker>` issue carrying the `needs triage`

--- a/skills/security-tracker-stats-dashboard/SKILL.md
+++ b/skills/security-tracker-stats-dashboard/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-tracker-stats-dashboard
+family: security
 description: Generate a self-contained HTML dashboard of `<tracker>` repository statistics for security-team review.
 when_to_use: |
   Invoke when the user says "regenerate the tracker dashboard", "show

--- a/skills/setup-isolated-setup-doctor/SKILL.md
+++ b/skills/setup-isolated-setup-doctor/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-doctor
+family: setup
 description: |
   Probe the secure-agent setup for in-session functional
   restrictions that block legitimate workflows. Three live

--- a/skills/setup-isolated-setup-install/SKILL.md
+++ b/skills/setup-isolated-setup-install/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-install
+family: setup
 description: |
   Guide an adopter through the first-time install of the
   framework's secure agent setup (bubblewrap + socat +

--- a/skills/setup-isolated-setup-update/SKILL.md
+++ b/skills/setup-isolated-setup-update/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-update
+family: setup
 description: |
   Surface drift between the user's installed secure agent setup
   and the framework's latest (framework checkout, pinned tools,

--- a/skills/setup-isolated-setup-verify/SKILL.md
+++ b/skills/setup-isolated-setup-verify/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-verify
+family: setup
 description: |
   Walk the verification checklist for the framework's secure
   agent setup and report ✓ done / ✗ missing / ⚠ partial for

--- a/skills/setup-override-upstream/SKILL.md
+++ b/skills/setup-override-upstream/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-override-upstream
+family: setup
 description: |
   Walk an adopter through promoting a local
   `.apache-magpie-overrides/<skill>.md` file into a PR

--- a/skills/setup-shared-config-sync/SKILL.md
+++ b/skills/setup-shared-config-sync/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-shared-config-sync
+family: setup
 description: |
   Commit + push the user's shared Claude config to the
   `~/.claude-config` private dotfile-style sync repo. Inspects

--- a/skills/setup-status/SKILL.md
+++ b/skills/setup-status/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-status
+family: setup
 description: |
   Show how the apache-magpie framework is adopted in the current
   repo, then adjust that setup in place. Renders a Markdown

--- a/skills/setup-status/collect.md
+++ b/skills/setup-status/collect.md
@@ -71,23 +71,29 @@ in-repo `skills/<n>/` — self-adoption), `canonical-snapshot`
 
 ## `families`
 
-Each installed canonical skill is bucketed by source-name prefix:
+Each installed canonical skill is bucketed by the `family:`
+frontmatter key read from its `SKILL.md` (never by name prefix —
+`repo-health` and `contributor-growth` span several prefixes, per
+[Golden rule 8](../setup/SKILL.md#golden-rules)):
 
-- `opt_in` — `security`, `pr-management`, `issue`: the three
-  user-selectable families. `opt_in_present` / `opt_in_absent`
-  list which are wired.
-- `always_on` — `setup` (every `setup-*` plus the committed
-  `setup` bootstrap) and `list` (`list-*`): wired unconditionally
-  per [Golden rule 8](../setup/SKILL.md#golden-rules).
-- `other` — installed skills outside those prefixes (the
-  contributor, pairing, audit, and authoring skills). Reported by
-  name so the dashboard never silently drops them.
+- `opt_in` — the user-selectable families: `security`,
+  `pr-management`, `issue`, `release-management`, `repo-health`,
+  `pairing`, `mentoring`, `contributor-growth`. `opt_in_present` /
+  `opt_in_absent` list which are wired.
+- `always_on` — `setup` (every `family: setup` skill plus the
+  committed `setup` bootstrap) and `utilities` (`list-skills`,
+  `write-skill`, `optimize-skill`, `skill-reconciler`): wired
+  unconditionally per
+  [Golden rule 8](../setup/SKILL.md#golden-rules).
+- `other` — any installed skill whose `SKILL.md` declares no
+  readable family. Reported by name so the dashboard never
+  silently drops it (empty for a healthy framework snapshot).
 
-The bucketing is a prefix heuristic over what is actually on disk.
-The authoritative opt-in pick for a normal adopter is recorded in
-the lock files; when present, prefer the lock's family list over
-the heuristic for the *intended* set, and use the heuristic for
-the *installed* set so the dashboard can flag a gap between them.
+The bucketing reads what is actually on disk. The authoritative
+opt-in pick for a normal adopter is recorded in the lock files;
+when present, prefer the lock's family list over the on-disk read
+for the *intended* set, and use the on-disk read for the
+*installed* set so the dashboard can flag a gap between them.
 
 ## `drift`
 

--- a/skills/setup-status/render.md
+++ b/skills/setup-status/render.md
@@ -64,7 +64,7 @@ and breaks). A self-adopted framework checkout renders like:
 
 ### Skill families
 
-security ✅ 11 · pr-management ✅ 5 · issue ✅ 5 · always-on setup-*(8) list-*(1) · other 10
+security ✅ 12 · pr-management ✅ 8 · issue ✅ 8 · release-management ✅ 10 · repo-health ✅ 6 · pairing ✅ 2 · mentoring ✅ 4 · contributor-growth ✅ 6 · always-on setup(9) utilities(4) · other 0
 
 ### Drift & integrity
 

--- a/skills/setup-status/scripts/collect_status.py
+++ b/skills/setup-status/scripts/collect_status.py
@@ -120,10 +120,23 @@ def load_agent_targets() -> tuple[list[tuple[str, str, str, str]], str]:
         return _FALLBACK_TARGETS, "fallback"
     return targets, "agents.md"
 
-# Opt-in families the lock can record; every other prefix is
-# either always-on (setup-*, list-*) or "other".
-OPT_IN_FAMILIES = ["security", "pr-management", "issue"]
-ALWAYS_ON_FAMILIES = ["setup", "list"]
+# Opt-in families the lock can record. Membership is read from each
+# skill's ``family:`` frontmatter key (see skills/setup/SKILL.md
+# Golden rule 8), NOT the name prefix — families like ``repo-health``
+# and ``contributor-growth`` span several prefixes. ``setup`` and
+# ``utilities`` are always-on; anything with no readable family lands
+# in "other".
+OPT_IN_FAMILIES = [
+    "security",
+    "pr-management",
+    "issue",
+    "release-management",
+    "repo-health",
+    "pairing",
+    "mentoring",
+    "contributor-growth",
+]
+ALWAYS_ON_FAMILIES = ["setup", "utilities"]
 
 
 def repo_root(explicit: str | None) -> Path:
@@ -157,15 +170,25 @@ def parse_lock(path: Path) -> dict | None:
     return data
 
 
-def family_of(skill: str) -> str:
-    """Map a framework skill source name to its family bucket."""
-    if skill == "setup" or skill.startswith("setup-"):
-        return "setup"
-    if skill.startswith("list-"):
-        return "list"
-    for fam in OPT_IN_FAMILIES:
-        if skill == fam or skill.startswith(fam + "-"):
-            return fam
+def read_family(skill_dir: Path) -> str:
+    """Read the ``family:`` frontmatter key from a skill's SKILL.md.
+
+    Returns the declared family, or ``"other"`` when the SKILL.md is
+    absent / unreadable or declares no family. Membership is never
+    inferred from the name prefix (Golden rule 8)."""
+    skill_md = skill_dir / "SKILL.md"
+    try:
+        text = skill_md.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return "other"
+    if not text.startswith("---"):
+        return "other"
+    end = text.find("\n---", 3)
+    frontmatter = text[3:end] if end != -1 else text
+    for raw in frontmatter.splitlines():
+        line = raw.strip()
+        if line.startswith("family:"):
+            return line.partition(":")[2].strip() or "other"
     return "other"
 
 
@@ -173,7 +196,7 @@ def link_info(entry: Path, root: Path) -> dict:
     """Describe one ``magpie-*`` directory entry."""
     name = entry.name
     skill = name[len("magpie-") :]
-    info: dict = {"name": name, "skill": skill, "family": family_of(skill)}
+    info: dict = {"name": name, "skill": skill}
     if not entry.is_symlink():
         info.update(is_symlink=False, resolves=False, raw_target=None)
         # A non-symlink magpie-* (e.g. the committed magpie-setup
@@ -181,12 +204,17 @@ def link_info(entry: Path, root: Path) -> dict:
         # SKILL.md.
         info["resolves"] = (entry / "SKILL.md").is_file()
         info["kind"] = "copy" if info["resolves"] else "broken"
+        info["family"] = read_family(entry)
         return info
     raw = os.readlink(entry)
     info["raw_target"] = raw
     info["is_symlink"] = True
     resolved = (entry.parent / raw).resolve() if not os.path.isabs(raw) else Path(raw)
     info["resolves"] = (resolved / "SKILL.md").is_file()
+    # Family comes from the target skill's frontmatter (Golden rule 8),
+    # not the symlink name. A relay points at the canonical entry, which
+    # itself points at the skill dir — resolve() collapses both hops.
+    info["family"] = read_family(resolved)
     # Relay links point back at the canonical .agents/skills home;
     # canonical links point at the snapshot or the in-repo source.
     if ".agents/skills/magpie-" in raw:
@@ -382,11 +410,11 @@ def render_markdown(d: dict) -> str:
     out.append("")
     out.append("| Family | Type | Installed |")
     out.append("|---|---|---|")
-    for f in ("security", "pr-management", "issue"):
+    for f in OPT_IN_FAMILIES:
         n = len(fam["opt_in"][f])
         out.append(f"| {f} | opt-in | {'✅ ' + str(n) if n else '— none'} |")
-    out.append(f"| setup-* | always-on | {len(fam['always_on']['setup'])} |")
-    out.append(f"| list-* | always-on | {len(fam['always_on']['list'])} |")
+    out.append(f"| setup | always-on | {len(fam['always_on']['setup'])} |")
+    out.append(f"| utilities | always-on | {len(fam['always_on']['utilities'])} |")
     out.append(f"| other | — | {len(fam['other'])} |")
     out.append("")
 

--- a/skills/setup-upstream-fix/SKILL.md
+++ b/skills/setup-upstream-fix/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-upstream-fix
+family: setup
 description: |
   Turn a framework bug or quirk the agent hit while running a
   Magpie skill or tool into a fix PR against `apache/magpie` —

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup
+family: setup
 description: |
   Adopt and maintain the apache-magpie framework in a project
   repo via the snapshot-based adoption mechanism. The only
@@ -188,7 +189,7 @@ They are written and reconciled by
 
 | File | Purpose |
 |---|---|
-| [`adopt.md`](adopt.md) | First-time adoption walk-through — recognise existing-snapshot vs needs-bootstrap, write the two lock files, ask the user which skill families to wire up, create the gitignored symlinks, scaffold `.apache-magpie-overrides/`, install the post-checkout hook, update project docs. The default sub-action. |
+| [`adopt.md`](adopt.md) | First-time adoption walk-through — recognise existing-snapshot vs needs-bootstrap, write the two lock files, ask the user which skill families and MCP servers to install, create the gitignored symlinks, scaffold `.apache-magpie-overrides/`, install the post-checkout hook, update project docs. The default sub-action. |
 | [`upgrade.md`](upgrade.md) | Refresh the gitignored snapshot per the committed lock, reconcile any agentic overrides + symlinks against the new framework structure, surface conflicts. Drives the on-drift remediation flow. |
 | [`verify.md`](verify.md) | Read-only health check — snapshot present + intact, both lock files in sync, symlinks point at live targets, `.gitignore` correct, `.apache-magpie-overrides/` exists, drift status (committed vs local), the `setup` skill itself is current. |
 | [`skill-sources.md`](skill-sources.md) | Fetch/verify skills from trusted external sources listed in `<project-config>/skill-sources.md`, pin them in the committed `.apache-magpie.sources.lock`, and symlink the provided skills in exactly like framework skills. The runnable half of [trusted external skill sources](../../docs/skill-sources/README.md); the install gate is the adopter trust list. |
@@ -304,34 +305,54 @@ patch tool. See
 [`docs/setup/agentic-overrides.md`](../../docs/setup/agentic-overrides.md)
 for the contract.
 
-**Golden rule 8 — two families are *always* installed; the
-rest are opt-in.** Two skill families are wired up
-unconditionally on every adopt / upgrade / worktree-init run
-and the user is **never asked** about them:
+**Golden rule 8 — family membership is declared in
+frontmatter; two families are *always* installed, the rest
+are opt-in.** Every framework skill declares its family in a
+`family:` key in its `SKILL.md` frontmatter (e.g.
+`family: repo-health`). The sub-actions read that key from the
+snapshot to build the adopt/upgrade install choice and to wire
+each family's symlinks — **family membership is never inferred
+from the skill-name prefix**, because families such as
+`repo-health` and `contributor-growth` deliberately span
+several prefixes. The canonical family vocabulary is validated
+by [`skill-and-tool-validator`](../../tools/skill-and-tool-validator/README.md)
+(`ALLOWED_FAMILIES`) and mirrored adopter-facing in
+[`README.md` → Skill families](../../README.md#skill-families).
 
-- **`setup-*`** — every framework skill whose source name
-  starts with `setup-` *except* the bootstrap `setup` itself
-  (which is copied as `magpie-setup` per Rule 6, not
-  symlinked). Concretely:
-  `setup-isolated-setup-install`,
-  `setup-isolated-setup-update`,
-  `setup-isolated-setup-verify`, `setup-override-upstream`,
-  `setup-shared-config-sync`, plus any new `setup-*` skill
-  the framework grows in the future — each symlinked as
-  `magpie-setup-*`.
-- **`list-*`** — the discovery family; every framework skill
-  whose source name starts with `list-`. Today this is
-  `list-skills` only (symlinked as `magpie-list-skills`); the
-  prefix lets the framework grow a discovery family without
-  re-prompting every adopter.
+Two families are wired up **unconditionally** on every adopt /
+upgrade / worktree-init run and the user is **never asked**
+about them:
 
-These two families are not exposed in the `skill-families:`
-prompt and not stored as user-selectable in the lock files;
-every sub-action that wires symlinks always covers them in
-addition to the user's opt-in family picks (`security`,
-`pr-management`, `issue`). Dropping them is *not* a supported
-configuration — the secure-setup and discovery flows the
-framework ships depend on those skills being callable.
+- **`setup`** — every skill with `family: setup` *except* the
+  bootstrap `setup` itself (which is copied as `magpie-setup`
+  per Rule 6, not symlinked): `setup-isolated-setup-install`,
+  `setup-isolated-setup-update`, `setup-isolated-setup-verify`,
+  `setup-isolated-setup-doctor`, `setup-override-upstream`,
+  `setup-shared-config-sync`, `setup-status`,
+  `setup-upstream-fix`, plus any new `family: setup` skill the
+  framework grows — each symlinked as `magpie-setup-*`.
+- **`utilities`** — the meta / discovery family; skills with
+  `family: utilities`: `list-skills`, `write-skill`,
+  `optimize-skill`, `skill-reconciler`. These are framework
+  self-authoring and discovery tools every adopter gets so the
+  framework can grow them without re-prompting.
+
+These two always-on families (`ALWAYS_ON_FAMILIES` in the
+validator) are not exposed in the `skill-families:` prompt and
+not stored as user-selectable in the lock files; every
+sub-action that wires symlinks always covers them **in addition
+to** the user's opt-in family picks. Dropping them is *not* a
+supported configuration — the secure-setup, discovery, and
+skill-authoring flows the framework ships depend on those
+skills being callable.
+
+Every **other** family is **opt-in** — offered in the Step 5
+prompt and recorded in the lock files. Today those are:
+`security`, `pr-management`, `issue`, `release-management`,
+`repo-health`, `pairing`, `mentoring`, `contributor-growth`.
+The set is computed from the `family:` keys present in the
+snapshot minus the always-on families, so a new opt-in family
+appears in the prompt automatically the run after it ships.
 
 **Golden rule 9 — reload `setup` in-flight after a
 self-update.** When a sub-action changes or creates the
@@ -401,7 +422,7 @@ first, then continue.
 | `from:<git-ref>` / `from:<version>` | Adopt or upgrade from a specific framework ref or version. Used during `adopt` (overrides the user prompt) and `upgrade` (overrides the committed lock for *this run only* — does NOT update the committed lock). |
 | `method:<git-branch\|git-tag\|svn-zip\|local>` | Pick the install method explicitly. Default during `adopt`: prompt the user. **`local`** is **framework-checkout only** — it self-adopts by linking the in-repo `skills/` source directly instead of fetching a snapshot (see [`adopt.md` → Local self-adoption](adopt.md#local-self-adoption-methodlocal)). |
 | `agents:<list>` | Comma-separated **agent targets** to wire symlinks into ([`agents.md`](agents.md) registry ids: `universal`, `claude-code`, `github`, `windsurf`, `goose`, …). Default on `adopt`/`upgrade`: auto — the always-on neutral set (`universal` + `claude-code` + `github`) plus any other registry dir already present in the repo. When passed, **replaces** the auto-detected set for that run, except `universal` (`.agents/skills/`) which is always retained because it is the canonical home every other target relays into — dropping it would leave the relays dangling. |
-| `skill-families:<list>` | Comma-separated **opt-in** families to symlink (`security`, `pr-management`, `issue`). Default on `adopt`: prompt. Default on `upgrade`: read the families list from `<committed-lock>` / `<local-lock>`, **auto-include any opt-in family the framework has introduced since the lock was written** (recorded back into the lock), and **ensure every framework skill in the effective family set has a valid symlink** — create or repair missing / broken symlinks, not just add new ones. The flag never accepts the always-on families (`setup-*` minus `setup` itself, and `list-*`); per [Golden rule 8](#golden-rules) those are wired up unconditionally on every run and there is no way to ask for them or opt out. |
+| `skill-families:<list>` | Comma-separated **opt-in** families to symlink — any of the opt-in families declared by a `family:` frontmatter key in the snapshot (today: `security`, `pr-management`, `issue`, `release-management`, `repo-health`, `pairing`, `mentoring`, `contributor-growth`). Default on `adopt`: prompt (see [`adopt.md` Step 5](adopt.md#step-5--pick-the-skill-families-and-mcp-servers)). Default on `upgrade`: read the families list from `<committed-lock>` / `<local-lock>`, **auto-include any opt-in family the framework has introduced since the lock was written** (recorded back into the lock), and **ensure every framework skill in the effective family set has a valid symlink** — create or repair missing / broken symlinks, not just add new ones. The flag never accepts the always-on families (`setup`, `utilities`); per [Golden rule 8](#golden-rules) those are wired up unconditionally on every run and there is no way to ask for them or opt out. |
 | `--purge-overrides` | *(unadopt only)* Also `git rm -r` `.apache-magpie-overrides/`. Default: preserve. |
 | `dry-run` | Show what the skill would do without writing anything. |
 

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -36,10 +36,12 @@ between automatically:
 - `method:<git-branch | git-tag | svn-zip>` — explicit method
   (overrides the prompt).
 - `skill-families:<list>` — comma-separated **opt-in**
-  families to symlink (default: prompt). Valid values:
-  `security`, `pr-management`, `issue`. The flag does **not**
-  accept the always-on families (`setup-*` minus
-  `setup` itself, and `list-*`); per
+  families to symlink (default: prompt). Valid values are the
+  opt-in families declared by `family:` keys in the snapshot:
+  `security`, `pr-management`, `issue`, `release-management`,
+  `repo-health`, `pairing`, `mentoring`, `contributor-growth`.
+  The flag does **not** accept the always-on families (`setup`,
+  `utilities`); per
   [`SKILL.md` Golden rule 8](SKILL.md#golden-rules) those
   are wired up unconditionally on every adopt run and the
   user is never asked about them.
@@ -137,7 +139,7 @@ How it differs from a remote adoption:
   skills active with no setup step, whatever agent they use.
 - **All skills, no family prompt.** Self-adoption links *every*
   skill under `skills/`, so the opt-in family prompt of
-  [Step 5](#step-5--pick-the-skill-families) is skipped.
+  [Step 5](#step-5--pick-the-skill-families-and-mcp-servers) is skipped.
   `skill-families:` is still honoured if the maintainer wants to
   narrow the set.
 - **`magpie-setup` is itself a symlink** (→ `../../skills/setup/`),
@@ -290,10 +292,11 @@ If `<snapshot-dir>/` already exists with content, skip the
 fetch — the recipe ran first and left the snapshot in place.
 
 After the fetch (or skip), confirm
-`<snapshot-dir>/skills/` lists the framework skills
-(`pr-management-*`, `security-*`, `issue-*`, `setup-*`,
-`list-*`). If not, the fetch produced an unexpected
-layout — surface and stop.
+`<snapshot-dir>/skills/` lists the framework skills (e.g.
+`pr-management-*`, `security-*`, `issue-*`, `release-*`,
+`setup-*`, `list-skills`, `write-skill`) and that each
+`SKILL.md` carries a `family:` frontmatter key. If not, the
+fetch produced an unexpected layout — surface and stop.
 
 ## Step 3b — Reconcile the committed `setup` with the new snapshot + reload in-flight
 
@@ -422,67 +425,111 @@ Step 5's fallback default applies.
 > content. Counts and dates are the only fields consumed; any
 > free-text field is discarded after extraction.
 
-## Step 5 — Pick the skill families
+## Step 5 — Pick the skill families and MCP servers
 
-The framework's family set splits into two tiers:
+This is the **single install choice**: which opt-in skill
+families to wire up, **and** which MCP servers to register.
+Both are collected here so the operator picks everything
+installable in one prompt; the MCP picks are then walked
+through their install in Steps 9c / 9d and reflected in the
+Step 9b `user.md` `tools` blocks.
 
-**Always-on (no prompt; per
-[`SKILL.md` Golden rule 8](SKILL.md#golden-rules)):**
+**Compute the family set from the snapshot, not from a hard-coded
+list.** Walk `<snapshot-dir>/skills/*/SKILL.md`, read each skill's
+`family:` frontmatter key, and group. Never infer a family from the
+skill-name prefix — `repo-health`, `contributor-growth`, and
+`mentoring` span several prefixes (per
+[`SKILL.md` Golden rule 8](SKILL.md#golden-rules)).
 
-- **`setup-*`** *(minus `setup` itself)* — every
-  `setup-*` skill in the snapshot. Today:
-  `setup-isolated-setup-install`,
-  `setup-isolated-setup-update`,
-  `setup-isolated-setup-verify`, `setup-override-upstream`,
-  `setup-shared-config-sync`.
-- **`list-*`** — every `list-*` skill in
-  the snapshot. Today: `list-skills`.
+**Always-on (no prompt):** the `setup` family (every
+`family: setup` skill except the bootstrap `setup` itself) and
+the `utilities` family (`list-skills`, `write-skill`,
+`optimize-skill`, `skill-reconciler`). These are wired
+unconditionally, cannot be opted out via `skill-families:`, and
+are **not** recorded in the lock files. Do **not** offer them as
+selectable options.
 
-These are wired up unconditionally; the user is **not**
-asked about them and they cannot be opted out via the
-`skill-families:` flag. The lock files do not record them
-because they are framework-mandated, not user-selected.
+**Opt-in families** = every family present in the snapshot minus
+the always-on two. Today, with a one-line purpose each (counts
+come from the snapshot, do not hard-code them):
 
-**Opt-in (prompt, or read from
-`skill-families:` / the locks):**
+- **`security`** — the security-issue handling lifecycle
+  (import → triage → CVE → sync). Maintainer-only; needs a
+  security tracker.
+- **`pr-management`** — maintainer-facing PR-queue work: triage,
+  deep code review, stats, express-lane merge, stale-sweep,
+  reviewer routing, pre-first-PR checks.
+- **`issue`** — general-issue tracker lifecycle: triage,
+  reproduce, fix-workflow, reassess, stale-sweep, deduplicate,
+  backlog stats. For a general-issue tracker (JIRA, GitHub
+  Issues, Bugzilla, GitLab) that is *not* the security tracker.
+  See [`docs/issue-management/README.md`](../../docs/issue-management/README.md).
+- **`release-management`** — the ASF release lifecycle: prepare,
+  RC cut + sign, `[VOTE]`, tally, promote, `[ANNOUNCE]`, archive,
+  audit. Release-Manager-facing; the agent never holds the
+  signing key. See [`docs/release-management/README.md`](../../docs/release-management/README.md).
+- **`repo-health`** — read-only repository-health audits: CI
+  runner labels, Actions workflow security, dependency
+  vulnerabilities, license/NOTICE compliance, flaky tests, and
+  audit-finding fixes. See [`docs/repo-health/README.md`](../../docs/repo-health/README.md).
+- **`pairing`** — pair a change with a structured self-review or
+  a multi-agent adversarial review. See [`docs/pairing/README.md`](../../docs/pairing/README.md).
+- **`mentoring`** — newcomer-facing: first-contact welcome,
+  newcomer-issue explainer, good-first-issue authoring and
+  backlog curation. See [`docs/mentoring/README.md`](../../docs/mentoring/README.md).
+- **`contributor-growth`** — the path-to-committer track:
+  activity sweep, nomination brief, sentiment signals, readiness
+  tracking, committer / post-vote onboarding. See
+  [`docs/contributor-growth/README.md`](../../docs/contributor-growth/README.md).
 
-(SUBSEQUENT adoption: re-use the opt-in families currently
-recorded in `<committed-lock>` / `<local-lock>`, if any. Or
-re-prompt if none.)
+**MCP servers** (folded into the same choice — read
+[Step 9b](#step-9b--scaffold-usermd-fresh-only)'s `tools` contract for the
+detail; install is walked in [Step 9c](#step-9c--comdev-mcp-prerequisites-asf-projects)
+/ [Step 9d](#step-9d--gmail-plaintext-mcp-optional-gmail-drafters)):
 
-If `skill-families:` was passed, use those values verbatim
-for the opt-in set. Otherwise prompt the user with:
+- **`ponymail`** — read the ASF mailing-list archives (the
+  primary mail-read backend for the security / release families;
+  Gmail is the fallback). **ASF projects: mandatory** — the
+  `_template` manifest declares it `mandatory: yes`.
+- **`apache-projects`** — read-only ASF rosters / people /
+  releases metadata (used by `contributor-nomination` and the
+  security roster paths). **ASF projects: mandatory.**
+- **`gmail-plaintext`** — create plain-text Gmail drafts with no
+  tracking redirects (for operators who draft mail from the
+  agent). Optional; not ASF-gated.
 
-- **`security`** — eight skills for security-issue
-  handling. Maintainer-only; not useful unless the project
-  has a security tracker.
-- **`pr-management`** — five skills for maintainer-facing
-  PR queue work.
-- **`issue`** — five skills for general-issue tracker work
-  (triage, reassess, reproducer, fix-workflow, stats).
-  Maintainer-only; for projects with a general-issue tracker
-  (JIRA, GitHub Issues, Bugzilla, GitLab Issues) that is
-  *not* the security tracker. See
-  [`docs/issue-management/README.md`](../../docs/issue-management/README.md).
+**Prefer structured Q&A.** When the harness offers a
+structured-question tool, use **one** *multi-select* prompt with
+two labelled groups — "Skill families" (the opt-in families
+above) and "MCP servers" (the three above). None are mutually
+exclusive. Pre-selection:
 
-**Prefer structured Q&A.** When the agent harness offers a
-structured-question tool, use a *multi-select* prompt for
-the three opt-in families (`security`, `pr-management`,
-`issue`) — the families are not mutually exclusive.
-Pre-select the **union** of (a) families the user named in
-their initial "adopt" request (e.g. *"adopt apache-magpie
-for PR triage"* → `pr-management`) and (b)
-`<signal-derived-families>` from Step 4b. Mention in the
-prompt body why each family is pre-ticked (named by the
-user, or which signal triggered it) so the operator can
-untick what does not fit. If both sources are empty, default
-to selecting all three for an adopter that is a maintainer-
-driven repo, or to no pre-selection otherwise. Free-form
-chat is the fallback.
+- *Families* — pre-tick the **union** of (a) families the user
+  named in their initial "adopt" request (e.g. *"adopt for PR
+  triage"* → `pr-management`, *"for releases"* →
+  `release-management`) and (b) `<signal-derived-families>` from
+  Step 4b. State in the prompt body why each is pre-ticked so the
+  operator can untick what does not fit. If both sources are
+  empty, pre-tick nothing and let the operator choose.
+- *MCP servers* — for an ASF project (detected per
+  [Step 9c](#step-9c--comdev-mcp-prerequisites-asf-projects)),
+  pre-tick `ponymail` and `apache-projects` and label them
+  **required**; pre-tick `gmail-plaintext` only if the operator
+  selected a mail-drafting family (`security` or
+  `release-management`). For a non-ASF project, pre-tick nothing.
 
-Do **not** offer `setup-*` or `list-*` as
-selectable options in the prompt — they are wired up
-silently regardless of what the user picks here.
+SUBSEQUENT adoption: re-use the opt-in families recorded in
+`<committed-lock>` / `<local-lock>` and the already-registered
+MCP servers (inspect the session tool list for `mcp__ponymail__*`
+/ `mcp__apache-projects__*` / `mcp__gmail-plaintext__*`); only
+re-prompt for what is neither locked nor registered. If
+`skill-families:` was passed, use those values verbatim for the
+family set (the flag does not carry MCP picks — confirm those
+separately). Free-form chat is the fallback when no structured
+tool is available; keep the same two-group structure.
+
+Record the family picks for Step 6 (the lock) and Step 8 (the
+symlink wiring), and the MCP picks for Steps 9b–9d.
 
 ## Step 6 — Write `<local-lock>`
 
@@ -581,10 +628,10 @@ gitignored exactly like the canonical ones: a relay points at
 gitignored snapshot, so it dangles on a fresh clone before
 `/magpie-setup` runs.
 
-The `magpie-*` glob covers both the opt-in families and the
-always-on families (`magpie-setup-*` and the `magpie-list-*`
-discovery family) per
-[`SKILL.md` Golden rule 8](SKILL.md#golden-rules); every
+The `magpie-*` glob covers every symlinked framework skill —
+the opt-in families and the always-on `setup` / `utilities`
+families alike (per
+[`SKILL.md` Golden rule 8](SKILL.md#golden-rules)); every
 symlinked framework skill is gitignored on every adopter
 regardless of the opt-in family pick. The committed
 `magpie-setup` skill is kept tracked by the
@@ -612,21 +659,25 @@ gitignored **canonical** symlink at `.agents/skills/magpie-<skill>`
 
 The set of skills to link is the **union** of:
 
-1. **The opt-in families the user picked in Step 5**
-   (`security`, `pr-management`, `issue`, or any
-   combination). Each contributes every framework skill in
-   the snapshot whose name starts with that family's prefix.
+1. **The opt-in families the user picked in Step 5** (any
+   combination of `security`, `pr-management`, `issue`,
+   `release-management`, `repo-health`, `pairing`, `mentoring`,
+   `contributor-growth`). Each contributes every framework skill
+   in the snapshot whose `family:` frontmatter key equals that
+   family — **not** by name prefix (per
+   [`SKILL.md` Golden rule 8](SKILL.md#golden-rules)).
 2. **The always-on families** (no user input — per
    [`SKILL.md` Golden rule 8](SKILL.md#golden-rules)):
-   every `setup-*` skill *except* `setup` itself,
-   and every `list-*` skill.
+   every `family: setup` skill *except* `setup` itself,
+   and every `family: utilities` skill.
 
 The always-on set is added on every run, even when the user
 picked no opt-in families, even when `skill-families:` was
 passed with a narrow value, and even on the SUBSEQUENT-
 adoption path where the committed lock only records the
-opt-in pick. Compute the family glob fresh from the snapshot
-contents on disk — do not hard-code skill names.
+opt-in pick. Compute family membership fresh by reading the
+`family:` key from each `SKILL.md` in the snapshot on disk — do
+not hard-code skill names, and do not glob by prefix.
 
 Symlink wiring (targets from [`agents.md`](agents.md)) — the
 **canonical-plus-relay** model, applied identically no matter
@@ -855,29 +906,26 @@ canonical batch is:
    leave the relevant TODO in place. "Auto-detected
    `upstream_clone=<path>`, `upstream_fork_remote=<remote>` — use
    as detected, or customise?"
-3. **`tools.ponymail.enabled`** — *single-select*. "Enable
-   PonyMail MCP as the primary mailing-list-archive backend?
-   (Gmail remains the fallback.)" **Default depends on the
-   manifest:** when `<project-config>/project.md → Mail sources`
-   declares `ponymail` with `mandatory: yes` (the ASF default),
-   default `Yes` and note that it is **required** for this
-   project, not optional — Step 9c walks the install. When
-   `mandatory: no`, default `No` (most non-ASF adopters have not
-   registered the MCP).
+3. **`tools.ponymail.enabled`** — do **not** re-ask; set it from
+   the **Step 5 MCP selection** (`ponymail` ticked → `true`). This
+   value only *records* the Step 5 pick in `user.md`; the install
+   is walked in Step 9c. (If Step 5 was skipped — e.g. no
+   structured tool and the operator deferred MCP — fall back to
+   the manifest default here: `mandatory: yes` → `true` and note
+   it is **required**, `mandatory: no` → `false`.)
 
-If the user picks `Yes` for Ponymail in (3), follow up with **one
-more** question — do not ask it upfront:
+If `ponymail` was selected, collect **one more** value not asked
+in Step 5 — do not ask it upfront:
 
 4. **`tools.ponymail.private_lists`** — *free-text*. "List the
    private mailing-list addresses PonyMail should query (one per
    line, e.g. `security@<adopter>.apache.org`)."
 
-5. **`tools.apache-projects.enabled`** — *single-select*. "Enable
-   the Apache Projects metadata MCP (read-only ASF rosters /
-   people / releases)?" **Default `Yes` for ASF projects** (the
-   manifest declares `project_metadata.mandatory: true`); default
-   `No` otherwise. Step 9c walks the install — the same `comdev`
-   checkout serves both MCP servers.
+5. **`tools.apache-projects.enabled`** — do **not** re-ask; set it
+   from the **Step 5 MCP selection** (`apache-projects` ticked →
+   `true`). Step 9c walks the install — the same `comdev` checkout
+   serves both MCP servers. (Same Step-5-skipped fallback as (3):
+   `project_metadata.mandatory: true` → `true`, else `false`.)
 
 Free-form chat is the fallback when the harness has no
 structured-Q&A tool. In that case still respect the order above
@@ -963,7 +1011,8 @@ are handled — both are read-only and scoped.
 
 ## Step 9d — gmail-plaintext MCP (optional, Gmail drafters)
 
-**Run this step only for operators who draft mail from an agent**
+**Run this step when `gmail-plaintext` was ticked in the Step 5
+MCP selection** — i.e. for operators who draft mail from an agent
 (the `security` family's mailing-list replies, release announcements,
 etc.). It is **optional** and not ASF-gated — unlike the comdev
 servers in 9c, this one ships **in-repo** as part of the

--- a/skills/setup/upgrade.md
+++ b/skills/setup/upgrade.md
@@ -313,16 +313,20 @@ silent on families). Compose the **effective family set**
 for this upgrade as:
 
 - **Opt-in families** the project recorded (`security`,
-  `pr-management`, `issue`, or any combination).
+  `pr-management`, `issue`, `release-management`, `repo-health`,
+  `pairing`, `mentoring`, `contributor-growth`, or any
+  combination).
 - **Newly-introduced opt-in families** — families the
   framework now ships that did not exist when the lock was
-  written. Detect by enumerating the prefixes of opt-in
-  families in the snapshot (`security-*`, `pr-management-*`,
-  `issue-*`) and comparing against the lock's recorded set.
-  Any family present in the snapshot but absent from the
-  lock is auto-added to the effective set on this run, and
-  the addition is **written back to `<committed-lock>`**
-  (same fields as
+  written. Detect by reading the distinct `family:` frontmatter
+  keys across the snapshot's `SKILL.md` files, dropping the
+  always-on families (`setup`, `utilities`), and comparing the
+  remaining opt-in set against the lock's recorded set — **not**
+  by name prefix, since families such as `repo-health` and
+  `contributor-growth` span several prefixes. Any family present
+  in the snapshot but absent from the lock is auto-added to the
+  effective set on this run, and the addition is **written back
+  to `<committed-lock>`** (same fields as
   [`adopt.md` Step 4](adopt.md#step-4--write-committed-lock-fresh-only)).
   Surface the added family in the upgrade summary so the
   operator sees it; do not prompt — per the framework's
@@ -332,14 +336,14 @@ for this upgrade as:
 - **Always-on families** (always added — never read from
   the lock, never user-configurable, per
   [`SKILL.md` Golden rule 8](SKILL.md#golden-rules)):
-  - every `setup-*` skill in the new snapshot *except*
+  - every `family: setup` skill in the new snapshot *except*
     `setup` itself, and
-  - every `list-*` skill in the new snapshot.
+  - every `family: utilities` skill in the new snapshot.
 
-Compute the always-on set fresh from the snapshot contents
-on disk — it expands automatically when the framework adds
-a new `setup-*` or `list-*` skill in a release, and
-contracts on a rename / removal without code changes here.
+Compute the always-on set fresh from the snapshot's `family:`
+keys on disk — it expands automatically when the framework adds
+a new `family: setup` or `family: utilities` skill in a release,
+and contracts on a rename / removal without code changes here.
 
 Before creating symlinks for a newly-introduced opt-in
 family — or for a newly-present active target dir — reconcile
@@ -739,9 +743,9 @@ setup (bootstrap):
   ✓ in sync   OR   ↻ overwritten from snapshot (reloaded in-flight)
 
 Symlinks (main checkout):
-  Opt-in families:     <security>, <pr-management>, <issue>   (from lock)
-  Newly added opt-in:  <issue>   (introduced since lock was written; lock updated)
-  Always-on families:  setup-*, list-*       (per Golden rule 8)
+  Opt-in families:     <e.g. security, pr-management, release-management>   (from lock)
+  Newly added opt-in:  <e.g. repo-health>   (introduced since lock was written; lock updated)
+  Always-on families:  setup, utilities       (per Golden rule 8)
   ✓ <list of unchanged symlinks>
   + <list of newly-created symlinks (skill present in the
      effective family set but missing from an active target dir)>

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -215,8 +215,9 @@ in a given active target dir, classify it (a skill missing
 from `.agents/skills/` is as much a gap as one missing from
 `.claude/skills/`):
 
-- **Always-on family** (every `setup-*` *except*
-  `setup` itself, and every `list-*` — per
+- **Always-on family** (every `family: setup` skill *except*
+  `setup` itself, and every `family: utilities` skill — read the
+  `family:` frontmatter key, per
   [`SKILL.md` Golden rule 8](SKILL.md#golden-rules)) →
   surface as ✗. These families are not opt-in; missing
   symlinks here indicate a broken install or a skipped
@@ -543,7 +544,7 @@ hit these constantly; pre-allowing them removes the
 repetitive confirmation prompts without weakening the
 boundary. Tailor the recommendation to the families the
 adopter opted into via
-[`<committed-lock>` → `skill-families`](adopt.md#step-5--pick-the-skill-families):
+[`<committed-lock>` → `skill-families`](adopt.md#step-5--pick-the-skill-families-and-mcp-servers):
 
 - **`security` family** —
   - `mcp__claude_ai_Gmail__get_thread`

--- a/skills/setup/worktree-init.md
+++ b/skills/setup/worktree-init.md
@@ -101,10 +101,11 @@ Compose the **effective family set** for this worktree:
 - **Opt-in families** the project recorded — read from
   `<main>/.apache-magpie.lock` (the committed lock; the
   worktree shares it via git).
-- **Always-on families** — every `setup-*` skill in the
+- **Always-on families** — every `family: setup` skill in the
   snapshot *except* `setup` itself, and every
-  `list-*` skill, per
-  [`SKILL.md` Golden rule 8](SKILL.md#golden-rules). These
+  `family: utilities` skill, per
+  [`SKILL.md` Golden rule 8](SKILL.md#golden-rules) (read the
+  `family:` frontmatter key, not the name prefix). These
   are added unconditionally, never read from the lock.
 
 Wiring follows the **canonical-plus-relay** model

--- a/skills/skill-reconciler/SKILL.md
+++ b/skills/skill-reconciler/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-skill-reconciler
+family: utilities
 description: |
   Compare two near-duplicate skills — typically an ASF variant and a
   non-ASF or multi-project variant — and classify every difference as

--- a/skills/workflow-security-audit/SKILL.md
+++ b/skills/workflow-security-audit/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-workflow-security-audit
+family: repo-health
 mode: Triage
 description: |
   Read-only GitHub Actions workflow security audit for one repository,

--- a/skills/write-skill/SKILL.md
+++ b/skills/write-skill/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-write-skill
+family: utilities
 description: |
   Author a new skill for the Apache Magpie framework, or update
   an existing one. Walks the user through the framework's skill

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -320,8 +320,31 @@ _CAPABILITY_TOKEN_RE = re.compile(r"`?((?:capability|contract|substrate):[a-z-]+
 _ITALIC_PARENS_RE = re.compile(r"\*\(.*?\)\*")
 
 REQUIRED_FRONTMATTER_KEYS = {"name", "description", "license", "capability"}
-OPTIONAL_FRONTMATTER_KEYS = {"when_to_use", "mode", "organization", "status", "source"}
+OPTIONAL_FRONTMATTER_KEYS = {"when_to_use", "mode", "organization", "status", "source", "family"}
 ALLOWED_LICENSES = {"Apache-2.0"}
+
+# Canonical skill-family vocabulary.  Skills declare their family via a
+# ``family:`` frontmatter key; `/magpie-setup` reads it to group the
+# adopt/upgrade install choice and to wire the family's symlinks (see
+# skills/setup/SKILL.md Golden rule 8).  ``setup`` and ``utilities`` are the
+# always-on families (never offered as an opt-in); the rest are opt-in.
+ALLOWED_FAMILIES: frozenset[str] = frozenset(
+    {
+        "setup",
+        "utilities",
+        "security",
+        "issue",
+        "release-management",
+        "pr-management",
+        "repo-health",
+        "pairing",
+        "mentoring",
+        "contributor-growth",
+    }
+)
+# The two families that are wired unconditionally and never appear in the
+# adopt/upgrade opt-in prompt (Golden rule 8).
+ALWAYS_ON_FAMILIES: frozenset[str] = frozenset({"setup", "utilities"})
 
 # Documented skill lifecycle vocabulary.  Skills may declare a ``status:``
 # frontmatter key; its value must be one of these strings.  Spec lifecycle
@@ -916,6 +939,14 @@ def validate_frontmatter(path: Path, text: str, root: Path | None = None) -> Ite
             path,
             1,
             f"frontmatter mode '{fm['mode']}' not in {sorted(ALLOWED_MODES)} (see docs/modes.md)",
+        )
+
+    if "family" in fm and fm["family"] not in ALLOWED_FAMILIES:
+        yield Violation(
+            path,
+            1,
+            f"frontmatter family '{fm['family']}' not in {sorted(ALLOWED_FAMILIES)} "
+            f"(see skills/setup/SKILL.md Golden rule 8)",
         )
 
     if fm.get("capability"):


### PR DESCRIPTION
## What

Adoption only ever offered three opt-in families (`security`, `pr-management`, `issue`). `release-management`, `repo-health`, `pairing`, `mentoring`, and `contributor-growth` had **no install path** because family membership was inferred from the skill-name prefix, which cannot express families that span several prefixes (e.g. `repo-health` covers `ci-`/`workflow-`/`dependency-`/`license-`/`flaky-`).

## Changes

- **`family:` frontmatter** — every skill now declares its family, validated against `ALLOWED_FAMILIES` in `skill-and-tool-validator`.
- **`/magpie-setup` reads `family:`** from the snapshot instead of prefix-globbing — Golden rule 8, `adopt.md` Step 5 & Step 8, `upgrade.md`, `worktree-init.md`, `verify.md`.
- **`adopt.md` Step 5 rewritten** into a single install choice offering all **eight** opt-in families **and** the three MCP servers (`ponymail`, `apache-projects`, `gmail-plaintext`) in one prompt; `setup` / `utilities` stay always-on (never prompted).
- **`setup-status/collect_status.py`** now reads `family:` (was a prefix heuristic) — verified against the live repo, 0 skills unclassified.
- **`README.md`** families table updated: 10 families, `pairing` added, corrected counts.

## Validation

`skill-and-tool-validate`, `ruff`, `mypy`, `pytest`, and the lychee link check all pass.
