### PR TITLE
feat(validator): drop mcp from optional frontmatter keys

### DIFF
--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -314,7 +314,7 @@ _CAPABILITY_TOKEN_RE = re.compile(r"`?((?:capability|contract|substrate):[a-z-]+
 _ITALIC_PARENS_RE = re.compile(r"\*\(.*?\)\*")
 
 REQUIRED_FRONTMATTER_KEYS = {"name", "description", "license", "capability", "family", "mode", "when_to_use"}
-OPTIONAL_FRONTMATTER_KEYS = {"organization", "mcp"}
+OPTIONAL_FRONTMATTER_KEYS = {"organization"}
 ALLOWED_LICENSES = {"Apache-2.0"}
 
 # Canonical skill-family vocabulary.  Skills declare their family via a


### PR DESCRIPTION
## What

Follow-up to #827. Removes the `mcp` key from the skill-frontmatter taxonomy — no skill declares an `mcp:` frontmatter key, so it was dead vocabulary in the optional set.

## Change

- `OPTIONAL_FRONTMATTER_KEYS` is now `{"organization"}` (was `{"organization", "mcp"}`).

Required keys are unchanged (`name, description, license, capability, family, mode, when_to_use`).

## Validation

`skill-and-tool-validate`, `ruff`, `mypy`, and `pytest` all pass.
