### PR TITLE
build(license): exclude .gitignore from RAT instead of stamping a header

### DIFF
--- a/.apache-magpie-overrides/.gitignore
+++ b/.apache-magpie-overrides/.gitignore
@@ -1,18 +1,1 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 user.md

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -75,12 +75,10 @@ jobs:
           # off the report so contributors get the offending file list, not a
           # Java stack trace. --input-exclude-parsed-scm GIT honours
           # .gitignore; --input-exclude-std GIT/HIDDEN_DIR skips VCS metadata.
-          # --input-include '**/.gitignore' overrides those exclusions for the
-          # tracked .gitignore files themselves (parsed-scm GIT otherwise
-          # self-excludes the ignore files), so RAT enforces the ASF header
-          # that tools/dev/add-license-headers.py stamps into them. (.git/ is
-          # still skipped as a hidden dir; .apache-magpie-overrides/.gitignore
-          # stays excluded under its hidden dir.)
+          # Tracked .gitignore files carry no licence header — they are
+          # hash-comment config with no downstream licensing significance —
+          # and are excluded via `.rat-excludes` (parsed-scm GIT also
+          # self-excludes the ignore files).
           jar="${RUNNER_TEMP}/apache-rat-${RAT_VERSION}/apache-rat-${RAT_VERSION}.jar"
           report="${RUNNER_TEMP}/rat-report.txt"
           stderr_log="${RUNNER_TEMP}/rat-stderr.log"
@@ -88,7 +86,6 @@ jobs:
             --input-exclude-std GIT HIDDEN_DIR \
             --input-exclude-parsed-scm GIT \
             --input-exclude-file .rat-excludes \
-            --input-include '**/.gitignore' \
             --output-style unapproved-licenses \
             --output-file "${report}" \
             . 2>"${stderr_log}" && rc=0 || rc=$?

--- a/.gitignore
+++ b/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 /.idea/
 /.vscode/
 *.iml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,28 +63,26 @@ repos:
         args:
           - "--maxlevel"
           - "3"
-  # Stamp an approved Apache-2.0 licence header into Markdown and .gitignore
-  # files so the Apache RAT licence check (.github/workflows/rat.yml) — and
-  # any reviewer — sees an approved header on every one. Markdown and
-  # .gitignore carry no comment header by convention, so RAT would otherwise
-  # flag (or silently skip) them. Plain Markdown gets an HTML-comment header
-  # on line 1; files with YAML front matter get a `# SPDX-License-Identifier`
-  # comment as the first line *inside* the front matter, so line 1 stays
-  # `---` and no new key is introduced for a front-matter validator to
-  # reject; .gitignore gets the full ASF header as `#` comments (the block
-  # .gitattributes carries), matching the convention that hash-comment
-  # config files carry the full header. The hook fixes files in place and
-  # fails the commit when it changes one (the end-of-file-fixer convention),
-  # so the contributor re-stages the now-stamped file. The `exclude` mirrors
-  # `.rat-excludes`: the third-party-licence detection fixtures deliberately
-  # contain non-Apache licence text and must not be stamped Apache-2.0.
+  # Stamp an SPDX Apache-2.0 licence identifier into Markdown files so the
+  # Apache RAT licence check (.github/workflows/rat.yml) sees an approved
+  # header on every scanned file. Markdown carries no comment header by
+  # convention, so RAT would otherwise flag it as unapproved. Plain
+  # Markdown gets an HTML-comment header on line 1; files with YAML front
+  # matter get a `# SPDX-License-Identifier` comment as the first line
+  # *inside* the front matter, so line 1 stays `---` and no new key is
+  # introduced for a front-matter validator to reject. The hook fixes files
+  # in place and fails the commit when it changes one (the end-of-file-fixer
+  # convention), so the contributor re-stages the now-stamped file. The
+  # `exclude` mirrors `.rat-excludes`: the third-party-licence detection
+  # fixtures deliberately contain non-Apache licence text and must not be
+  # stamped Apache-2.0.
   - repo: local
     hooks:
       - id: add-license-headers
-        name: Stamp Apache licence header into Markdown and .gitignore
+        name: Stamp SPDX licence header into Markdown
         language: system
         entry: tools/dev/add-license-headers.py
-        files: (\.md|(^|/)\.gitignore)$
+        files: \.md$
         exclude: ^tools/skill-evals/evals/pr-management-code-review/step-4-third-party-license/fixtures/.*$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0

--- a/.rat-excludes
+++ b/.rat-excludes
@@ -31,6 +31,12 @@
 # Python bytecode caches (untracked; present only in local runs)
 **/__pycache__/**
 
+# Git ignore files — hash-comment config with no downstream licensing
+# significance; carry no licence header. (parsed-scm GIT self-excludes
+# these too; listed here to make the exclusion explicit.)
+**/.gitignore
+.gitignore
+
 # Empty package markers
 **/__init__.py
 

--- a/projects/_template/.gitignore
+++ b/projects/_template/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 # Reassessment / reproducer campaign evidence packages are
 # local-only working material: description.md and issue.json are
 # verbatim, unredacted copies of the reporter's issue body and every

--- a/tools/cve-tool-vulnogram/generate-cve-json/.gitignore
+++ b/tools/cve-tool-vulnogram/generate-cve-json/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/cve-tool-vulnogram/oauth-api/.gitignore
+++ b/tools/cve-tool-vulnogram/oauth-api/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 __pycache__/
 .mypy_cache/
 .ruff_cache/

--- a/tools/dev/add-license-headers.py
+++ b/tools/dev/add-license-headers.py
@@ -15,28 +15,15 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""Insert an Apache-2.0 licence header into Markdown and `.gitignore` files.
+"""Insert an SPDX Apache-2.0 licence header into Markdown files.
 
 Apache RAT (see `.github/workflows/rat.yml`) requires every scanned file
 to carry an approved licence header. Markdown carries no comment header by
 convention, so this script stamps an SPDX identifier and the licence URL
-that RAT recognises as an approved licence. `.gitignore` files are
-hash-comment config, so they get the full ASF header (the same block
-`.gitattributes` and `.pre-commit-config.yaml` carry) — matching the
-project convention that source/config files carry the full header while
-Markdown carries the SPDX identifier.
+that RAT recognises as an approved licence.
 
-Placements, chosen per file so the stamp never breaks downstream
+Two placements, chosen per file so the stamp never breaks downstream
 parsers:
-
-* **`.gitignore`** — the full ASF licence header as `#` comment lines,
-  prepended before the ignore patterns (a leading comment block is inert
-  to git's ignore parser)::
-
-      # Licensed to the Apache Software Foundation (ASF) under one
-      # ... (full ASF header) ...
-      # under the License.
-
 
 * **Plain Markdown** — a two-line HTML comment on the first line::
 
@@ -54,20 +41,19 @@ parsers:
       name: ...
 
 The operation is idempotent: a file that already carries any
-``SPDX-License-Identifier:`` declaration — or the full ASF header's first
-line — in its leading lines is left untouched, so a hand-written header in
-a different comment style is never double-stamped.
+``SPDX-License-Identifier:`` declaration in its leading lines is left
+untouched, so a hand-written header in a different comment style is never
+double-stamped.
 
 Usage::
 
     # Stamp specific files (the pre-commit / prek entry point; prek passes
-    # the staged Markdown / .gitignore files as arguments). Exits non-zero
-    # if any file was modified, so the commit fails and the contributor
-    # re-stages the now-stamped file — the same convention as
-    # end-of-file-fixer.
+    # the staged Markdown files as arguments). Exits non-zero if any file
+    # was modified, so the commit fails and the contributor re-stages the
+    # now-stamped file — the same convention as end-of-file-fixer.
     tools/dev/add-license-headers.py path/to/file.md ...
 
-    # Stamp every tracked Markdown and .gitignore file in the repository.
+    # Stamp every tracked Markdown file in the repository.
     tools/dev/add-license-headers.py --all
 """
 
@@ -86,27 +72,6 @@ SPDX_HTML = f"<!-- SPDX-License-Identifier: Apache-2.0\n     {_LICENSE_URL} -->"
 # YAML front matter: the same two lines as YAML comments, inserted after
 # the opening `---` so line 1 stays `---` and no key is introduced.
 SPDX_YAML = f"# SPDX-License-Identifier: Apache-2.0\n# {_LICENSE_URL}"
-
-# Full ASF licence header as `#` comments, for hash-comment config files
-# that carry no SPDX convention (`.gitignore`) — the same block
-# `.gitattributes` and `.pre-commit-config.yaml` carry.
-ASF_HEADER_HASH = """\
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License."""
 
 # How many leading lines to scan for an existing SPDX declaration.
 _SCAN_LINES = 12
@@ -132,13 +97,10 @@ def _already_stamped(lines: list[str]) -> bool:
     multi-line HTML comment) is left untouched rather than double-stamped.
     A bare mention of the token without a ``:`` value (prose describing
     SPDX) is not treated as a declaration, so such a file still gets a real
-    header. The full ASF header (`.gitignore`) carries no SPDX token, so its
-    first line is recognised too.
+    header.
     """
     for line in lines[:_SCAN_LINES]:
         if "SPDX-License-Identifier:" in line:
-            return True
-        if "Licensed to the Apache Software Foundation" in line:
             return True
     return False
 
@@ -150,13 +112,9 @@ def stamp(path: Path) -> bool:
     if _already_stamped(lines):
         return False
     if not text:
-        # An empty file has no content to license; leave it be.
+        # An empty Markdown file has no content to license; leave it be.
         return False
-    if path.name == ".gitignore":
-        # Hash-comment config: full ASF header, then a blank line before the
-        # existing patterns (a leading comment block is inert to git).
-        new_text = ASF_HEADER_HASH + "\n\n" + text
-    elif lines[0].rstrip("\n") == "---":
+    if lines[0].rstrip("\n") == "---":
         new_text = lines[0] + SPDX_YAML + "\n" + "".join(lines[1:])
     else:
         new_text = SPDX_HTML + "\n\n" + text
@@ -164,24 +122,17 @@ def stamp(path: Path) -> bool:
     return True
 
 
-def _is_target(name: str) -> bool:
-    """Files this script stamps: Markdown and `.gitignore`."""
-    return name.endswith(".md") or name == ".gitignore"
-
-
-def _tracked_targets() -> list[Path]:
-    out = subprocess.check_output(
-        ["git", "ls-files", "*.md", ".gitignore", "**/.gitignore"], text=True
-    )
+def _tracked_markdown() -> list[Path]:
+    out = subprocess.check_output(["git", "ls-files", "*.md"], text=True)
     return [Path(p) for p in out.splitlines()]
 
 
 def main(argv: list[str]) -> int:
     args = argv[1:]
     if "--all" in args:
-        targets = _tracked_targets()
+        targets = _tracked_markdown()
     else:
-        targets = [Path(a) for a in args if _is_target(Path(a).name)]
+        targets = [Path(a) for a in args if a.endswith(".md")]
 
     modified: list[Path] = []
     for path in targets:
@@ -193,7 +144,7 @@ def main(argv: list[str]) -> int:
             modified.append(path)
 
     for path in modified:
-        print(f"stamped licence header: {path}")
+        print(f"stamped SPDX header: {path}")
     if modified:
         print(f"\n{len(modified)} file(s) stamped. Re-stage them and commit again.")
         return 1

--- a/tools/egress-gateway/.gitignore
+++ b/tools/egress-gateway/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/gmail/oauth-draft/.gitignore
+++ b/tools/gmail/oauth-draft/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/privacy-llm/checker/.gitignore
+++ b/tools/privacy-llm/checker/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 __pycache__/
 *.py[cod]
 .venv/

--- a/tools/privacy-llm/redactor/.gitignore
+++ b/tools/privacy-llm/redactor/.gitignore
@@ -1,20 +1,3 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
-
 __pycache__/
 *.py[cod]
 .venv/


### PR DESCRIPTION
Reverses #846 and #847. Instead of stamping the full ASF header into every tracked `.gitignore` and forcing RAT to scan them, this treats `.gitignore` as hash-comment config with no downstream licensing significance and excludes it from the RAT check — per @justinmclean's point on #847 that a `.gitignore` is just a list of files and needs no header.

- Strip the ASF header from all 9 tracked `.gitignore` files.
- `.rat-excludes`: add an explicit `**/.gitignore` + `.gitignore` exclusion (parsed-scm GIT self-excludes them too; the entry makes it explicit).
- `.github/workflows/rat.yml`: drop `--input-include '**/.gitignore'`, so the default exclusion holds again.
- `tools/dev/add-license-headers.py`: revert to Markdown-only.
- `.pre-commit-config.yaml`: hook `files:` back to `\.md$`.