### PR TITLE
feat(skills): require family/mode/when_to_use frontmatter; add Meta mode

### DIFF
--- a/docs/modes.md
+++ b/docs/modes.md
@@ -13,7 +13,7 @@
   - [Drafting](#drafting)
   - [Pairing](#pairing)
   - [Agentic Autonomous](#agentic-autonomous)
-  - [Outside the modes](#outside-the-modes)
+  - [Meta](#meta)
   - [Mode lifecycle](#mode-lifecycle)
   - [Cross-references](#cross-references)
 
@@ -63,10 +63,11 @@ Autonomous* (the renamed former *Auto-merge*).
 | **Mentoring** | *(Agentic Mentoring)* Joins issue and PR threads in a teaching register: clarifying questions, pointers to project conventions, paired examples from prior PRs, hand-off to a human when scope exceeds the agent. Also authors net-new good first issues, curates the existing backlog, and explains filed issues to newcomers to lower onboarding latency. | experimental | 7 |
 | **Drafting** | *(Agentic Drafting)* Agent drafts a fix for a well-scoped problem and opens a PR; every PR is reviewed and merged by a human committer. | stable (security-only); experimental (issue-management, audit-findings, release-management family) | 9 |
 | **Pairing** | *(Agentic Pairing)* Developer-side dev-cycle skills with mentorship intrinsic — multi-agent review pipelines, self-review and pre-flight patterns, scoped fix drafting under the developer's driver's seat. | experimental | 3 |
+| **Meta** | *(framework infrastructure & authoring)* Adoption, isolation, upgrade, status, and skill-authoring flows plus read-only stats dashboards' framework plumbing. These skills are framework machinery rather than a maintainership mode; they do not act on issues, PRs, or contributor threads on their own. | stable | 17 |
 | **Agentic Autonomous** | Auto-merge restricted to objectively boring change classes only (lint, dependency bumps inside an allow-list, license-header insertion, formatting, broken-link repair). | off | 0 |
 
-A few skills sit **outside** the mode taxonomy by design — see
-[Outside the modes](#outside-the-modes) below.
+Framework-infrastructure and authoring skills carry the **Meta**
+mode — see [Meta](#meta) below.
 
 ## Triage
 
@@ -276,16 +277,21 @@ declared per-adopter in `<project-config>/` and gated by an
 allow-list that the framework refuses to grow without an
 adopter PR.
 
-## Outside the modes
+## Meta
 
-Several skills are framework infrastructure rather than
-maintainership modes. They support adoption, isolation, and
-upgrade flows; they do not act on issues, PRs, or contributor
-threads on their own.
+The **Meta** mode (`mode: Meta`) covers skills that are framework
+machinery rather than a maintainership mode: adoption, isolation,
+upgrade, status, and skill-authoring flows, plus read-only stats
+dashboards and evidence producers. They support the framework and
+the maintainer's own tooling; they do not act on issues, PRs, or
+contributor threads on their own. The always-on `setup` and
+`utilities` families live entirely in this mode.
 
 | Skill | Purpose |
 |---|---|
 | [`setup`](../skills/setup/SKILL.md) | Adopt the framework into an adopter repo; manage the snapshot, symlinks, and overrides. |
+| [`setup-upstream-fix`](../skills/setup-upstream-fix/SKILL.md) | Turn a framework bug hit while running a skill into a fix PR against `apache/magpie`. |
+| [`skill-reconciler`](../skills/skill-reconciler/SKILL.md) | Compare two near-duplicate skills and classify each difference as ALLOWED / DRIFT / SAFETY-BASELINE. Read-only. |
 | [`issue-reproducer`](../skills/issue-reproducer/SKILL.md) | Per-issue code extraction + execution; produces structured evidence. Read-only on the tracker. |
 | [`issue-reassess-stats`](../skills/issue-reassess-stats/SKILL.md) | Read-only dashboard over reassessment-campaign verdict.json files. |
 | [`setup-isolated-setup-install`](../skills/setup-isolated-setup-install/SKILL.md) | Install the credential-isolation sandbox harness. |
@@ -301,11 +307,14 @@ threads on their own.
 | [`list-skills`](../skills/list-skills/SKILL.md) | Print a live index of every skill in this repository grouped by family, with each skill's name and first-sentence description. |
 | [`write-skill`](../skills/write-skill/SKILL.md) | Author a new framework skill or update an existing one: frontmatter, placeholder convention, injection defences, Privacy-LLM gate-check, and validator sign-off. |
 
-The `setup*` skills ship as a single **setup family** — see
-[`docs/setup/README.md`](setup/README.md). The remaining skills
-(`committer-onboarding`, `security-tracker-stats-dashboard`,
-`optimize-skill`, `list-skills`, `write-skill`) are standalone
-framework utilities.
+The `setup*` skills ship as the always-on **setup family** — see
+[`docs/setup/README.md`](setup/README.md) — and `list-skills`,
+`optimize-skill`, `write-skill`, and `skill-reconciler` as the
+always-on **utilities family**. The rest (`committer-onboarding`,
+`security-tracker-stats-dashboard`, `issue-reproducer`,
+`issue-reassess-stats`) are opt-in family skills that nonetheless
+carry the Meta mode because they are read-only dashboards or
+evidence producers, not maintainership actions.
 
 ## Mode lifecycle
 

--- a/docs/release-management/README.md
+++ b/docs/release-management/README.md
@@ -219,7 +219,7 @@ The family's read-only dashboard skill
 (`release-audit-report`)
 sits in Agentic Triage because it classifies and reports against existing
 state, not because it routes inbound work. The
-[`docs/modes.md` § Outside the modes](../modes.md#outside-the-modes)
+[`docs/modes.md` § Meta](../modes.md#meta)
 section is reserved for framework infrastructure (`setup-*`,
 `issue-reassess-stats`, isolation tooling) and the audit skill
 does not belong there, it is project-facing maintainership work.

--- a/docs/utilities/README.md
+++ b/docs/utilities/README.md
@@ -70,7 +70,7 @@ with the framework's own conventions rather than with adopter pilots.
 
 ## Cross-references
 
-- [`docs/modes.md` § Outside the modes](../modes.md#outside-the-modes) — why
+- [`docs/modes.md` § Meta](../modes.md#meta) — why
   these skills sit outside the maintainership-mode taxonomy.
 - [`docs/spec-driven-development.md`](../spec-driven-development.md) — the
   authoring loop `write-skill` and `optimize-skill` support.

--- a/skills/committer-onboarding/SKILL.md
+++ b/skills/committer-onboarding/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-committer-onboarding
 family: contributor-growth
+mode: Meta
 organization: ASF
 description: |
   Post-vote committer and PMC onboarding for Apache projects.

--- a/skills/dependency-license-audit/SKILL.md
+++ b/skills/dependency-license-audit/SKILL.md
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-dependency-license-audit
+family: repo-health
 mode: Triage
 description: |
   Read-only license audit of a project's direct and transitive dependency

--- a/skills/issue-reassess-stats/SKILL.md
+++ b/skills/issue-reassess-stats/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-reassess-stats
 family: issue
+mode: Meta
 description: |
   Read-only dashboard over a directory of `verdict.json` files
   produced by `issue-reassess` campaigns. Surfaces a health

--- a/skills/issue-reproducer/SKILL.md
+++ b/skills/issue-reproducer/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-issue-reproducer
 family: issue
+mode: Meta
 description: |
   For a single `<issue-tracker>` issue identifying a code-level
   bug, extract the reporter's example code from the issue body,

--- a/skills/list-skills/SKILL.md
+++ b/skills/list-skills/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-list-skills
 family: utilities
+mode: Meta
 description: |
   Print a human-readable index of every skill in this repository,
   grouped by family prefix (`pr-management`, `security`, `setup`,

--- a/skills/optimize-skill/SKILL.md
+++ b/skills/optimize-skill/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-optimize-skill
 family: utilities
+mode: Meta
 description: |
   Optimize an existing framework skill (or sweep a set of them) by
   applying the restructuring patterns proven on the security-skill

--- a/skills/pairing-multi-agent-review/SKILL.md
+++ b/skills/pairing-multi-agent-review/SKILL.md
@@ -4,7 +4,6 @@
 name: magpie-pairing-multi-agent-review
 family: pairing
 mode: Pairing
-status: experimental
 description: |
   Fan a local diff through three independent, axis-focused review passes
   (correctness, security, conventions), then merge the findings into a

--- a/skills/pr-management-quick-merge/SKILL.md
+++ b/skills/pr-management-quick-merge/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-quick-merge
 family: pr-management
+mode: Triage
 description: |
   Identify trivial, low-risk pull requests in the `ready for maintainer review`
   queue of <upstream> that pass every quality gate and touch only supplementary

--- a/skills/pr-management-stats/SKILL.md
+++ b/skills/pr-management-stats/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-pr-management-stats
 family: pr-management
+mode: Triage
 description: |
   Read-only maintainer dashboard for the open-PR backlog of <upstream>.
   Surfaces a health rating, prioritised action recommendations, weekly closure

--- a/skills/security-issue-import-via-forwarder/SKILL.md
+++ b/skills/security-issue-import-via-forwarder/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-issue-import-via-forwarder
 family: security
+mode: Triage
 description: |
   Optional sub-skill of `security-issue-import`,
   `security-issue-invalidate`, and `security-issue-sync` that

--- a/skills/security-tracker-stats-dashboard/SKILL.md
+++ b/skills/security-tracker-stats-dashboard/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-security-tracker-stats-dashboard
 family: security
+mode: Meta
 description: Generate a self-contained HTML dashboard of `<tracker>` repository statistics for security-team review.
 when_to_use: |
   Invoke when the user says "regenerate the tracker dashboard", "show

--- a/skills/setup-isolated-setup-doctor/SKILL.md
+++ b/skills/setup-isolated-setup-doctor/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-doctor
 family: setup
+mode: Meta
 description: |
   Probe the secure-agent setup for in-session functional
   restrictions that block legitimate workflows. Three live

--- a/skills/setup-isolated-setup-install/SKILL.md
+++ b/skills/setup-isolated-setup-install/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-install
 family: setup
+mode: Meta
 description: |
   Guide an adopter through the first-time install of the
   framework's secure agent setup (bubblewrap + socat +

--- a/skills/setup-isolated-setup-update/SKILL.md
+++ b/skills/setup-isolated-setup-update/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-update
 family: setup
+mode: Meta
 description: |
   Surface drift between the user's installed secure agent setup
   and the framework's latest (framework checkout, pinned tools,

--- a/skills/setup-isolated-setup-verify/SKILL.md
+++ b/skills/setup-isolated-setup-verify/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-isolated-setup-verify
 family: setup
+mode: Meta
 description: |
   Walk the verification checklist for the framework's secure
   agent setup and report ✓ done / ✗ missing / ⚠ partial for

--- a/skills/setup-override-upstream/SKILL.md
+++ b/skills/setup-override-upstream/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-override-upstream
 family: setup
+mode: Meta
 description: |
   Walk an adopter through promoting a local
   `.apache-magpie-overrides/<skill>.md` file into a PR

--- a/skills/setup-shared-config-sync/SKILL.md
+++ b/skills/setup-shared-config-sync/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-shared-config-sync
 family: setup
+mode: Meta
 description: |
   Commit + push the user's shared Claude config to the
   `~/.claude-config` private dotfile-style sync repo. Inspects

--- a/skills/setup-status/SKILL.md
+++ b/skills/setup-status/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-status
 family: setup
+mode: Meta
 description: |
   Show how the apache-magpie framework is adopted in the current
   repo, then adjust that setup in place. Renders a Markdown

--- a/skills/setup-upstream-fix/SKILL.md
+++ b/skills/setup-upstream-fix/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup-upstream-fix
 family: setup
+mode: Meta
 description: |
   Turn a framework bug or quirk the agent hit while running a
   Magpie skill or tool into a fix PR against `apache/magpie` —

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-setup
 family: setup
+mode: Meta
 description: |
   Adopt and maintain the apache-magpie framework in a project
   repo via the snapshot-based adoption mechanism. The only

--- a/skills/skill-reconciler/SKILL.md
+++ b/skills/skill-reconciler/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-skill-reconciler
 family: utilities
+mode: Meta
 description: |
   Compare two near-duplicate skills — typically an ASF variant and a
   non-ASF or multi-project variant — and classify every difference as

--- a/skills/write-skill/SKILL.md
+++ b/skills/write-skill/SKILL.md
@@ -3,6 +3,7 @@
 # https://www.apache.org/licenses/LICENSE-2.0
 name: magpie-write-skill
 family: utilities
+mode: Meta
 description: |
   Author a new skill for the Apache Magpie framework, or update
   an existing one. Walks the user through the framework's skill

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -74,7 +74,7 @@ skills/:
     the actual per-section row counts, and every live skill with a
     ``mode:`` frontmatter must appear in the corresponding section.
     Advisory only — never fails the run unless ``--strict``.
-14. Multi-capability form advisory (SOFT) — when a ``capability:``
+13. Multi-capability form advisory (SOFT) — when a ``capability:``
     value looks like multiple tokens joined by a space or comma (e.g.
     ``capability: capability:fix capability:resolve``), the skill is
     using string form for what should be a YAML list.  Use the list
@@ -82,14 +82,14 @@ skills/:
     so each entry is validated individually.  Advisory only — the
     vocabulary check (aspect 1) already rejects the joined string, but
     this advisory gives a more actionable error message.
-15. Override-file contract (SOFT) — when a ``.apache-magpie-overrides/``
+14. Override-file contract (SOFT) — when a ``.apache-magpie-overrides/``
     directory exists in the repo, every ``<skill>.md`` file inside it is
     checked to ensure it carries the canonical ``apache-magpie agentic
     override`` header comment and does not contain heuristic patterns that
     attempt to weaken the framework's safety / confidentiality / privacy /
     external-content-as-data baseline.  Advisory only — prose explanations
     of what NOT to do can false-positive here.
-16. Project-template drift (SOFT) — compares ``projects/_template/``
+15. Project-template drift (SOFT) — compares ``projects/_template/``
     with ``projects/non-asf-example/`` for structural drift: files
     referenced in the example README must exist on disk, every config
     file in the example must be documented in its README, and config
@@ -97,7 +97,7 @@ skills/:
     headings (``project.md`` and ``README.md`` are excluded from the
     h2 comparison because their structures intentionally differ by
     organization profile). Advisory only.
-17. Branch-name confidentiality (SOFT) — scans ``git checkout -b`` and
+16. Branch-name confidentiality (SOFT) — scans ``git checkout -b`` and
     ``git switch -c`` examples in fenced code blocks across skills and
     docs and flags any concrete branch name that contains an
     embargo-breaking term: a CVE ID (``CVE-YYYY-NNNNN``), ``security``,
@@ -105,7 +105,7 @@ skills/:
     public branch names must not reveal embargo context.  Lines in
     explicit "bad example" contexts (containing ``**bad**`` or
     ``bad:``) are exempt.  Advisory only.
-18. Capability taxonomy coverage (SOFT) — reads the Axis 1 (skill) and
+17. Capability taxonomy coverage (SOFT) — reads the Axis 1 (skill) and
     Axis 2 (tool) capability vocabulary tables from
     ``docs/labels-and-capabilities.md`` and verifies that every taxonomy
     entry appears in at least one row of the corresponding mapping table
@@ -114,20 +114,20 @@ skills/:
     Definition column are exempted.  Also cross-checks that the hardcoded
     ``SKILL_CAPABILITIES`` and ``TOOL_CAPABILITIES`` code constants match
     the parsed vocabulary so code and docs stay in sync.  Advisory only.
-19. Mail-adapter privacy-boundary (SOFT) — ``contract:mail-source``
+18. Mail-adapter privacy-boundary (SOFT) — ``contract:mail-source``
     and ``contract:mail-archive`` adapter READMEs must declare that
     fetched mail content is external data (not instructions) and must
     mention the prompt-injection risk in embedded mail content. Both
     are advisories — the check warns without failing the run so legacy
     adapters can be brought into compliance deliberately.
-20. SKILL.md line-length limit (SOFT) — ``SKILL.md`` entrypoint files
+19. SKILL.md line-length limit (SOFT) — ``SKILL.md`` entrypoint files
     must stay under ``SKILL_LINE_LIMIT`` (500) lines per PRINCIPLE 14.
     Reference material beyond that limit should move into sibling
     markdown files linked one level deep, with no unreferenced siblings.
     Advisory only — existing skills that pre-date this check are flagged
     for gradual migration; the check prevents new oversized entrypoints
     from being merged unnoticed.
-21. No-default-telemetry import check (SOFT) — PRINCIPLE 10 guarantees
+20. No-default-telemetry import check (SOFT) — PRINCIPLE 10 guarantees
     zero outbound calls from the framework unless a skill's adapter
     action explicitly makes them.  Only ``contract:*`` adapter tools and
     the ``egress-gateway`` proxy are declared egress surfaces; all other

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -74,12 +74,6 @@ skills/:
     the actual per-section row counts, and every live skill with a
     ``mode:`` frontmatter must appear in the corresponding section.
     Advisory only — never fails the run unless ``--strict``.
-13. Status field validation (HARD) — when a skill declares a
-    ``status:`` frontmatter key, its value must be from the
-    documented lifecycle vocabulary (``ALLOWED_SKILL_STATUSES``).
-    An unknown status (e.g. ``proposed``, ``done``) is a HARD failure
-    because those values belong to the spec lifecycle, not skill
-    lifecycle.
 14. Multi-capability form advisory (SOFT) — when a ``capability:``
     value looks like multiple tokens joined by a space or comma (e.g.
     ``capability: capability:fix capability:resolve``), the skill is
@@ -319,8 +313,8 @@ _CAPABILITY_TOKEN_RE = re.compile(r"`?((?:capability|contract|substrate):[a-z-]+
 # parens.
 _ITALIC_PARENS_RE = re.compile(r"\*\(.*?\)\*")
 
-REQUIRED_FRONTMATTER_KEYS = {"name", "description", "license", "capability"}
-OPTIONAL_FRONTMATTER_KEYS = {"when_to_use", "mode", "organization", "status", "source", "family"}
+REQUIRED_FRONTMATTER_KEYS = {"name", "description", "license", "capability", "family", "mode", "when_to_use"}
+OPTIONAL_FRONTMATTER_KEYS = {"organization", "mcp"}
 ALLOWED_LICENSES = {"Apache-2.0"}
 
 # Canonical skill-family vocabulary.  Skills declare their family via a
@@ -345,12 +339,6 @@ ALLOWED_FAMILIES: frozenset[str] = frozenset(
 # The two families that are wired unconditionally and never appear in the
 # adopt/upgrade opt-in prompt (Golden rule 8).
 ALWAYS_ON_FAMILIES: frozenset[str] = frozenset({"setup", "utilities"})
-
-# Documented skill lifecycle vocabulary.  Skills may declare a ``status:``
-# frontmatter key; its value must be one of these strings.  Spec lifecycle
-# values (``proposed``, ``done``) belong only in spec-loop spec files and
-# are rejected here so a spec status cannot accidentally appear on a skill.
-ALLOWED_SKILL_STATUSES: frozenset[str] = frozenset({"experimental"})
 
 # Canonical capability taxonomy — two orthogonal axes per RFC-AI-0005;
 # docs/labels-and-capabilities.md is authoritative.
@@ -535,8 +523,6 @@ TRIGGER_PRESERVATION_CATEGORY = "trigger_preservation"
 # Pattern 4 — injection-guard callout.  Missing callout = HARD; unfilled TODO = SOFT.
 INJECTION_GUARD_CATEGORY = "injection_guard"
 INJECTION_GUARD_TODO_CATEGORY = "injection_guard_todo"
-# Skill lifecycle status vocabulary check (HARD).
-STATUS_CATEGORY = "skill_status"
 # Space/comma-separated multi-capability form check (SOFT advisory).
 MULTI_CAPABILITY_CATEGORY = "multi_capability_form"
 
@@ -621,7 +607,6 @@ HARD_CATEGORIES: frozenset[str] = frozenset(
         INJECTION_GUARD_CATEGORY,
         NAME_CONVENTION_CATEGORY,
         LICENSE_HEADER_CATEGORY,
-        STATUS_CATEGORY,
         SKILL_SOURCE_CATEGORY,
     }
 )
@@ -993,16 +978,6 @@ def validate_frontmatter(path: Path, text: str, root: Path | None = None) -> Ite
                     f"frontmatter capability '{entry}' not in {sorted(SKILL_CAPABILITIES)} "
                     f"(skills use Axis-1 capability:* values; see docs/labels-and-capabilities.md)",
                 )
-
-    if fm.get("status") and fm["status"] not in ALLOWED_SKILL_STATUSES:
-        yield Violation(
-            path,
-            1,
-            f"frontmatter status '{fm['status']}' not in {sorted(ALLOWED_SKILL_STATUSES)} "
-            f"(documented skill lifecycle vocabulary; spec values like 'proposed'/'done' "
-            f"belong in spec-loop specs, not in skill frontmatter)",
-            category=STATUS_CATEGORY,
-        )
 
     desc_len = len(fm.get("description", ""))
     wtu_len = len(fm.get("when_to_use", ""))

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -61,7 +61,6 @@ from skill_and_tool_validator import (
     SKILL_LINE_LIMIT_CATEGORY,
     SKILL_SOURCE_CATEGORY,
     SOFT_CATEGORIES,
-    STATUS_CATEGORY,
     TEMPLATE_DRIFT_CATEGORY,
     TOOL_CAPABILITIES,
     TRIGGER_PRESERVATION_CATEGORY,
@@ -125,7 +124,7 @@ from skill_and_tool_validator import (
 
 class TestParseFrontmatter:
     def test_valid_frontmatter(self) -> None:
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n# heading\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n# heading\n"
         fm = parse_frontmatter(text)
         assert fm is not None
         assert fm["name"] == "foo"
@@ -139,7 +138,7 @@ class TestParseFrontmatter:
             "description: |\n"
             "  First line of description.\n"
             "  Second line.\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
+            "capability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "---\n"
         )
         fm = parse_frontmatter(text)
@@ -162,7 +161,7 @@ class TestParseFrontmatter:
             "  Paragraph one.\n"
             "\n"
             "  Paragraph two, which used to be dropped.\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
+            "capability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "---\n"
         )
         fm = parse_frontmatter(text)
@@ -186,13 +185,13 @@ class TestParseFrontmatter:
 class TestValidateFrontmatter:
     def test_valid(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert violations == []
 
     def test_missing_name(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = "---\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert len(violations) == 1
         assert "name" in violations[0].message
@@ -208,7 +207,7 @@ class TestValidateFrontmatter:
 
     def test_empty_value(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: \ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: \ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert any("name' is empty" in v.message for v in violations)
 
@@ -221,20 +220,27 @@ class TestValidateFrontmatter:
     def test_valid_mode(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
         for mode in ("Triage", "Mentoring", "Drafting", "Pairing"):
-            text = f"---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\nmode: {mode}\n---\n"
+            text = f"---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nwhen_to_use: when it applies\nlicense: Apache-2.0\nmode: {mode}\n---\n"
             violations = list(validate_frontmatter(path, text))
             assert violations == [], f"mode '{mode}' should be valid"
 
     def test_invalid_mode(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\nmode: Auto-merge\n---\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nwhen_to_use: when it applies\nlicense: Apache-2.0\nmode: Auto-merge\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert any("mode" in v.message and "'Auto-merge'" in v.message for v in violations)
 
-    def test_mode_optional(self, tmp_path: Path) -> None:
-        # Skills without a mode (e.g. setup-* infrastructure) must not fail.
+    def test_mode_required(self, tmp_path: Path) -> None:
+        # mode is a required key: a skill without one must fail.
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
+        violations = list(validate_frontmatter(path, text))
+        assert any("mode" in v.message for v in violations)
+
+    def test_meta_mode_valid(self, tmp_path: Path) -> None:
+        # Framework infrastructure/meta skills declare mode: Meta.
+        path = tmp_path / "SKILL.md"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: setup\nmode: Meta\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert violations == []
 
@@ -262,7 +268,7 @@ class TestValidateFrontmatter:
         path = tmp_path / "SKILL.md"
         desc = "a" * 800
         wtu = "b" * 700
-        text = f"---\nname: foo\ndescription: {desc}\nwhen_to_use: {wtu}\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = f"---\nname: foo\ndescription: {desc}\nwhen_to_use: {wtu}\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert violations == []
 
@@ -270,7 +276,7 @@ class TestValidateFrontmatter:
         path = tmp_path / "SKILL.md"
         desc = "a" * 1000
         wtu = "b" * (MAX_METADATA_CHARS - 1000 + 1)
-        text = f"---\nname: foo\ndescription: {desc}\nwhen_to_use: {wtu}\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = f"---\nname: foo\ndescription: {desc}\nwhen_to_use: {wtu}\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert any("truncates" in v.message and str(MAX_METADATA_CHARS) in v.message for v in violations)
 
@@ -283,7 +289,7 @@ class TestValidateFrontmatter:
             "---\n"
             "name: foo\n"
             "description: bar\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
+            "capability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "argument-hint: [--quick|--standard|--deep] <idea>\n"
             "---\n"
         )
@@ -299,7 +305,7 @@ class TestValidateFrontmatter:
             "---\n"
             "name: setup\n"
             "description: bar\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
+            "capability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "argument-hint: [adopt|upgrade|worktree-init|verify|override skill-name|unadopt]\n"
             "---\n"
         )
@@ -322,7 +328,7 @@ class TestValidateFrontmatter:
             f"name: foo\n"
             f"description: {desc}\n"
             f"when_to_use: {wtu}\n"
-            f"capability: capability:platform\nlicense: Apache-2.0\n"
+            f"capability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             f"argument-hint: {hint}\n"
             f"---\n"
         )
@@ -330,7 +336,7 @@ class TestValidateFrontmatter:
         assert violations == [], "argument-hint must not count toward description+when_to_use budget"
 
     def test_metadata_block_scalar_indicator_not_counted(self) -> None:
-        text = f"---\nname: foo\ndescription: |\n  {'a' * 100}\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        text = f"---\nname: foo\ndescription: |\n  {'a' * 100}\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         fm = parse_frontmatter(text)
         assert fm is not None
         assert not fm["description"].startswith("|")
@@ -338,7 +344,7 @@ class TestValidateFrontmatter:
 
     def test_capability_single_string(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:triage\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:triage\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert violations == []
 
@@ -347,20 +353,20 @@ class TestValidateFrontmatter:
         text = (
             "---\nname: foo\ndescription: bar\n"
             "capability:\n  - capability:intake\n  - capability:platform\n"
-            "license: Apache-2.0\n---\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
         violations = list(validate_frontmatter(path, text))
         assert violations == []
 
     def test_capability_missing(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: foo\ndescription: bar\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert any("capability" in v.message for v in violations)
 
     def test_capability_invalid_value(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:bogus\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:bogus\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert any("capability:bogus" in v.message for v in violations)
 
@@ -369,7 +375,7 @@ class TestValidateFrontmatter:
         text = (
             "---\nname: foo\ndescription: bar\n"
             "capability:\n  - capability:platform\n  - capability:invented\n"
-            "license: Apache-2.0\n---\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
         violations = list(validate_frontmatter(path, text))
         # The "subject" of each violation is the first single-quoted token after
@@ -384,53 +390,6 @@ class TestValidateFrontmatter:
 
 
 # ---------------------------------------------------------------------------
-# Status field: must be from ALLOWED_SKILL_STATUSES when present (HARD)
-# ---------------------------------------------------------------------------
-
-
-class TestStatusValidation:
-    def test_valid_status_experimental(self, tmp_path: Path) -> None:
-        path = tmp_path / "SKILL.md"
-        text = (
-            "---\nname: foo\ndescription: bar\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
-            "status: experimental\n---\n"
-        )
-        violations = list(validate_frontmatter(path, text))
-        assert not any(v.category == "skill_status" for v in violations)
-
-    def test_invalid_status_proposed(self, tmp_path: Path) -> None:
-        path = tmp_path / "SKILL.md"
-        text = (
-            "---\nname: foo\ndescription: bar\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
-            "status: proposed\n---\n"
-        )
-        violations = list(validate_frontmatter(path, text))
-        assert any("skill_status" == v.category and "proposed" in v.message for v in violations)
-
-    def test_invalid_status_done(self, tmp_path: Path) -> None:
-        path = tmp_path / "SKILL.md"
-        text = (
-            "---\nname: foo\ndescription: bar\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
-            "status: done\n---\n"
-        )
-        violations = list(validate_frontmatter(path, text))
-        assert any("skill_status" == v.category for v in violations)
-
-    def test_status_absent_is_ok(self, tmp_path: Path) -> None:
-        path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
-        violations = list(validate_frontmatter(path, text))
-        assert not any(v.category == "skill_status" for v in violations)
-
-    def test_status_category_is_hard(self) -> None:
-        assert STATUS_CATEGORY in HARD_CATEGORIES
-        assert STATUS_CATEGORY not in SOFT_CATEGORIES
-
-
-# ---------------------------------------------------------------------------
 # Multi-capability form: space/comma-separated string → SOFT advisory
 # ---------------------------------------------------------------------------
 
@@ -441,7 +400,7 @@ class TestMultiCapabilityForm:
         text = (
             "---\nname: foo\ndescription: bar\n"
             "capability: capability:triage capability:fix\n"
-            "license: Apache-2.0\n---\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
         violations = list(validate_frontmatter(path, text))
         assert any(v.category == "multi_capability_form" for v in violations)
@@ -451,7 +410,7 @@ class TestMultiCapabilityForm:
         text = (
             "---\nname: foo\ndescription: bar\n"
             "capability: capability:fix, capability:resolve\n"
-            "license: Apache-2.0\n---\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
         violations = list(validate_frontmatter(path, text))
         assert any(v.category == "multi_capability_form" for v in violations)
@@ -461,14 +420,14 @@ class TestMultiCapabilityForm:
         text = (
             "---\nname: foo\ndescription: bar\n"
             "capability:\n  - capability:fix\n  - capability:resolve\n"
-            "license: Apache-2.0\n---\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
         violations = list(validate_frontmatter(path, text))
         assert not any(v.category == "multi_capability_form" for v in violations)
 
     def test_single_capability_string_clean(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:triage\nlicense: Apache-2.0\n---\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:triage\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         violations = list(validate_frontmatter(path, text))
         assert not any(v.category == "multi_capability_form" for v in violations)
 
@@ -488,7 +447,7 @@ class TestValidateNameConvention:
         skill_dir.mkdir(parents=True)
         path = skill_dir / "SKILL.md"
         path.write_text(
-            f"---\nname: {name}\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n# body\n",
+            f"---\nname: {name}\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n# body\n",
             encoding="utf-8",
         )
         return path
@@ -517,7 +476,7 @@ class TestValidateNameConvention:
         skill_dir.mkdir(parents=True)
         path = skill_dir / "SKILL.md"
         path.write_text(
-            "---\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n# body\n",
+            "---\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n# body\n",
             encoding="utf-8",
         )
         assert list(validate_name_convention(path, path.read_text())) == []
@@ -770,7 +729,7 @@ class TestSubDocFiles:
         skill_dir = root / "skills" / skill_name
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
-            f"---\nname: magpie-{skill_name}\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+            f"---\nname: magpie-{skill_name}\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
             "<!-- SPDX-License-Identifier: Apache-2.0\n     https://www.apache.org/licenses/LICENSE-2.0 -->\n"
             "# body\n",
             encoding="utf-8",
@@ -1094,9 +1053,7 @@ class TestTriggerPreservation:
 # ---------------------------------------------------------------------------
 
 # Minimal valid SKILL.md frontmatter used across injection-guard tests.
-_GUARD_FM = (
-    "---\nname: test-skill\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
-)
+_GUARD_FM = "---\nname: test-skill\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
 
 # A gh-pr-view signal that unambiguously looks like a workflow fetch step.
 _GH_PR_VIEW_SIGNAL = "2. **Fetch the PR.** `gh pr view <N> --json title,body`\n"
@@ -1506,7 +1463,7 @@ class TestSecurityPatterns:
 
 def _fenced_skill_lf(cmd: str) -> str:
     """Wrap *cmd* in a minimal SKILL.md with a fenced bash block."""
-    return f"---\nname: test\ndescription: test\ncapability: capability:platform\nlicense: Apache-2.0\n---\n\n```bash\n{cmd}\n```\n"
+    return f"---\nname: test\ndescription: test\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n\n```bash\n{cmd}\n```\n"
 
 
 class TestLowercaseFField:
@@ -1576,7 +1533,7 @@ class TestLowercaseFField:
         """Inline backtick prose like ``-f title='...'`` must not fire."""
         path = tmp_path / "SKILL.md"
         text = (
-            "---\nname: test\ndescription: test\ncapability: capability:platform\nlicense: Apache-2.0\n---\n\n"
+            "---\nname: test\ndescription: test\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n\n"
             "Avoid using `-f title='value'` — use `-F title=@file` instead.\n"
         )
         violations = list(validate_lowercase_f_field(path, text))
@@ -1586,7 +1543,7 @@ class TestLowercaseFField:
         """Bare prose outside a fenced block must not fire."""
         path = tmp_path / "SKILL.md"
         text = (
-            "---\nname: test\ndescription: test\ncapability: capability:platform\nlicense: Apache-2.0\n---\n\n"
+            "---\nname: test\ndescription: test\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n\n"
             "Run: gh api milestones -f title='v1'\n"
         )
         violations = list(validate_lowercase_f_field(path, text))
@@ -1603,9 +1560,10 @@ class TestLowercaseFField:
     def test_violation_line_number_correct(self, tmp_path: Path) -> None:
         path = tmp_path / "SKILL.md"
         text = _fenced_skill_lf("gh api repos/<tracker>/milestones -f title='v1.0'")
-        # Layout: 1:--- 2:name 3:description 4:capability 5:license 6:--- 7:blank 8:```bash 9:command
+        # Layout: 1:--- 2:name 3:description 4:capability 5:family 6:mode
+        # 7:when_to_use 8:license 9:--- 10:blank 11:```bash 12:command
         violations = list(validate_lowercase_f_field(path, text))
-        assert violations[0].line == 9
+        assert violations[0].line == 12
 
     def test_lowercase_f_field_in_soft_categories(self) -> None:
         assert LOWERCASE_F_FIELD_CATEGORY in SOFT_CATEGORIES
@@ -1649,7 +1607,7 @@ class TestValidateLicenseHeader:
     def test_md_file_is_exempt(self, tmp_path: Path) -> None:
         """Skill .md files declare license via frontmatter, so they need no header."""
         path = tmp_path / "SKILL.md"
-        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nlicense: Apache-2.0\n---\n# Body\n"
+        text = "---\nname: foo\ndescription: bar\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n# Body\n"
         violations = list(validate_license_header(path, text))
         assert violations == []
 
@@ -2220,7 +2178,7 @@ def _make_valid_skill(root: Path, name: str) -> Path:
     skill_dir = root / "skills" / name
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "SKILL.md").write_text(
-        f"---\nname: magpie-{name}\ndescription: A test skill.\ncapability: capability:platform\nlicense: Apache-2.0\n---\n"
+        f"---\nname: magpie-{name}\ndescription: A test skill.\ncapability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         "<!-- SPDX-License-Identifier: Apache-2.0\n     https://www.apache.org/licenses/LICENSE-2.0 -->\n"
         "# Body\nSome content.\n"
     )
@@ -2293,7 +2251,7 @@ class TestMain:
             "---\n"
             "name: magpie-soft-skill\n"
             "description: A test skill.\n"
-            "capability: capability:platform\nlicense: Apache-2.0\n"
+            "capability: capability:platform\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "---\n"
             "<!-- SPDX-License-Identifier: Apache-2.0\n     https://www.apache.org/licenses/LICENSE-2.0 -->\n"
             "```bash\n"
@@ -2335,7 +2293,7 @@ class TestValidateAsfCoupling:
             "---\n"
             "name: magpie-test\n"
             "description: Test skill.\n"
-            "license: Apache-2.0\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "capability: capability:triage\n"
             "---\n" + body
         )
@@ -2483,7 +2441,7 @@ class TestValidateAsfCoupling:
             "name: magpie-test\n"
             "organization: ASF\n"
             "description: Test skill.\n"
-            "license: Apache-2.0\n"
+            "family: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "capability: capability:triage\n"
             "---\n" + body
         )
@@ -3047,7 +3005,7 @@ class TestOrganizationMembership:
     def test_frontmatter_organization_known(self, tmp_path: Path) -> None:
         (tmp_path / "organizations" / "ASF").mkdir(parents=True)
         text = (
-            "---\nname: magpie-x\ndescription: d\nlicense: Apache-2.0\n"
+            "---\nname: magpie-x\ndescription: d\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "capability: capability:platform\norganization: ASF\n---\n\nBody.\n"
         )
         violations = [
@@ -3060,7 +3018,7 @@ class TestOrganizationMembership:
     def test_frontmatter_organization_unknown(self, tmp_path: Path) -> None:
         (tmp_path / "organizations" / "ASF").mkdir(parents=True)
         text = (
-            "---\nname: magpie-x\ndescription: d\nlicense: Apache-2.0\n"
+            "---\nname: magpie-x\ndescription: d\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n"
             "capability: capability:platform\norganization: Nope\n---\n\nBody.\n"
         )
         violations = [
@@ -3171,7 +3129,7 @@ def _seed_capability_repo(
         d = root / "skills" / skill
         d.mkdir()
         (d / "SKILL.md").write_text(
-            f"---\nname: {skill}\ndescription: test\ncapability: {cap}\nlicense: Apache-2.0\n---\n"
+            f"---\nname: {skill}\ndescription: test\ncapability: {cap}\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
 
     for tool, cap in live_tools.items():
@@ -3269,7 +3227,7 @@ class TestValidateCapabilitySync:
         )
         (root / "docs" / "labels-and-capabilities.md").write_text(doc)
         (root / "skills" / "alpha" / "SKILL.md").write_text(
-            "---\nname: alpha\ndescription: test\ncapability: capability:intake\nlicense: Apache-2.0\n---\n"
+            "---\nname: alpha\ndescription: test\ncapability: capability:intake\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
         (root / "tools").mkdir()
         violations = list(validate_capability_sync(root))
@@ -3512,7 +3470,7 @@ class TestValidateEvalCoverage:
         skill_dir = root / "skills" / slug
         skill_dir.mkdir(parents=True, exist_ok=True)
         (skill_dir / "SKILL.md").write_text(
-            f"---\nname: magpie-{slug}\ndescription: test\ncapability: capability:triage\nlicense: Apache-2.0\n---\n"
+            f"---\nname: magpie-{slug}\ndescription: test\ncapability: capability:triage\nfamily: repo-health\nmode: Triage\nwhen_to_use: when it applies\nlicense: Apache-2.0\n---\n"
         )
 
     def _make_eval(self, root: Path, slug: str) -> None:
@@ -3661,7 +3619,7 @@ class TestValidateModeDocConsistency:
         mode_line = f"mode: {mode}\n" if mode else ""
         (skill_dir / "SKILL.md").write_text(
             f"---\nname: magpie-{slug}\ndescription: test skill\n"
-            f"capability: capability:triage\nlicense: Apache-2.0\n{mode_line}---\n"
+            f"capability: capability:triage\nfamily: repo-health\nwhen_to_use: when it applies\nlicense: Apache-2.0\n{mode_line}---\n"
         )
 
     def _make_modes_md(self, root: Path, text: str) -> Path:


### PR DESCRIPTION
## What

Tightens the skill-frontmatter schema so `skill-and-tool-validator` (and its prek hook) **hard-fails** on incomplete frontmatter, instead of silently accepting it.

## Changes

- **Required keys** are now `name, description, license, capability, family, mode, when_to_use` (added `family`, `mode`, `when_to_use` — all three were already present on every shipped skill, so this just enforces it).
- **Optional keys**: `organization` (removed the unused `source` key; `mcp` is not part of the taxonomy).
- **Removed `status` entirely** — it was used by exactly one skill; the value check, `ALLOWED_SKILL_STATUSES`, and `STATUS_CATEGORY` are gone.
- **New `Meta` mode** in `docs/modes.md`: the former "Outside the modes" section is reframed as the `Meta` mode's description (TOC + two external anchor refs fixed).
- **Stamped `mode:` on the 20 previously mode-less skills** — `Meta` on framework infrastructure / authoring / read-only-dashboard skills (all `setup`/`utilities`, plus `issue-reproducer`, `issue-reassess-stats`, `committer-onboarding`, `security-tracker-stats-dashboard`); `Triage` on the three opt-in skills that act on PRs/issues (`pr-management-stats`, `pr-management-quick-merge`, `security-issue-import-via-forwarder`) — already listed under `## Triage`.
- Adds `family: repo-health` to `dependency-license-audit` (a skill that landed without a family).

## Validation

Validator unit tests, `ruff`, `mypy`, `pytest`, and the repo `skill-and-tool-validate` all pass.
