### PR TITLE
test(validator): add non-ASF organization profile smoke coverage

### DIFF
--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -3130,6 +3130,103 @@ class TestOrganizationStructure:
 
 
 # ---------------------------------------------------------------------------
+# Non-ASF organization profile smoke coverage
+# ---------------------------------------------------------------------------
+
+
+class TestOrganizationNonASFSmoke:
+    """Smoke coverage for the 'independent' (no-formal-governing-body) profile.
+
+    The non-ASF profile must drive security intake backend selection,
+    release backend selection, and contributor-governance defaults without
+    any ASF-specific coupling violations — per the organization-adapters
+    spec acceptance criteria.
+    """
+
+    def _make_org(self, tmp_path: Path, org: str) -> None:
+        org_dir = tmp_path / "organizations" / org
+        org_dir.mkdir(parents=True)
+        (org_dir / "README.md").write_text("# placeholder\n")
+        (org_dir / "organization.md").write_text("# placeholder\n")
+
+    def test_security_intake_independent_org_no_violations(self, tmp_path: Path) -> None:
+        """Security-intake skill (GHSA direct, no forwarder relay) validates clean."""
+        self._make_org(tmp_path, "independent")
+        text = (
+            "---\n"
+            "name: magpie-security-intake\n"
+            "description: d\n"
+            "license: Apache-2.0\n"
+            "capability: capability:intake\n"
+            "organization: independent\n"
+            "---\n\n"
+            "## Workflow\n\n"
+            "Import security reports filed via GitHub Security Advisories (GHSA).\n"
+            "No forwarder relay is configured; reports arrive directly from\n"
+            "`notifications@github.com` into the project security inbox.\n"
+        )
+        path = tmp_path / "SKILL.md"
+        org_violations = [
+            v for v in validate_frontmatter(path, text, root=tmp_path) if v.category == ORGANIZATION_CATEGORY
+        ]
+        coupling_violations = list(validate_asf_coupling(path, text))
+        assert org_violations == [], "independent org must be accepted for intake skill"
+        assert coupling_violations == [], "GHSA/inbox body must not trigger ASF-coupling warnings"
+
+    def test_release_backend_independent_org_no_violations(self, tmp_path: Path) -> None:
+        """Release housekeeping skill (GitHub Releases, no SVN/dist tree) validates clean."""
+        self._make_org(tmp_path, "independent")
+        text = (
+            "---\n"
+            "name: magpie-release-housekeeping\n"
+            "description: d\n"
+            "license: Apache-2.0\n"
+            "capability: capability:resolve\n"
+            "organization: independent\n"
+            "---\n\n"
+            "## Workflow\n\n"
+            "Post-release housekeeping: publish the GitHub Release artifact,\n"
+            "update the changelog, and close the project milestone.\n"
+        )
+        path = tmp_path / "SKILL.md"
+        org_violations = [
+            v for v in validate_frontmatter(path, text, root=tmp_path) if v.category == ORGANIZATION_CATEGORY
+        ]
+        coupling_violations = list(validate_asf_coupling(path, text))
+        assert org_violations == [], "independent org must be accepted for resolve skill"
+        assert coupling_violations == [], "GitHub Releases body must not trigger ASF-coupling warnings"
+
+    def test_contributor_governance_independent_org_no_violations(self, tmp_path: Path) -> None:
+        """Contributor governance skill (DCO, maintainer vote) validates clean."""
+        self._make_org(tmp_path, "independent")
+        text = (
+            "---\n"
+            "name: magpie-contributor-setup\n"
+            "description: d\n"
+            "license: Apache-2.0\n"
+            "capability: capability:platform\n"
+            "organization: independent\n"
+            "---\n\n"
+            "## Workflow\n\n"
+            "Verify DCO sign-off on the contributor's recent merged PRs.\n"
+            "The maintainer team votes to grant repository write access.\n"
+        )
+        path = tmp_path / "SKILL.md"
+        org_violations = [
+            v for v in validate_frontmatter(path, text, root=tmp_path) if v.category == ORGANIZATION_CATEGORY
+        ]
+        coupling_violations = list(validate_asf_coupling(path, text))
+        assert org_violations == [], "independent org must be accepted for platform skill"
+        assert coupling_violations == [], "DCO/maintainer body must not trigger ASF-coupling warnings"
+
+    def test_independent_org_structure_no_violations(self, tmp_path: Path) -> None:
+        """A fully-formed independent organization adapter passes the structure check."""
+        self._make_org(tmp_path, "independent")
+        vs = list(validate_organization_structure(tmp_path))
+        assert vs == []
+
+
+# ---------------------------------------------------------------------------
 # Capability sync check: docs/labels-and-capabilities.md ↔ live source
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Add TestOrganizationNonASFSmoke to the validator test suite, covering the three workflow surfaces the organization-adapters spec acceptance criteria require for at least one non-ASF profile:

- Security intake (capability:intake, GHSA direct / no forwarder relay) confirms organization: independent is accepted and GHSA/inbox body terms produce no ASF-coupling warnings.

- Release housekeeping (capability:resolve, GitHub Releases / no SVN or dist tree) confirms the same for the GitHub Releases workflow.

- Contributor governance (capability:platform, DCO / maintainer vote) confirms DCO and maintainer-team terms produce no ASF-coupling warnings.

A fourth case verifies that a fully-formed independent adapter directory (README.md + organization.md present) passes validate_organization_structure.

The spec gap closed: "Smoke coverage is narrow — the next coverage pass should exercise security intake, release backend selection, and contributor governance so organization defaults are tested across the surfaces most likely to drift." (organization-adapters.md Known gaps)

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
