### PR TITLE
refactor(config): drop org-inherited values from project template and non-asf fixture

### DIFF
--- a/projects/_template/project.md
+++ b/projects/_template/project.md
@@ -87,14 +87,14 @@ produces.
 | `dev_list` | TODO: e.g. `dev@foo.apache.org` | Release `[RESULT][VOTE]` threads; publicly archived |
 | `announce_list` | TODO: e.g. `announce@apache.org` | Cross-project announcement list; publicly archived |
 | `commits_list` | TODO: e.g. `commits@foo.apache.org` | Publicly archived |
-| `asf_security_list` | `security@apache.org` | ASF-wide security team; relays some inbound reports |
 
-**Public archives** typically live at
-`https://lists.apache.org/list.html?<list>`. **Private** lists on
-`lists.apache.org/thread/<id>` 404 for non-members. Only URLs on
-publicly archived lists may appear in CVE `references[]` as
+Only URLs on publicly archived lists may appear in CVE `references[]` as
 `vendor-advisory`; see `../../AGENTS.md` and
 [`security-model.md`](security-model.md).
+
+The foundation-wide security forwarding address (e.g. `security@apache.org`
+for ASF projects) is org-level — inherited from your organization's
+`security_inbox.foundation_security_address`. Do not declare it here.
 
 ## Tools enabled
 
@@ -103,9 +103,9 @@ publicly archived lists may appear in CVE `references[]` as
 | Issue tracking + project board | `github` | [`../../tools/github/`](../../tools/github/) | `tracker_repo`, `upstream_repo`, `github_project_board_*`, `issue_template_fields` |
 | Source control (VCS) | `github` (Git) — replaceable with a non-Git VCS | [`../../tools/github/source-control.md`](../../tools/github/source-control.md) | `upstream_repo`, `default_branch`; for a non-Git VCS declare the sibling tool + its working-copy URL |
 | Inbound email / drafts | `<one or more mail-source backends>` | [`../../tools/mail-source/contract.md`](../../tools/mail-source/contract.md) (abstract) + per-backend adapter dirs (`tools/gmail/`, `tools/ponymail/`, `tools/mail-source/imap/`, `tools/mail-source/mbox/`, ...) | See [Mail sources](#mail-sources) below — declare each backend's role (primary / preferred-for-`<op>` / fallback / optional) and `mandatory` flag |
-| CVE allocation + record mgmt | `vulnogram` | [`../../tools/cve-tool-vulnogram/`](../../tools/cve-tool-vulnogram/) | see [CVE tooling](#cve-tooling) below |
-| ASF project metadata (rosters / people / releases) | `apache-projects` | [`../../tools/apache-projects/`](../../tools/apache-projects/) | see [`project_metadata`](#project-metadata) below — ASF default `mandatory: true` |
-| Release voting / announce | TODO: ASF mailing lists — or replace with the project's release-comms backend | — | via `dev_list` / `announce_list` / `users_list` |
+| CVE allocation + record mgmt | *org-level* — inherited from `organizations/<org>/organization.md → cve_authority.tool`; for ASF: `vulnogram` ([`tools/cve-tool-vulnogram/`](../../tools/cve-tool-vulnogram/)), for independent: `mitre-form` | — | override in [CVE authority](#cve-authority) only if this project differs from its org |
+| Project metadata (rosters / people / releases) | *org-level* — inherited from `organizations/<org>/organization.md → project_metadata.kind`; for ASF: `apache-projects` ([`tools/apache-projects/`](../../tools/apache-projects/)), for independent: `none` | — | override in [Project metadata](#project-metadata) only if this project differs from its org |
+| Release comms | TODO: the backend that carries release announcements — for ASF: `dev_list` / `announce_list` / `users_list`; for GitHub Releases leave blank | — | whichever release-comms keys the org default or per-project override declares |
 
 To replace a tool (e.g. swap GitHub issues for JIRA), declare an
 alternate tool in the table above, add a `tools/<name>/` adapter
@@ -114,21 +114,23 @@ reachable from this manifest.
 
 ## CVE tooling
 
-TODO: describe which CNA tool the project uses. For ASF projects the
-default is ASF's Vulnogram; other CNAs will substitute their own
-equivalents. The Vulnogram-side mechanics live under
-[`../../tools/cve-tool-vulnogram/`](../../tools/cve-tool-vulnogram/); the per-project
-values below are what the generic recipes substitute in.
+The CNA tool, allocation URL, record URL template, and allocation gate are
+**org-level** — inherited from your organization's `cve_authority` and
+`governance` blocks (see
+[`organizations/ASF/organization.md`](../../organizations/ASF/organization.md)
+for ASF defaults,
+[`organizations/independent/organization.md`](../../organizations/independent/organization.md)
+for the GitHub-native baseline). Override a key in the
+[Security workflow configuration → CVE authority](#cve-authority) block only
+if this project's CNA setup genuinely differs from its organization.
+
+For **ASF adopters**, fill in the per-project CNA queue fields below — each
+ASF project has its own queue slug and org UUID, so these are not org-level:
 
 | Key | Value |
 |---|---|
-| `cve_tool` | TODO: e.g. `vulnogram` (ASF-hosted) |
-| `cve_tool_allocate_url` | TODO: e.g. `https://cveprocess.apache.org/allocatecve` |
-| `cve_tool_record_url_template` | TODO: e.g. `https://cveprocess.apache.org/cve5/<CVE-ID>` |
-| `cve_tool_source_tab_url_template` | TODO |
-| `cve_allocation_gated_by` | TODO: e.g. `Foo PMC membership (ASF OAuth)` |
-| `asf_org_id` | TODO: project's CNA org UUID (for ASF projects: `f0158376-9dc2-43b6-827c-5f631a4d8d09`) |
-| `cna_private_owner` | TODO: e.g. `foo` (CNA_private.owner — identifies the project slug inside the ASF CNA queue) |
+| `asf_org_id` | TODO: project's CNA org UUID — e.g. `f0158376-9dc2-43b6-827c-5f631a4d8d09` |
+| `cna_private_owner` | TODO: e.g. `foo` (CNA_private.owner — the project slug inside the ASF CNA queue) |
 | `cna_private_projecturl` | TODO: e.g. `https://foo.apache.org/` |
 | `cna_private_userslist` | TODO: e.g. `users@foo.apache.org` |
 
@@ -183,21 +185,18 @@ remaining backends (and skips ops that no available backend supports).
 | Backend | Role | Mandatory | Notes |
 |---|---|---|---|
 | TODO: `gmail` | TODO: e.g. `primary` | TODO: `yes` / `no` | TODO: e.g. "Triager Gmail account subscribed to `<security-list>` and `<private-list>`" |
-| TODO: `ponymail` | TODO: e.g. `fallback` or `preferred for thread_url` | TODO: ASF default `yes` | TODO: e.g. "Read-only archive backstop; PMC LDAP session required for private-list reads" |
+| TODO: `ponymail` | TODO: e.g. `fallback` or `preferred for thread_url` | TODO: `yes` / `no` | TODO: e.g. "Read-only archive backstop; install per [`tools/ponymail/tool.md`](../../tools/ponymail/tool.md)" |
 | TODO: *(add more rows as needed — `imap`, `mbox`, project-specific adapter)* | | | |
 
-> **ASF default — `ponymail` is `mandatory: yes`.** For ASF
-> projects the PonyMail MCP is a pre-flight prerequisite, not an
-> opt-in backstop: the mail-reading skills that run the Step 0
-> mail-source check (`security-issue-import`, `security-issue-sync`)
-> refuse to run when it is unavailable, even though `gmail` keeps the
-> `primary` role (PonyMail is read-only — drafts stay on Gmail).
-> Skills that only touch a single Gmail thread opportunistically
-> (e.g. `security-cve-allocate`) do not hard-gate on it.
-> Install it from the latest `main` of `apache/comdev` per
+> **Mail backend selection is org-level.** The `mail_provider` block in
+> your organization manifest sets the primary and fallback backends
+> (for ASF: `primary: gmail-mcp`, `fallback: ponymail`; for independent:
+> `primary: none`, `fallback: none`). Only declare backends here that
+> override or extend what the organization manifest provides. For ASF
+> projects where PonyMail is the inherited fallback, declare it here only
+> to change its `mandatory` flag or role for this specific project; the
+> backend itself is already wired by the organization. Install PonyMail per
 > [`../../tools/ponymail/tool.md`](../../tools/ponymail/tool.md#keeping-the-checkout-current).
-> A non-ASF adopter with no `lists.apache.org` archive sets this row
-> to `mandatory: no` (or drops it).
 
 Reference adapter docs:
 [`tools/gmail/tool.md`](../../tools/gmail/tool.md) (full read+write),

--- a/projects/non-asf-example/project.md
+++ b/projects/non-asf-example/project.md
@@ -11,10 +11,7 @@
     - [CVE authority](#cve-authority)
     - [Governance](#governance)
     - [Security inbox](#security-inbox)
-    - [Forwarders](#forwarders)
-    - [Mail provider](#mail-provider)
     - [Archive system](#archive-system)
-    - [Project metadata](#project-metadata)
     - [Tracker](#tracker)
     - [Scope detection](#scope-detection)
     - [Release process](#release-process)
@@ -43,11 +40,14 @@ See [`README.md`](README.md) for the fixture's purpose.
 | `short_name` | velox-stream |
 | `product_family_url` | https://velox-stream.example.io/ |
 
-This fixture **spells out every workflow knob explicitly** below, even
-the ones it would otherwise inherit from `organizations/independent/`,
-so the worked example is self-contained and the values are visible at a
-glance. A real adopter would omit the inherited keys and declare only
-its per-project values (see [`projects/_template/project.md`](../_template/project.md)).
+This fixture shows the **minimal per-project configuration** a real
+independent adopter would declare — only values that override or extend the
+[`organizations/independent/`](../../organizations/independent/) defaults.
+Org-level values (`cve_authority`, `forwarders`, `mail_provider`,
+`project_metadata`, and most of `archive_system` and `release_process`) are
+inherited from that manifest and not repeated here. See
+[`projects/_template/project.md`](../_template/project.md) for the full
+schema and field descriptions.
 
 ## Repositories
 
@@ -85,58 +85,29 @@ and has no public mailing lists.
 
 ## Security workflow configuration
 
+The blocks below declare only **per-project values** — overrides and
+extensions of what `organizations/independent/organization.md` already
+provides. Inherited keys (`forwarders`, `mail_provider`, `project_metadata`,
+and the base CVE/governance/inbox defaults) are omitted; the framework
+resolves them from the organization manifest automatically.
+
 ### CVE authority
 
 ```yaml
 cve_authority:
-  # Non-ASF adopter: direct MITRE CNA submission form, not Vulnogram.
-  tool: mitre-form
-
-  # Front-door allocation URL — MITRE's request form.
-  allocate_url: https://cveform.mitre.org/
-
-  # Record URL template — public cve.org record.
-  record_url_template: https://www.cve.org/CVERecord?id=<CVE-ID>
-
-  # No "source tab" equivalent; set to null.
-  source_tab_url_template: null
-
-  # No allocation email preview; set to null.
-  email_preview_url_template: null
-
-  # MITRE state machine maps to the generic 4-stop sequence.
+  # Override the independent-org 2-stop state machine: Velox uses MITRE's
+  # extended 4-stop sequence and polls for publication rather than waiting
+  # for manual notification.
   states: [allocated, review-ready, publish-ready, public]
-
-  # MITRE notifies by email; poll for public propagation.
   publication_propagation: poll
-
-  # MITRE does not auto-email on allocation.
-  emits_allocation_email: false
-
-  # Review happens in a private GitHub discussion thread, not a mailing list.
-  reviewer_channel: github-pr
 ```
 
 ### Governance
 
 ```yaml
 governance:
-  # Non-ASF: any security team member can allocate a CVE.
-  cve_allocation_gate: security-team-member
-
-  # Tracker label for security-team-member gate.
-  gate_label: "security-team"
-
-  # No formal release-vote gate.
-  release_vote_gating: false
-
-  # No private mailing list; use GitHub team DMs or a private channel.
-  private_governance_list: null
-
-  # Escalation contact (GitHub handle of the project lead).
+  # Per-project: escalation handle and public roster URL.
   escalation_contact: "@velox-lead"
-
-  # Public maintainer roster on GitHub.
   roster_url: https://github.com/orgs/velox-community/people
 ```
 
@@ -144,64 +115,16 @@ governance:
 
 ```yaml
 security_inbox:
-  # Non-ASF: GitHub Security Advisories (GHSA private reports), not email.
-  kind: ghsa-inbox
-
-  # GHSA inbox URL.
+  # Per-project: the concrete GHSA inbox URL for this repo.
   address: https://github.com/velox-community/velox-stream/security/advisories
-
-  # No foundation-level security address.
-  foundation_security_address: null
-
-  # No forwarder/relay layer.
-  has_forwarder_relay: false
-
-  # GHSA uses the platform's own notification channel, not a list filter.
-  list_filter_query: null
-```
-
-### Forwarders
-
-```yaml
-forwarders:
-  # Non-ASF: no forwarder/relay layer.
-  enabled: []
-```
-
-### Mail provider
-
-```yaml
-mail_provider:
-  # Non-ASF: no mail backend; security intake is entirely via GHSA.
-  primary: none
-  fallback: none
 ```
 
 ### Archive system
 
 ```yaml
 archive_system:
-  # Non-ASF: no public mailing-list archive. Announcements go on
-  # GitHub Releases.
-  kind: none
-  list_domain: null
-  search_url_template: null
-  api_query_url_template: null
+  # Per-project: where public advisories and release notes surface.
   advisory_publication_signal_url: https://github.com/velox-community/velox-stream/releases
-```
-
-### Project metadata
-
-```yaml
-project_metadata:
-  # Non-ASF: no apache-projects-mcp. Roster is supplied by maintainers
-  # via the release-trains.md file.
-  kind: none
-
-  # Not a pre-flight prerequisite (no ASF roster service available).
-  mandatory: false
-
-  install_source: null
 ```
 
 ### Tracker
@@ -243,16 +166,13 @@ scope_detection:
 
 ```yaml
 release_process:
-  # Non-ASF: RM lookup from a roster file only; no wiki or mailing-list thread.
-  release_manager_lookup_cascade:
-    - kind: roster_file
-      path: "release-trains.md"
-
-  # Artifacts published on PyPI only (no ArtifactHub / Helm chart).
+  # Override: PyPI only (independent-org default is []).
   artifact_registries: [pypi]
 
+  # Per-project: this project has no overdue milestones to track.
   stale_milestones: []
 
+  # Per-project: newsfragments tool.
   newsfragments:
     enabled: true
     tool: towncrier
@@ -262,9 +182,8 @@ release_process:
 
 ```yaml
 roster:
-  # Source of truth: a checked-in roster file.
-  source: roster-file:release-trains.md
-
+  # Per-project: name → handle map and release-manager list.
+  # roster.source is inherited from organizations/independent (roster-file).
   bare_name_handles:
     "Alex": "@alex-velox"
     "Robin": "@robin-velox"


### PR DESCRIPTION
## Summary

projects/_template/project.md: remove `asf_security_list` (now `security_inbox.foundation_security_address` in the org manifest), drop org-level CVE-tooling fields (`cve_tool`, `cve_tool_allocate_url`, `cve_tool_record_url_template`, `cve_tool_source_tab_url_template`) in favour of a pointer to the org `cve_authority` block, update the Tools enabled table to show CVE/metadata backends as org-level inherited (not ASF-specific hardcoded), and replace the ASF-specific PonyMail callout with an org-neutral `mail_provider` inheritance note.  Per-project ASF CNA queue fields (`asf_org_id`, `cna_private_owner`, etc.) are kept.

projects/non-asf-example/project.md: trim all keys that match the `organizations/independent/` defaults — forwarders, mail_provider, project_metadata, archive_system base keys, release_manager_lookup_cascade, and roster.source — leaving only per-project overrides and the two cve_authority keys where Velox Stream deviates from the independent-org defaults (4-stop state machine, poll propagation).  Updates TOC and introductory comment to reflect the minimal-config model.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
