### PR TITLE
feat(permission-audit): add audit-any and declare harness agnostic

### DIFF
--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -588,11 +588,7 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 56.
 | `dashboard-generator` | analytics | any | ✅ agnostic |
 | `dev` | framework-dev | any | ✅ agnostic |
 | `egress-gateway` | sandbox | any | ✅ agnostic |
-<<<<<<< HEAD
-| `permission-audit` | sandbox | Claude Code, Kiro, OpenCode | ✅ portable |
-=======
 | `permission-audit` | sandbox | any | ✅ agnostic |
->>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 | `pilot-report-validator` | framework-dev | any | ✅ agnostic |
 | `pr-management-stats` | analytics | any | ✅ agnostic |
 | `preflight-audit` | analytics | any | ✅ agnostic |
@@ -612,22 +608,13 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 56.
 
 Harness → substrate tools it supports:
 
-<<<<<<< HEAD
-- **Claude Code** (4): `agent-guard`, `permission-audit`, `sandbox-lint`, `spec-loop`
+- **Claude Code** (3): `agent-guard`, `sandbox-lint`, `spec-loop`
 - **Codex** (1): `spec-loop`
 - **Cursor** (1): `spec-loop`
 - **Gemini CLI** (1): `spec-loop`
-- **Kiro** (4): `agent-guard`, `permission-audit`, `sandbox-lint`, `spec-loop`
-- **OpenCode** (4): `agent-guard`, `permission-audit`, `sandbox-lint`, `spec-loop`
-- **any harness** (18): `agent-isolation`, `dashboard-generator`, `dev`, `egress-gateway`, `pilot-report-validator`, `pr-management-stats`, `preflight-audit`, `privacy-llm`, `probe-templates`, `security-tracker-stats-dashboard`, `skill-and-tool-validator`, `skill-evals`, `skill-reconciler-diff`, `spec-inventory`, `spec-status-index`, `spec-validator`, `symlink-lint`, `vendor-neutrality-score`
-=======
-- **Claude Code** (4): `agent-guard`, `agent-isolation`, `sandbox-lint`, `spec-loop`
-- **Codex** (1): `spec-loop`
-- **Cursor** (1): `spec-loop`
-- **Gemini CLI** (1): `spec-loop`
-- **OpenCode** (4): `agent-guard`, `agent-isolation`, `sandbox-lint`, `spec-loop`
-- **any harness** (18): `dashboard-generator`, `dev`, `egress-gateway`, `permission-audit`, `pilot-report-validator`, `pr-management-stats`, `preflight-audit`, `privacy-llm`, `probe-templates`, `security-tracker-stats-dashboard`, `skill-and-tool-validator`, `skill-evals`, `skill-reconciler-diff`, `spec-inventory`, `spec-status-index`, `spec-validator`, `symlink-lint`, `vendor-neutrality-score`
->>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
+- **Kiro** (3): `agent-guard`, `sandbox-lint`, `spec-loop`
+- **OpenCode** (3): `agent-guard`, `sandbox-lint`, `spec-loop`
+- **any harness** (19): `agent-isolation`, `dashboard-generator`, `dev`, `egress-gateway`, `permission-audit`, `pilot-report-validator`, `pr-management-stats`, `preflight-audit`, `privacy-llm`, `probe-templates`, `security-tracker-stats-dashboard`, `skill-and-tool-validator`, `skill-evals`, `skill-reconciler-diff`, `spec-inventory`, `spec-status-index`, `spec-validator`, `symlink-lint`, `vendor-neutrality-score`
 
 **Model endpoint: neutral by construction — 4 default-approved endpoint classes across independent trust domains, plus adopter opt-in.** From the [`privacy-llm` registry](../tools/privacy-llm/models.md): the framework keys approval on *endpoint identity*, not on who hosts the model, so no single LLM vendor is privileged.
 

--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -588,7 +588,11 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 56.
 | `dashboard-generator` | analytics | any | ✅ agnostic |
 | `dev` | framework-dev | any | ✅ agnostic |
 | `egress-gateway` | sandbox | any | ✅ agnostic |
+<<<<<<< HEAD
 | `permission-audit` | sandbox | Claude Code, Kiro, OpenCode | ✅ portable |
+=======
+| `permission-audit` | sandbox | any | ✅ agnostic |
+>>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 | `pilot-report-validator` | framework-dev | any | ✅ agnostic |
 | `pr-management-stats` | analytics | any | ✅ agnostic |
 | `preflight-audit` | analytics | any | ✅ agnostic |
@@ -608,6 +612,7 @@ Organization scope (declared, orthogonal to vendor): ASF = 14, agnostic = 56.
 
 Harness → substrate tools it supports:
 
+<<<<<<< HEAD
 - **Claude Code** (4): `agent-guard`, `permission-audit`, `sandbox-lint`, `spec-loop`
 - **Codex** (1): `spec-loop`
 - **Cursor** (1): `spec-loop`
@@ -615,6 +620,14 @@ Harness → substrate tools it supports:
 - **Kiro** (4): `agent-guard`, `permission-audit`, `sandbox-lint`, `spec-loop`
 - **OpenCode** (4): `agent-guard`, `permission-audit`, `sandbox-lint`, `spec-loop`
 - **any harness** (18): `agent-isolation`, `dashboard-generator`, `dev`, `egress-gateway`, `pilot-report-validator`, `pr-management-stats`, `preflight-audit`, `privacy-llm`, `probe-templates`, `security-tracker-stats-dashboard`, `skill-and-tool-validator`, `skill-evals`, `skill-reconciler-diff`, `spec-inventory`, `spec-status-index`, `spec-validator`, `symlink-lint`, `vendor-neutrality-score`
+=======
+- **Claude Code** (4): `agent-guard`, `agent-isolation`, `sandbox-lint`, `spec-loop`
+- **Codex** (1): `spec-loop`
+- **Cursor** (1): `spec-loop`
+- **Gemini CLI** (1): `spec-loop`
+- **OpenCode** (4): `agent-guard`, `agent-isolation`, `sandbox-lint`, `spec-loop`
+- **any harness** (18): `dashboard-generator`, `dev`, `egress-gateway`, `permission-audit`, `pilot-report-validator`, `pr-management-stats`, `preflight-audit`, `privacy-llm`, `probe-templates`, `security-tracker-stats-dashboard`, `skill-and-tool-validator`, `skill-evals`, `skill-reconciler-diff`, `spec-inventory`, `spec-status-index`, `spec-validator`, `symlink-lint`, `vendor-neutrality-score`
+>>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 
 **Model endpoint: neutral by construction — 4 default-approved endpoint classes across independent trust domains, plus adopter opt-in.** From the [`privacy-llm` registry](../tools/privacy-llm/models.md): the framework keys approval on *endpoint identity*, not on who hosts the model, so no single LLM vendor is privileged.
 

--- a/tools/permission-audit/README.md
+++ b/tools/permission-audit/README.md
@@ -10,6 +10,7 @@
   - [Why](#why)
   - [Install](#install)
   - [CLI](#cli)
+    - [`audit-any` (harness-neutral)](#audit-any-harness-neutral)
     - [`audit`](#audit)
     - [`apply`](#apply)
     - [`list-known`](#list-known)
@@ -26,7 +27,11 @@
 
 **Capability:** substrate:sandbox
 
+<<<<<<< HEAD
 **Harness:** Claude Code, OpenCode, Kiro
+=======
+**Harness:** agnostic
+>>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 
 Audit + atomically edit Claude Code's `permissions.allow[]` entries
 in `<repo>/.claude/settings.json` and `<repo>/.claude/settings.local.json`.
@@ -126,10 +131,53 @@ Stdlib-only runtime; the dev group adds `pytest`, `ruff`, `mypy`.
 ## CLI
 
 ```bash
+permission-audit audit-any [--dir <project-root>] [--families security,issue]
 permission-audit audit <settings-path> [--families security,issue]
 permission-audit apply <settings-path> [--add <entry>]... [--remove <entry>]... [--create-if-missing]
 permission-audit list-known
 ```
+
+### `audit-any` (harness-neutral)
+
+Scans `<project-root>` (default: `.`) for every known settings file and
+audits each with the appropriate classifier — no need to know which
+harness is active. Detected harnesses:
+
+| File | Harness |
+|---|---|
+| `.claude/settings.json` | Claude Code |
+| `.claude/settings.local.json` | Claude Code (local override) |
+| `opencode.json` | OpenCode |
+
+Returns JSON with one entry per detected file plus a top-level
+`has_forbidden` flag. Exit code `1` when any harness has forbidden
+entries, `0` otherwise.
+
+```bash
+$ permission-audit audit-any --dir /path/to/project
+{
+  "dir": "/path/to/project",
+  "detected_harnesses": ["claude-code", "opencode"],
+  "results": [
+    {
+      "harness": "claude-code",
+      "settings_path": "/path/to/project/.claude/settings.json",
+      "forbidden": [...],
+      "missing_recommended": [...]
+    },
+    {
+      "harness": "opencode",
+      "settings_path": "/path/to/project/opencode.json",
+      "forbidden": [...]
+    }
+  ],
+  "has_forbidden": true
+}
+```
+
+This is the recommended entry point when driving the audit from a harness
+that is not Claude Code or OpenCode — wire it as a startup check or CI step
+without any harness-specific plumbing.
 
 ### `audit`
 

--- a/tools/permission-audit/README.md
+++ b/tools/permission-audit/README.md
@@ -27,11 +27,7 @@
 
 **Capability:** substrate:sandbox
 
-<<<<<<< HEAD
-**Harness:** Claude Code, OpenCode, Kiro
-=======
 **Harness:** agnostic
->>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 
 Audit + atomically edit Claude Code's `permissions.allow[]` entries
 in `<repo>/.claude/settings.json` and `<repo>/.claude/settings.local.json`.

--- a/tools/permission-audit/pyproject.toml
+++ b/tools/permission-audit/pyproject.toml
@@ -21,7 +21,7 @@ build-backend = "hatchling.build"
 [project]
 name = "permission-audit"
 version = "0.1.0"
-description = "Audit + atomically edit Claude Code permissions.allow[] entries in .claude/settings*.json."
+description = "Harness-neutral permission audit: auto-detect and audit Claude Code, OpenCode, and future harness settings in one CLI call."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/tools/permission-audit/src/permission_audit/cli.py
+++ b/tools/permission-audit/src/permission_audit/cli.py
@@ -145,7 +145,6 @@ def _cmd_audit_opencode(args: argparse.Namespace) -> int:
     return 1 if result.forbidden else 0
 
 
-<<<<<<< HEAD
 def _cmd_audit_kiro(args: argparse.Namespace) -> int:
     config_path = Path(args.config_path).resolve()
     config = _read_opencode_config(config_path)
@@ -160,7 +159,8 @@ def _cmd_audit_kiro(args: argparse.Namespace) -> int:
     json.dump(output, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 1 if result.forbidden else 0
-=======
+
+
 # Known harness settings locations in declaration-check order.
 # Each entry: (harness_id, path_relative_to_project_dir, audit_kind)
 # audit_kind is "claude" (uses audit_settings) or "opencode" (uses audit_opencode).
@@ -218,7 +218,6 @@ def _cmd_audit_any(args: argparse.Namespace) -> int:
     json.dump(output, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 1 if has_forbidden else 0
->>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 
 
 def _cmd_list_known(args: argparse.Namespace) -> int:

--- a/tools/permission-audit/src/permission_audit/cli.py
+++ b/tools/permission-audit/src/permission_audit/cli.py
@@ -16,13 +16,21 @@
 # under the License.
 """CLI front-end for the permission allow-list audit + edit tool.
 
-Two subcommands:
+Subcommands:
 
-- ``audit``  — read a settings file, classify allow-list entries
+- ``audit``      — read a Claude Code settings file, classify allow-list entries
   against the forbidden and family-scoped recommended lists, print
   findings as JSON for the calling skill to surface.
 
-- ``apply`` — atomic add/remove against `.permissions.allow[]`.
+- ``apply``      — atomic add/remove against `.permissions.allow[]`.
+
+- ``audit-any``  — harness-neutral sweep: auto-detect every known settings
+  file in a project directory and audit each with the appropriate classifier.
+  Works regardless of which agent harness the caller uses.
+
+- ``audit-opencode`` — audit an OpenCode opencode.json permission config.
+
+- ``list-known`` — print the canonical forbidden + recommended-by-family lists.
 """
 
 from __future__ import annotations
@@ -137,6 +145,7 @@ def _cmd_audit_opencode(args: argparse.Namespace) -> int:
     return 1 if result.forbidden else 0
 
 
+<<<<<<< HEAD
 def _cmd_audit_kiro(args: argparse.Namespace) -> int:
     config_path = Path(args.config_path).resolve()
     config = _read_opencode_config(config_path)
@@ -151,6 +160,65 @@ def _cmd_audit_kiro(args: argparse.Namespace) -> int:
     json.dump(output, sys.stdout, indent=2)
     sys.stdout.write("\n")
     return 1 if result.forbidden else 0
+=======
+# Known harness settings locations in declaration-check order.
+# Each entry: (harness_id, path_relative_to_project_dir, audit_kind)
+# audit_kind is "claude" (uses audit_settings) or "opencode" (uses audit_opencode).
+_HARNESS_SETTINGS: tuple[tuple[str, str, str], ...] = (
+    ("claude-code", ".claude/settings.json", "claude"),
+    ("claude-code-local", ".claude/settings.local.json", "claude"),
+    ("opencode", "opencode.json", "opencode"),
+)
+
+
+def _cmd_audit_any(args: argparse.Namespace) -> int:
+    """Auto-detect settings files in --dir and audit each with the right classifier.
+
+    Harness-neutral: the caller does not need to know which harness is active —
+    every settings file that exists in the project directory is audited.
+    Returns exit code 1 if any harness has forbidden entries, 0 otherwise.
+    """
+    root = Path(args.dir).resolve()
+    families = [f.strip() for f in (args.families or "").split(",") if f.strip()]
+
+    results: list[dict] = []
+    for harness_id, rel_path, audit_kind in _HARNESS_SETTINGS:
+        full_path = root / rel_path
+        if not full_path.exists():
+            continue
+        if audit_kind == "claude":
+            allow = _read_allow(full_path)
+            r = audit_settings(allow, families)
+            results.append(
+                {
+                    "harness": harness_id,
+                    "settings_path": str(full_path),
+                    "forbidden": [asdict(f) for f in r.forbidden],
+                    "missing_recommended": [asdict(f) for f in r.missing_recommended],
+                }
+            )
+        else:  # opencode
+            config = _read_opencode_config(full_path)
+            r_oc = audit_opencode(config)
+            results.append(
+                {
+                    "harness": harness_id,
+                    "settings_path": str(full_path),
+                    "forbidden": [asdict(f) for f in r_oc.forbidden],
+                }
+            )
+
+    has_forbidden = any(entry["forbidden"] for entry in results)
+    output = {
+        "dir": str(root),
+        "detected_harnesses": [entry["harness"] for entry in results],
+        "results": results,
+        "has_forbidden": has_forbidden,
+    }
+    json.dump(output, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    return 1 if has_forbidden else 0
+>>>>>>> f6689f1c8 (feat(permission-audit): add audit-any and declare harness agnostic)
 
 
 def _cmd_list_known(args: argparse.Namespace) -> int:
@@ -168,8 +236,10 @@ def _build_parser() -> argparse.ArgumentParser:
         prog="permission-audit",
         description=(
             "Audit + atomically edit Claude Code permissions.allow[] entries "
-            "in .claude/settings.json / .claude/settings.local.json; and "
-            "audit an OpenCode opencode.json permission config (audit-opencode)."
+            "in .claude/settings.json / .claude/settings.local.json; "
+            "audit an OpenCode opencode.json permission config (audit-opencode); "
+            "or run a harness-neutral sweep that auto-detects all known settings "
+            "files in the project (audit-any)."
         ),
     )
     subparsers = parser.add_subparsers(dest="cmd", required=True)
@@ -203,6 +273,26 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Create the settings file if it does not exist.",
     )
     p_apply.set_defaults(func=_cmd_apply)
+
+    p_audit_any = subparsers.add_parser(
+        "audit-any",
+        help=(
+            "Harness-neutral sweep: auto-detect every known settings file under "
+            "--dir and audit each. Works without knowing which harness is active."
+        ),
+    )
+    p_audit_any.add_argument(
+        "--dir",
+        default=".",
+        metavar="DIR",
+        help="Project root to search for settings files (default: current directory).",
+    )
+    p_audit_any.add_argument(
+        "--families",
+        default="",
+        help="Comma-separated opt-in family names for Claude Code audits (e.g. 'security,issue').",
+    )
+    p_audit_any.set_defaults(func=_cmd_audit_any)
 
     p_audit_oc = subparsers.add_parser(
         "audit-opencode",

--- a/tools/permission-audit/tests/test_any.py
+++ b/tools/permission-audit/tests/test_any.py
@@ -1,0 +1,139 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the harness-neutral audit-any subcommand."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from permission_audit.cli import main
+
+
+def _claude_settings(path: Path, allow: list[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"permissions": {"allow": allow}}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _opencode_config(path: Path, permission: object) -> None:
+    path.write_text(
+        json.dumps({"permission": permission}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_no_settings_files_exits_zero(tmp_path, capsys):
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["detected_harnesses"] == []
+    assert out["results"] == []
+    assert out["has_forbidden"] is False
+
+
+def test_only_claude_code_clean(tmp_path, capsys):
+    _claude_settings(tmp_path / ".claude" / "settings.json", ["Bash(lychee *)"])
+    rc = main(["audit-any", "--dir", str(tmp_path), "--families", ""])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["detected_harnesses"] == ["claude-code"]
+    assert out["has_forbidden"] is False
+    assert out["results"][0]["forbidden"] == []
+
+
+def test_claude_code_forbidden_exits_nonzero(tmp_path, capsys):
+    _claude_settings(tmp_path / ".claude" / "settings.json", ["Bash(uv run *)"])
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["has_forbidden"] is True
+    assert out["results"][0]["forbidden"][0]["pattern"] == "Bash(uv run *)"
+
+
+def test_only_opencode_clean(tmp_path, capsys):
+    _opencode_config(tmp_path / "opencode.json", {"bash": {"*": "ask"}})
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["detected_harnesses"] == ["opencode"]
+    assert out["has_forbidden"] is False
+    # OpenCode results have no missing_recommended key
+    assert "forbidden" in out["results"][0]
+
+
+def test_opencode_forbidden_exits_nonzero(tmp_path, capsys):
+    _opencode_config(tmp_path / "opencode.json", "allow")
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["has_forbidden"] is True
+    assert out["results"][0]["forbidden"][0]["kind"] == "blanket-allow"
+
+
+def test_both_harnesses_detected(tmp_path, capsys):
+    _claude_settings(tmp_path / ".claude" / "settings.json", ["Bash(lychee *)"])
+    _opencode_config(tmp_path / "opencode.json", {"bash": {"*": "ask"}})
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert set(out["detected_harnesses"]) == {"claude-code", "opencode"}
+    assert len(out["results"]) == 2
+
+
+def test_both_harnesses_one_forbidden(tmp_path, capsys):
+    _claude_settings(tmp_path / ".claude" / "settings.json", ["Bash(lychee *)"])
+    _opencode_config(tmp_path / "opencode.json", "allow")
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["has_forbidden"] is True
+
+
+def test_claude_local_settings_detected_separately(tmp_path, capsys):
+    _claude_settings(tmp_path / ".claude" / "settings.json", [])
+    _claude_settings(tmp_path / ".claude" / "settings.local.json", ["Bash(uv run *)"])
+    rc = main(["audit-any", "--dir", str(tmp_path)])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert "claude-code" in out["detected_harnesses"]
+    assert "claude-code-local" in out["detected_harnesses"]
+    # Only the local file has the forbidden entry
+    local_result = next(r for r in out["results"] if r["harness"] == "claude-code-local")
+    assert len(local_result["forbidden"]) == 1
+
+
+def test_dir_defaults_to_cwd_and_respects_explicit_dir(tmp_path, capsys):
+    # Explicitly setting --dir should let us point at any directory
+    _claude_settings(tmp_path / ".claude" / "settings.json", [])
+    rc = main(["audit-any", "--dir", str(tmp_path), "--families", ""])
+    out = json.loads(capsys.readouterr().out)
+    assert out["dir"] == str(tmp_path)
+    assert rc == 0
+
+
+def test_families_scoping_passed_through_to_claude_audit(tmp_path, capsys):
+    # With no families, only the default "" bucket is checked.
+    # "Bash(lychee *)" is in the "" bucket; with it present, no missing_recommended.
+    _claude_settings(tmp_path / ".claude" / "settings.json", ["Bash(lychee *)"])
+    rc = main(["audit-any", "--dir", str(tmp_path), "--families", ""])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert out["results"][0]["missing_recommended"] == []


### PR DESCRIPTION
## Summary

Add an `audit-any` subcommand that auto-detects every known settings
file in a project directory (.claude/settings.json,
.claude/settings.local.json, opencode.json) and audits each with the
appropriate classifier, with no harness-specific knowledge required
from the caller.

Change the tool's Harness declaration from Claude Code, OpenCode to
agnostic, making permission-audit the fourth substrate tool in the
harness-neutral bucket. Regenerate the vendor-neutrality.md scored block.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [X] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [X] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
