### PR TITLE
build(license): stamp ASF header into .gitignore files + enforce in prek

### DIFF
--- a/.apache-magpie-overrides/.gitignore
+++ b/.apache-magpie-overrides/.gitignore
@@ -1,1 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 user.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 /.idea/
 /.vscode/
 *.iml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,26 +63,28 @@ repos:
         args:
           - "--maxlevel"
           - "3"
-  # Stamp an SPDX Apache-2.0 licence identifier into Markdown files so the
-  # Apache RAT licence check (.github/workflows/rat.yml) sees an approved
-  # header on every scanned file. Markdown carries no comment header by
-  # convention, so RAT would otherwise flag it as unapproved. Plain
-  # Markdown gets an HTML-comment header on line 1; files with YAML front
-  # matter get a `# SPDX-License-Identifier` comment as the first line
-  # *inside* the front matter, so line 1 stays `---` and no new key is
-  # introduced for a front-matter validator to reject. The hook fixes files
-  # in place and fails the commit when it changes one (the end-of-file-fixer
-  # convention), so the contributor re-stages the now-stamped file. The
-  # `exclude` mirrors `.rat-excludes`: the third-party-licence detection
-  # fixtures deliberately contain non-Apache licence text and must not be
-  # stamped Apache-2.0.
+  # Stamp an approved Apache-2.0 licence header into Markdown and .gitignore
+  # files so the Apache RAT licence check (.github/workflows/rat.yml) — and
+  # any reviewer — sees an approved header on every one. Markdown and
+  # .gitignore carry no comment header by convention, so RAT would otherwise
+  # flag (or silently skip) them. Plain Markdown gets an HTML-comment header
+  # on line 1; files with YAML front matter get a `# SPDX-License-Identifier`
+  # comment as the first line *inside* the front matter, so line 1 stays
+  # `---` and no new key is introduced for a front-matter validator to
+  # reject; .gitignore gets the full ASF header as `#` comments (the block
+  # .gitattributes carries), matching the convention that hash-comment
+  # config files carry the full header. The hook fixes files in place and
+  # fails the commit when it changes one (the end-of-file-fixer convention),
+  # so the contributor re-stages the now-stamped file. The `exclude` mirrors
+  # `.rat-excludes`: the third-party-licence detection fixtures deliberately
+  # contain non-Apache licence text and must not be stamped Apache-2.0.
   - repo: local
     hooks:
       - id: add-license-headers
-        name: Stamp SPDX licence header into Markdown
+        name: Stamp Apache licence header into Markdown and .gitignore
         language: system
         entry: tools/dev/add-license-headers.py
-        files: \.md$
+        files: (\.md|(^|/)\.gitignore)$
         exclude: ^tools/skill-evals/evals/pr-management-code-review/step-4-third-party-license/fixtures/.*$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/projects/_template/.gitignore
+++ b/projects/_template/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 # Reassessment / reproducer campaign evidence packages are
 # local-only working material: description.md and issue.json are
 # verbatim, unredacted copies of the reporter's issue body and every

--- a/tools/cve-tool-vulnogram/generate-cve-json/.gitignore
+++ b/tools/cve-tool-vulnogram/generate-cve-json/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/cve-tool-vulnogram/oauth-api/.gitignore
+++ b/tools/cve-tool-vulnogram/oauth-api/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 __pycache__/
 .mypy_cache/
 .ruff_cache/

--- a/tools/dev/add-license-headers.py
+++ b/tools/dev/add-license-headers.py
@@ -15,15 +15,28 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Insert an SPDX Apache-2.0 licence header into Markdown files.
+"""Insert an Apache-2.0 licence header into Markdown and `.gitignore` files.
 
 Apache RAT (see `.github/workflows/rat.yml`) requires every scanned file
 to carry an approved licence header. Markdown carries no comment header by
 convention, so this script stamps an SPDX identifier and the licence URL
-that RAT recognises as an approved licence.
+that RAT recognises as an approved licence. `.gitignore` files are
+hash-comment config, so they get the full ASF header (the same block
+`.gitattributes` and `.pre-commit-config.yaml` carry) — matching the
+project convention that source/config files carry the full header while
+Markdown carries the SPDX identifier.
 
-Two placements, chosen per file so the stamp never breaks downstream
+Placements, chosen per file so the stamp never breaks downstream
 parsers:
+
+* **`.gitignore`** — the full ASF licence header as `#` comment lines,
+  prepended before the ignore patterns (a leading comment block is inert
+  to git's ignore parser)::
+
+      # Licensed to the Apache Software Foundation (ASF) under one
+      # ... (full ASF header) ...
+      # under the License.
+
 
 * **Plain Markdown** — a two-line HTML comment on the first line::
 
@@ -41,19 +54,20 @@ parsers:
       name: ...
 
 The operation is idempotent: a file that already carries any
-``SPDX-License-Identifier:`` declaration in its leading lines is left
-untouched, so a hand-written header in a different comment style is never
-double-stamped.
+``SPDX-License-Identifier:`` declaration — or the full ASF header's first
+line — in its leading lines is left untouched, so a hand-written header in
+a different comment style is never double-stamped.
 
 Usage::
 
     # Stamp specific files (the pre-commit / prek entry point; prek passes
-    # the staged Markdown files as arguments). Exits non-zero if any file
-    # was modified, so the commit fails and the contributor re-stages the
-    # now-stamped file — the same convention as end-of-file-fixer.
+    # the staged Markdown / .gitignore files as arguments). Exits non-zero
+    # if any file was modified, so the commit fails and the contributor
+    # re-stages the now-stamped file — the same convention as
+    # end-of-file-fixer.
     tools/dev/add-license-headers.py path/to/file.md ...
 
-    # Stamp every tracked Markdown file in the repository.
+    # Stamp every tracked Markdown and .gitignore file in the repository.
     tools/dev/add-license-headers.py --all
 """
 
@@ -72,6 +86,27 @@ SPDX_HTML = f"<!-- SPDX-License-Identifier: Apache-2.0\n     {_LICENSE_URL} -->"
 # YAML front matter: the same two lines as YAML comments, inserted after
 # the opening `---` so line 1 stays `---` and no key is introduced.
 SPDX_YAML = f"# SPDX-License-Identifier: Apache-2.0\n# {_LICENSE_URL}"
+
+# Full ASF licence header as `#` comments, for hash-comment config files
+# that carry no SPDX convention (`.gitignore`) — the same block
+# `.gitattributes` and `.pre-commit-config.yaml` carry.
+ASF_HEADER_HASH = """\
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License."""
 
 # How many leading lines to scan for an existing SPDX declaration.
 _SCAN_LINES = 12
@@ -97,10 +132,13 @@ def _already_stamped(lines: list[str]) -> bool:
     multi-line HTML comment) is left untouched rather than double-stamped.
     A bare mention of the token without a ``:`` value (prose describing
     SPDX) is not treated as a declaration, so such a file still gets a real
-    header.
+    header. The full ASF header (`.gitignore`) carries no SPDX token, so its
+    first line is recognised too.
     """
     for line in lines[:_SCAN_LINES]:
         if "SPDX-License-Identifier:" in line:
+            return True
+        if "Licensed to the Apache Software Foundation" in line:
             return True
     return False
 
@@ -112,9 +150,13 @@ def stamp(path: Path) -> bool:
     if _already_stamped(lines):
         return False
     if not text:
-        # An empty Markdown file has no content to license; leave it be.
+        # An empty file has no content to license; leave it be.
         return False
-    if lines[0].rstrip("\n") == "---":
+    if path.name == ".gitignore":
+        # Hash-comment config: full ASF header, then a blank line before the
+        # existing patterns (a leading comment block is inert to git).
+        new_text = ASF_HEADER_HASH + "\n\n" + text
+    elif lines[0].rstrip("\n") == "---":
         new_text = lines[0] + SPDX_YAML + "\n" + "".join(lines[1:])
     else:
         new_text = SPDX_HTML + "\n\n" + text
@@ -122,17 +164,24 @@ def stamp(path: Path) -> bool:
     return True
 
 
-def _tracked_markdown() -> list[Path]:
-    out = subprocess.check_output(["git", "ls-files", "*.md"], text=True)
+def _is_target(name: str) -> bool:
+    """Files this script stamps: Markdown and `.gitignore`."""
+    return name.endswith(".md") or name == ".gitignore"
+
+
+def _tracked_targets() -> list[Path]:
+    out = subprocess.check_output(
+        ["git", "ls-files", "*.md", ".gitignore", "**/.gitignore"], text=True
+    )
     return [Path(p) for p in out.splitlines()]
 
 
 def main(argv: list[str]) -> int:
     args = argv[1:]
     if "--all" in args:
-        targets = _tracked_markdown()
+        targets = _tracked_targets()
     else:
-        targets = [Path(a) for a in args if a.endswith(".md")]
+        targets = [Path(a) for a in args if _is_target(Path(a).name)]
 
     modified: list[Path] = []
     for path in targets:
@@ -144,7 +193,7 @@ def main(argv: list[str]) -> int:
             modified.append(path)
 
     for path in modified:
-        print(f"stamped SPDX header: {path}")
+        print(f"stamped licence header: {path}")
     if modified:
         print(f"\n{len(modified)} file(s) stamped. Re-stage them and commit again.")
         return 1

--- a/tools/egress-gateway/.gitignore
+++ b/tools/egress-gateway/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/gmail/oauth-draft/.gitignore
+++ b/tools/gmail/oauth-draft/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/privacy-llm/checker/.gitignore
+++ b/tools/privacy-llm/checker/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/privacy-llm/redactor/.gitignore
+++ b/tools/privacy-llm/redactor/.gitignore
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 __pycache__/
 *.py[cod]
 .venv/


### PR DESCRIPTION
## Why

The 9 tracked `.gitignore` files carried no licence header. Apache RAT
ignores `.gitignore` by default, so CI stayed green while they shipped
**unlicensed** — a gap for a source-first ASF project where the `git archive`
source zip *is* the release.

## What

Extend the existing `add-license-headers` hook (previously Markdown-only) to
also stamp `.gitignore`, with the **full ASF header** as `#` comments — the
same block `.gitattributes` and `.pre-commit-config.yaml` carry. This follows
the project convention (documented in `.rat-excludes`): hash-comment config
files carry the full header; Markdown carries the SPDX identifier. A leading
comment block is inert to git's ignore parser.

- **`tools/dev/add-license-headers.py`** — add `ASF_HEADER_HASH`; stamp
  `.gitignore` with it; recognise the ASF header's first line for
  idempotency; `--all` now covers tracked `.gitignore` too.
- **`.pre-commit-config.yaml`** — hook `files:` regex now matches
  `.gitignore`; hook name + comment updated.
- **Stamp all 9 existing `.gitignore` files.**

Idempotent (re-running is a no-op) and RAT-approved.

## Note on `.py`

`.py` files are already fully licensed (208 with the full ASF header, 2 with
the SPDX short form; zero unlicensed) and enforced by RAT in CI — they're just
stamped manually rather than by a hook. This PR closes the `.gitignore` gap
specifically; if you'd want `.py` auto-stamping too (with shebang handling),
that's a separate follow-up.
