### PR TITLE
feat(evals): tag 64 cases as local-smoke candidates across 20 skills

### DIFF
--- a/tools/skill-evals/evals/ci-runner-audit/step-reporting/fixtures/case-2-no-security-overclaim/case-meta.json
+++ b/tools/skill-evals/evals/ci-runner-audit/step-reporting/fixtures/case-2-no-security-overclaim/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/ci-runner-audit/step-scope-selection/fixtures/case-1-explicit-single-repo/case-meta.json
+++ b/tools/skill-evals/evals/ci-runner-audit/step-scope-selection/fixtures/case-1-explicit-single-repo/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/ci-runner-audit/step-scope-selection/fixtures/case-2-ambiguous-project/case-meta.json
+++ b/tools/skill-evals/evals/ci-runner-audit/step-scope-selection/fixtures/case-2-ambiguous-project/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/ci-runner-audit/step-scope-selection/fixtures/case-3-full-apache-org/case-meta.json
+++ b/tools/skill-evals/evals/ci-runner-audit/step-scope-selection/fixtures/case-3-full-apache-org/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/committer-onboarding/step-0-validate-vote/fixtures/case-2-veto-blocks/case-meta.json
+++ b/tools/skill-evals/evals/committer-onboarding/step-0-validate-vote/fixtures/case-2-veto-blocks/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/committer-onboarding/step-0-validate-vote/fixtures/case-3-insufficient-binding/case-meta.json
+++ b/tools/skill-evals/evals/committer-onboarding/step-0-validate-vote/fixtures/case-3-insufficient-binding/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/contributor-activity-sweep/step-0-resolve-inputs/fixtures/case-1-safe-handle/case-meta.json
+++ b/tools/skill-evals/evals/contributor-activity-sweep/step-0-resolve-inputs/fixtures/case-1-safe-handle/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/contributor-activity-sweep/step-1-classify-reviews/fixtures/case-3-lgtm-only-threshold/case-meta.json
+++ b/tools/skill-evals/evals/contributor-activity-sweep/step-1-classify-reviews/fixtures/case-3-lgtm-only-threshold/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/contributor-activity-sweep/step-1-classify-reviews/fixtures/case-4-lgtm-only-empty/case-meta.json
+++ b/tools/skill-evals/evals/contributor-activity-sweep/step-1-classify-reviews/fixtures/case-4-lgtm-only-empty/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/dependency-audit/step-scope-selection/fixtures/case-1-explicit-repo/case-meta.json
+++ b/tools/skill-evals/evals/dependency-audit/step-scope-selection/fixtures/case-1-explicit-repo/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/dependency-audit/step-scope-selection/fixtures/case-2-ambiguous-scope/case-meta.json
+++ b/tools/skill-evals/evals/dependency-audit/step-scope-selection/fixtures/case-2-ambiguous-scope/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/flaky-test-triage/step-classify/fixtures/case-3-clean/case-meta.json
+++ b/tools/skill-evals/evals/flaky-test-triage/step-classify/fixtures/case-3-clean/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-2-classify/fixtures/case-1-ready/case-meta.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-2-classify/fixtures/case-1-ready/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-2-classify/fixtures/case-4-skip-security/case-meta.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-2-classify/fixtures/case-4-skip-security/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-2-classify/fixtures/case-5-skip-architectural/case-meta.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-2-classify/fixtures/case-5-skip-architectural/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/issue-deduplicate/step-0-preflight/fixtures/case-1-clean-pass/case-meta.json
+++ b/tools/skill-evals/evals/issue-deduplicate/step-0-preflight/fixtures/case-1-clean-pass/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/issue-deduplicate/step-3-confirm/fixtures/case-3-cancel/case-meta.json
+++ b/tools/skill-evals/evals/issue-deduplicate/step-3-confirm/fixtures/case-3-cancel/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-1-explicit-repo/case-meta.json
+++ b/tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-1-explicit-repo/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-2-ambiguous-scope/case-meta.json
+++ b/tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-2-ambiguous-scope/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/tone-checks/fixtures/case-1-clean-issue-draft/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/tone-checks/fixtures/case-1-clean-issue-draft/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/tone-checks/fixtures/case-2-clean-pr-draft/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/tone-checks/fixtures/case-2-clean-pr-draft/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-1-first-timer-issue/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-1-first-timer-issue/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-3-contributor-skip/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-3-contributor-skip/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-4-member-skip/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-4-member-skip/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-5-prior-welcome-skip/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-5-prior-welcome-skip/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-7-out-of-scope-skip/case-meta.json
+++ b/tools/skill-evals/evals/mentoring-welcome/welcome-decision/fixtures/case-7-out-of-scope-skip/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/newcomer-issue-explainer/issue-assessment/fixtures/case-1-explain-ready/case-meta.json
+++ b/tools/skill-evals/evals/newcomer-issue-explainer/issue-assessment/fixtures/case-1-explain-ready/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/newcomer-issue-explainer/issue-assessment/fixtures/case-2-security-sensitive/case-meta.json
+++ b/tools/skill-evals/evals/newcomer-issue-explainer/issue-assessment/fixtures/case-2-security-sensitive/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/newcomer-issue-explainer/issue-assessment/fixtures/case-4-already-closed/case-meta.json
+++ b/tools/skill-evals/evals/newcomer-issue-explainer/issue-assessment/fixtures/case-4-already-closed/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-1-setup/case-meta.json
+++ b/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-1-setup/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-3-first-issue/case-meta.json
+++ b/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-3-first-issue/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-4-architecture/case-meta.json
+++ b/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-4-architecture/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-5-security/case-meta.json
+++ b/tools/skill-evals/evals/onboarding-concierge/question-classify/fixtures/case-5-security/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/optimize-skill/step-diagnose/fixtures/case-1-oversized-and-leak/case-meta.json
+++ b/tools/skill-evals/evals/optimize-skill/step-diagnose/fixtures/case-1-oversized-and-leak/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/optimize-skill/step-diagnose/fixtures/case-2-clean-noop/case-meta.json
+++ b/tools/skill-evals/evals/optimize-skill/step-diagnose/fixtures/case-2-clean-noop/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/decision-table/fixtures/case-1-passing/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/decision-table/fixtures/case-1-passing/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/decision-table/fixtures/case-14-already-ready/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/decision-table/fixtures/case-14-already-ready/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/decision-table/fixtures/case-2-merge-conflict/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/decision-table/fixtures/case-2-merge-conflict/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-1-clean-contributor/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-1-clean-contributor/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-2-bot-author/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-2-bot-author/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-4-fresh-pr/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-4-fresh-pr/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-6-viewer-is-author/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-6-viewer-is-author/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-7-draft-recent/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-7-draft-recent/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-8-already-ready/case-meta.json
+++ b/tools/skill-evals/evals/pr-management-triage/pre-filter/fixtures/case-8-already-ready/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-install/step-scope-confirm/fixtures/case-1-per-project-fresh/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/step-scope-confirm/fixtures/case-1-per-project-fresh/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-install/step-scope-confirm/fixtures/case-2-whole-user-disclosure/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/step-scope-confirm/fixtures/case-2-whole-user-disclosure/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-install/step-snapshot-drift/fixtures/case-1-clean/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/step-snapshot-drift/fixtures/case-1-clean/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-update/step-after-report/fixtures/case-1-all-clean/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/step-after-report/fixtures/case-1-all-clean/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-update/step-snapshot-drift/fixtures/case-1-clean/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/step-snapshot-drift/fixtures/case-1-clean/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-update/step-tool-freshness/fixtures/case-1-all-current/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/step-tool-freshness/fixtures/case-1-all-current/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-update/step-tool-freshness/fixtures/case-4-within-cooldown/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/step-tool-freshness/fixtures/case-4-within-cooldown/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/step-2-recommend/fixtures/case-1-all-pass/case-meta.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/step-2-recommend/fixtures/case-1-all-pass/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-1-in-sync/case-meta.json
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-1-in-sync/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-2-push-only/case-meta.json
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-2-push-only/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-5-not-a-git-repo/case-meta.json
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-5-not-a-git-repo/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-6-lock-held/case-meta.json
+++ b/tools/skill-evals/evals/setup-shared-config-sync/step-3-decide-action/fixtures/case-6-lock-held/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-status/step-0-preflight/fixtures/case-1-not-adopted/case-meta.json
+++ b/tools/skill-evals/evals/setup-status/step-0-preflight/fixtures/case-1-not-adopted/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-status/step-0-preflight/fixtures/case-2-adopted-clean/case-meta.json
+++ b/tools/skill-evals/evals/setup-status/step-0-preflight/fixtures/case-2-adopted-clean/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-status/step-1-command/fixtures/case-1-default/case-meta.json
+++ b/tools/skill-evals/evals/setup-status/step-1-command/fixtures/case-1-default/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-status/step-1-command/fixtures/case-2-no-adjust/case-meta.json
+++ b/tools/skill-evals/evals/setup-status/step-1-command/fixtures/case-2-no-adjust/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-status/step-3-adjust-decision/fixtures/case-1-no-adjust-flag/case-meta.json
+++ b/tools/skill-evals/evals/setup-status/step-3-adjust-decision/fixtures/case-1-no-adjust-flag/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup-status/step-3-adjust-decision/fixtures/case-2-clean-state/case-meta.json
+++ b/tools/skill-evals/evals/setup-status/step-3-adjust-decision/fixtures/case-2-clean-state/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-1-explicit-repo/case-meta.json
+++ b/tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-1-explicit-repo/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-2-ambiguous-scope/case-meta.json
+++ b/tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-2-ambiguous-scope/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}


### PR DESCRIPTION
## Summary

Static identification pass over the previously untagged eval corpus. Reviewed cases in ci-runner-audit, committer-onboarding, contributor- activity-sweep, dependency-audit, flaky-test-triage, good-first-issue- sweep, issue-deduplicate, issue-reassess, license-compliance-audit, mentoring-welcome, newcomer-issue-explainer, onboarding-concierge, optimize-skill, pr-management-triage, setup-isolated-setup-install, setup-isolated-setup-update, setup-isolated-setup-verify, setup-shared-config-sync, setup-status, and workflow-security-audit.

Selected cases with ≤6 flat fields (enums, booleans, short strings), non-adversarial inputs, and single-rule or canonical empty-state shapes (cancel, all-pass, in-sync, not-adopted, clean, etc.) that a small local model (Qwen3.5 9B / Llama 3.1 8B) is likely to get right. Excluded aggregation steps, multi-rule classification cases, prose-heavy composition steps, and injection/adversarial fixtures.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other: evals

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [X] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
