### PR TITLE
docs(education): fix Pattern 8 eval layout to match real fixtures structure

### DIFF
--- a/docs/education/pattern-catalogue.md
+++ b/docs/education/pattern-catalogue.md
@@ -348,13 +348,39 @@ finished (PRINCIPLE 8, AGENTS.md § Reusable skills).
 
 ```text
 tools/skill-evals/evals/<skill-name>/
-├── eval.yaml           # eval harness config pointing at the skill
-└── cases/
-    ├── 01-happy-path.md     # the normal flow produces the right output
-    ├── 02-inject-attempt.md # prompt-injection attempt is flagged, not followed
-    ├── 03-empty-queue.md    # graceful no-op when nothing to do
-    └── 04-confirm-step.md   # agent pauses and waits, not auto-acts
+├── README.md
+└── <step-slug>/
+    └── fixtures/
+        ├── step-config.json          # { "skill_md": "...", "step_heading": "..." }
+        ├── output-spec.md            # JSON schema the step must return
+        ├── user-prompt-template.md   # user-facing prompt with {variable} slots
+        ├── case-1-normal/
+        │   ├── report.md             # realistic example input
+        │   └── expected.json         # expected structured output
+        ├── case-2-injection/
+        │   ├── report.md             # input containing a prompt-injection string
+        │   └── expected.json         # injection flagged, not followed
+        ├── case-3-empty-queue/
+        │   ├── report.md             # nothing to classify or act on
+        │   └── expected.json         # graceful no-op output
+        └── case-4-confirm-gate/
+            ├── report.md             # normal input requiring a state change
+            └── expected.json         # output shows draft, confirm not assumed
 ```
+
+`step-config.json` links each case to its skill step by pointing at the skill
+file and the heading that names the step:
+
+```json
+{
+  "skill_md": "skills/<skill-name>/SKILL.md",
+  "step_heading": "## Step N — <step title>"
+}
+```
+
+`output-spec.md` tells the model what JSON shape to return. `expected.json` in
+each case is a concrete instance of that shape — decision fields (enums,
+booleans, IDs) are compared exactly; prose fields are scored by a judge model.
 
 **A minimum eval suite has four cases:**
 


### PR DESCRIPTION
## Summary

Pattern 8 in pattern-catalogue.md showed a fictional layout using eval.yaml and a flat cases/*.md directory. Neither exists anywhere in the repo. The real harness uses evals/<skill>/<step-slug>/fixtures/ with step-config.json, output-spec.md, and per-case case-*/expected.json dirs, matching eval-driven-development.md and tutorials.md.

Rewrite the pattern's code block and prose to document the real layout, keeping the four-case minimum-suite guidance (normal, injection, empty queue, confirm gate) mapped to the actual case-*/ directory structure.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
