### PR TITLE
ci(rat): enforce the ASF licence header on .gitignore files

### DIFF
--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -75,6 +75,12 @@ jobs:
           # off the report so contributors get the offending file list, not a
           # Java stack trace. --input-exclude-parsed-scm GIT honours
           # .gitignore; --input-exclude-std GIT/HIDDEN_DIR skips VCS metadata.
+          # --input-include '**/.gitignore' overrides those exclusions for the
+          # tracked .gitignore files themselves (parsed-scm GIT otherwise
+          # self-excludes the ignore files), so RAT enforces the ASF header
+          # that tools/dev/add-license-headers.py stamps into them. (.git/ is
+          # still skipped as a hidden dir; .apache-magpie-overrides/.gitignore
+          # stays excluded under its hidden dir.)
           jar="${RUNNER_TEMP}/apache-rat-${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
           report="${RUNNER_TEMP}/rat-report.txt"
           stderr_log="${RUNNER_TEMP}/rat-stderr.log"
@@ -82,6 +88,7 @@ jobs:
             --input-exclude-std GIT HIDDEN_DIR \
             --input-exclude-parsed-scm GIT \
             --input-exclude-file .rat-excludes \
+            --input-include '**/.gitignore' \
             --output-style unapproved-licenses \
             --output-file "${report}" \
             . 2>"${stderr_log}" && rc=0 || rc=$?


### PR DESCRIPTION
## Why

RAT already runs in CI, but it **was not scanning `.gitignore` files** — its
`--input-exclude-parsed-scm GIT` reads the `.gitignore` files and self-excludes
them, so the ASF headers stamped by the prek `add-license-headers` hook (added
in #846) were not actually enforced. A future headerless `.gitignore` would
slip through CI.

## What

Add `--input-include '**/.gitignore'` to the RAT invocation in
`.github/workflows/rat.yml`. `--input-include` overrides the SCM/std
exclusions for exactly the tracked `.gitignore` files, so RAT scans them and
requires an approved header.

## Verification (apache-rat 0.18, run locally)

- With the flag: **+8** `.gitignore` files move into scope (`Standards`
  2292 → 2300), all **Approved**, `Unapproved: 0`.
- Negative test: a `.gitignore` with no header is reported **Unapproved** and
  fails the check.
- `.git/` stays excluded as a hidden dir; `.apache-magpie-overrides/.gitignore`
  stays excluded under its hidden dir (no behaviour change there).

## Follow-up to #846

#846 (headers + prek stamper) is merged; this PR is rebased onto it, so the
diff is just the one-line workflow change.
