### PR TITLE
feat(setup): add .apache-magpie-local/ personal override surface

### DIFF
--- a/docs/setup/agentic-overrides.md
+++ b/docs/setup/agentic-overrides.md
@@ -6,7 +6,8 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Agentic overrides — modifying framework workflows in an adopter](#agentic-overrides--modifying-framework-workflows-in-an-adopter)
-  - [Where override files live](#where-override-files-live)
+  - [Override surfaces — two directories, one lookup chain](#override-surfaces--two-directories-one-lookup-chain)
+    - [Adoption and `.gitignore`](#adoption-and-gitignore)
   - [What an override file may contain](#what-an-override-file-may-contain)
     - [Skip a step](#skip-a-step)
     - [Replace a step](#replace-a-step)
@@ -40,19 +41,52 @@ run-time and applies before executing default behaviour.
 This document is the **contract** between adopter authors of
 override files and framework authors of skills that read them.
 
-## Where override files live
+## Override surfaces — two directories, one lookup chain
+
+Framework skills consult **two** override directories in precedence
+order, first hit wins:
+
+1. **`.apache-magpie-local/<skill>.md`** — personal, gitignored.
+   Per-developer preferences (local clone paths, a release manager
+   enabling an extra MCP, wording adjustments) that should not be
+   committed to the shared repo.  Never committed; never pushed.
+   Works on a repo that has not yet adopted Magpie — the user adds
+   one `.gitignore` line by hand so the directory stays untracked,
+   then drops their overrides there.  The same additive-only
+   guardrail applies: it cannot weaken the safety, confidentiality,
+   or privacy baseline.
+
+2. **`.apache-magpie-overrides/<skill>.md`** — committed,
+   project-wide.  Shared modifications every contributor on the
+   project sees (custom steps, project-specific defaults, integrations
+   with project tooling).
 
 ```text
-<adopter-repo>/.apache-magpie-overrides/
-├── README.md                            (the dir's own readme,
-│                                          scaffolded by
-│                                          /magpie-setup adopt)
-├── <framework-skill-name>.md            (e.g. pr-management-triage.md)
-└── <other-framework-skill-name>.md
+<adopter-repo>/
+├── .apache-magpie-local/                (gitignored, per-person)
+│   └── <framework-skill-name>.md       (e.g. pr-management-triage.md)
+├── .apache-magpie-overrides/            (committed, project-wide)
+│   ├── README.md                        (scaffolded by /magpie-setup adopt)
+│   ├── <framework-skill-name>.md
+│   └── <other-framework-skill-name>.md
 ```
 
-The directory is **committed** in the adopter repo (the whole
-point is for overrides to ship with the project's repo).
+When both directories contain a file for the same skill, the
+personal-local file wins — its instructions are applied first,
+then (by default) the committed file's instructions are also applied
+unless the personal file explicitly says to skip it.  Neither file
+is required to exist; a skill that finds neither proceeds with
+framework defaults.
+
+### Adoption and `.gitignore`
+
+`/magpie-setup adopt` adds `/.apache-magpie-local/` to the adopter
+repo's `.gitignore` automatically.  On a repo that has not adopted
+Magpie, add the line manually:
+
+```text
+/.apache-magpie-local/
+```
 
 ## What an override file may contain
 
@@ -128,17 +162,24 @@ maintainer (or a future agent on a later run):
 Every framework skill that supports overrides starts each
 invocation with this opening protocol:
 
-1. Read `<adopter-repo>/.apache-magpie-overrides/<this-skill>.md`
-   if it exists. Surface the file's title and the list of
-   override headlines (`### Override N — ...`) to the user
-   before doing anything else.
-2. Apply the overrides: each `### Override N — ...` section
-   modifies the skill's default behaviour for this run. The
-   agent interprets the instructions in the override section
-   and adjusts the rest of the skill's flow accordingly.
-3. After the skill finishes, recap which overrides were
-   applied (and any the agent decided not to apply with the
-   reasoning), so the user has an audit trail.
+1. Read `<adopter-repo>/.apache-magpie-local/<this-skill>.md`
+   (personal, gitignored) if it exists.
+2. Read `<adopter-repo>/.apache-magpie-overrides/<this-skill>.md`
+   (committed, project-wide) if it exists.
+3. Surface the titles and override headlines
+   (`### Override N — ...`) from both files to the user
+   before doing anything else.  Indicate which file each
+   came from so the user can tell personal from shared
+   overrides at a glance.
+4. Apply both sets of overrides: personal-local first, then
+   committed.  Each `### Override N — ...` section modifies
+   the skill's default behaviour for this run.  The agent
+   interprets the instructions and adjusts the rest of the
+   skill's flow accordingly.
+5. After the skill finishes, recap which overrides were
+   applied (source file + override headline), and any the
+   agent decided not to apply with the reasoning, so the user
+   has an audit trail.
 
 A skill that does **not** yet support overrides documents
 that explicitly in its `SKILL.md`. The
@@ -155,7 +196,12 @@ A framework agent NEVER:
   `<adopter-repo>/.apache-magpie/`. The snapshot is a build
   artefact — every modification gets blown away on the next
   `/magpie-setup upgrade`. Local mods go into
-  `.apache-magpie-overrides/`.
+  `.apache-magpie-local/` (personal) or
+  `.apache-magpie-overrides/` (shared).
+- Commits or pushes `.apache-magpie-local/` content. The
+  personal override directory is gitignored by design — it
+  carries per-person paths, credentials, and capability
+  enablements the contributor has not chosen to share.
 - Proposes overrides be merged in by editing the framework
   source in the snapshot. Framework changes go via PR to
   `apache/magpie`.
@@ -165,6 +211,9 @@ A framework agent NEVER:
   human decide (the override expresses adopter intent —
   re-anchoring it correctly is human judgement, not
   pattern-matching).
+- Weakens the safety, confidentiality, or privacy baseline
+  from either override surface.  An override that attempts
+  to do so is ignored and the conflict is surfaced.
 
 ## Reconciliation on framework upgrade
 
@@ -246,6 +295,13 @@ this by:
 
 ## Cross-references
 
-- [`setup` skill](../../skills/setup/SKILL.md) — the entry point that manages the snapshot + scaffolds overrides.
-- [`overrides.md` sub-action](../../skills/setup/overrides.md) — interactive override creation.
+- [`setup` skill](../../skills/setup/SKILL.md) — the entry point
+  that manages the snapshot, scaffolds overrides, and adds the
+  `.gitignore` entries for both override directories.
+- [`overrides.md` sub-action](../../skills/setup/overrides.md) —
+  interactive override creation (lets the user choose between the
+  personal-local and committed surfaces).
 - [Top-level README](../../README.md) — adoption flow.
+- [`setup-status` skill](../../skills/setup-status/SKILL.md) —
+  the adoption dashboard, which reports whether both override
+  directories are present.

--- a/skills/setup-status/SKILL.md
+++ b/skills/setup-status/SKILL.md
@@ -59,12 +59,15 @@ it rather than duplicating its checks.
 ## Adopter overrides
 
 Before running the default behaviour documented below, this skill
-consults
-[`.apache-magpie-overrides/setup-status.md`](../../docs/setup/agentic-overrides.md)
-in the adopter repo if it exists, and applies any agent-readable
-overrides it finds. See
+consults (in order, first hit wins):
+
+1. `.apache-magpie-local/setup-status.md` — personal, gitignored.
+2. `.apache-magpie-overrides/setup-status.md` — committed,
+   project-wide.
+
+Both files are applied if present.  See
 [`docs/setup/agentic-overrides.md`](../../docs/setup/agentic-overrides.md)
-for the contract.
+for the full lookup contract.
 
 **Hard rule**: agents NEVER modify the snapshot under
 `<adopter-repo>/.apache-magpie/`. Local modifications go in the

--- a/skills/setup-status/collect.md
+++ b/skills/setup-status/collect.md
@@ -35,7 +35,8 @@ python3 <framework>/skills/setup-status/scripts/collect_status.py --format json 
 | `agent_targets` | One record per registry target (see below). |
 | `active_target_ids` | The subset of registry ids whose directory is present on disk. |
 | `families` | The installed-skill roster grouped by family (see below). |
-| `overrides` | `{present, has_readme}` for `.apache-magpie-overrides/`. |
+| `overrides` | `{present, has_readme, skill_count}` for `.apache-magpie-overrides/` (committed, shared). |
+| `local_overrides` | `{present, has_readme, skill_count}` for `.apache-magpie-local/` (gitignored, personal). Always reported; `present: false` when the directory does not exist. |
 | `post_checkout_hook` | `{present, executable, has_verify_recipe}`. |
 | `gitignore` | Coverage flags (see below). |
 
@@ -106,7 +107,9 @@ for the *intended* set, and use the on-disk read for the
 ## `gitignore`
 
 Top-level flags (`snapshot_ignored`, `local_lock_ignored`,
-`settings_local_ignored`) plus a per-target map. Each target
+`local_overrides_ignored`, `settings_local_ignored`) plus a
+per-target map.  `local_overrides_ignored` is `true` when
+`/.apache-magpie-local/` appears in `.gitignore`. Each target
 carries `glob_ignored` + `setup_unignored` (the **normal-adopter**
 pattern: ignore the symlinks, keep the bootstrap tracked) and
 `all_unignored` (the **self-adoption** pattern: every `magpie-*`

--- a/skills/setup-status/render.md
+++ b/skills/setup-status/render.md
@@ -69,7 +69,8 @@ security ✅ 12 · pr-management ✅ 8 · issue ✅ 8 · release-management ✅ 
 ### Drift & integrity
 
 - **drift:** n/a (method:local …) · **snapshot:** in-repo source (local)
-- **overrides:** — · **hook:** —
+- **shared overrides** (`.apache-magpie-overrides/`): — · **personal overrides** (`.apache-magpie-local/`): —
+- **hook:** —
 - → deep check (integrity, permissions, worktrees): `/magpie-setup verify`
 ```
 
@@ -107,6 +108,8 @@ this before assigning health:
 | `gitignore.targets[].all_unignored` | ✅ expected — symlinks are committed | not the pattern used; ignore |
 | `gitignore.targets[].glob_ignored` + `setup_unignored` | not used | ✅ expected — symlinks gitignored, bootstrap tracked |
 | `drift.checked == false` | ✅ nothing to drift against | depends on `reason` (see [`collect.md`](collect.md#drift)) |
+| `local_overrides.present == false` | ✅ optional personal surface — not required | ✅ same — `.apache-magpie-local/` is always optional |
+| `gitignore.local_overrides_ignored == false` | advisory: add `/.apache-magpie-local/` to `.gitignore` | same advisory |
 
 Never report a self-adopted framework checkout as unhealthy merely
 for lacking a snapshot, a local lock, or ignored symlinks — those

--- a/skills/setup-status/scripts/collect_status.py
+++ b/skills/setup-status/scripts/collect_status.py
@@ -19,10 +19,11 @@
 
 Read-only. Enumerates the on-disk adoption artefacts —
 the two lock files, the framework-skill symlinks across every
-agent target, the snapshot, the overrides directory, the
-post-checkout hook, and the .gitignore coverage — and emits a
-single JSON document the ``setup-status`` skill renders into a
-dashboard.
+agent target, the snapshot, the overrides directories (both the
+committed .apache-magpie-overrides/ and the personal
+.apache-magpie-local/), the post-checkout hook, and the
+.gitignore coverage — and emits a single JSON document the
+``setup-status`` skill renders into a dashboard.
 
 The script never fetches over the network and never writes: the
 upstream-tip drift check and any remediation belong to
@@ -302,6 +303,7 @@ def gitignore_coverage(root: Path, targets: list[dict]) -> dict:
         "present": gi.is_file(),
         "snapshot_ignored": "/.apache-magpie/" in lines,
         "local_lock_ignored": "/.apache-magpie.local.lock" in lines,
+        "local_overrides_ignored": "/.apache-magpie-local/" in lines,
         "settings_local_ignored": "/.claude/settings.local.json" in lines,
         "targets": {},
     }
@@ -321,6 +323,22 @@ def gitignore_coverage(root: Path, targets: list[dict]) -> dict:
             "all_unignored": keep_all in lines,
         }
     return cov
+
+
+def override_dir_status(root: Path, dirname: str) -> dict:
+    """Describe one override directory (committed or personal-local)."""
+    d = root / dirname
+    if not d.is_dir():
+        return {"present": False, "has_readme": False, "skill_count": 0}
+    skill_files = [
+        p for p in d.iterdir()
+        if p.is_file() and p.suffix == ".md" and p.name != "README.md"
+    ]
+    return {
+        "present": True,
+        "has_readme": (d / "README.md").is_file(),
+        "skill_count": len(skill_files),
+    }
 
 
 def hook_status(root: Path) -> dict:
@@ -435,9 +453,20 @@ def render_markdown(d: dict) -> str:
     out.append("### Drift & integrity")
     out.append("")
     out.append(f"- **drift:** {drift_line} · **snapshot:** {snap}")
+    ov = d["overrides"]
+    local_ov = d["local_overrides"]
+    ov_text = f"present ({ov['skill_count']} skill(s))" if ov["present"] else "—"
+    local_ov_text = (
+        f"present ({local_ov['skill_count']} skill(s))"
+        if local_ov["present"]
+        else "—"
+    )
     out.append(
-        f"- **overrides:** {'present' if d['overrides']['present'] else '—'} · "
-        f"**hook:** {'installed' if d['post_checkout_hook']['present'] else '—'}"
+        f"- **shared overrides** (`.apache-magpie-overrides/`): {ov_text} · "
+        f"**personal overrides** (`.apache-magpie-local/`): {local_ov_text}"
+    )
+    out.append(
+        f"- **hook:** {'installed' if d['post_checkout_hook']['present'] else '—'}"
     )
     out.append("- → deep check (integrity, permissions, worktrees): `/magpie-setup verify`")
     return "\n".join(out) + "\n"
@@ -485,10 +514,8 @@ def main(argv: list[str] | None = None) -> int:
         "agent_targets": targets,
         "active_target_ids": [t["id"] for t in targets if t["present"]],
         "families": families_installed(canonical["entries"]),
-        "overrides": {
-            "present": (root / ".apache-magpie-overrides").is_dir(),
-            "has_readme": (root / ".apache-magpie-overrides" / "README.md").is_file(),
-        },
+        "overrides": override_dir_status(root, ".apache-magpie-overrides"),
+        "local_overrides": override_dir_status(root, ".apache-magpie-local"),
         "post_checkout_hook": hook_status(root),
         "gitignore": gitignore_coverage(root, targets),
     }

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -246,6 +246,8 @@ Gitignored in the adopter repo:
 - `<snapshot-dir>` (the entire framework snapshot — gigabytes
   potentially).
 - `<local-lock>` (per-machine state).
+- `.apache-magpie-local/` (personal, per-developer override
+  directory — see Golden rule 7).
 - The `magpie-*` symlinks `setup adopt` creates in every active
   target dir — the canonical ones in `.agents/skills/` (they
   target the gitignored snapshot) and the relays in
@@ -298,13 +300,21 @@ silently mis-applies.
 
 **Golden rule 7 — agentic overrides are read at run-time.**
 Every framework skill that supports overrides starts its run
-by checking `.apache-magpie-overrides/<this-skill>.md` for
-adopter-specific instructions and applying them before
-executing the default behaviour. The override file is plain
-markdown the agent interprets — no templating engine, no
-patch tool. See
+by consulting **two** directories in precedence order (first
+hit wins):
+
+1. `.apache-magpie-local/<this-skill>.md` — personal,
+   gitignored. Per-developer overrides that are never
+   committed.
+2. `.apache-magpie-overrides/<this-skill>.md` — committed,
+   project-wide. Overrides shared with every contributor.
+
+Both files are plain markdown the agent interprets — no
+templating engine, no patch tool. The additive-only guardrail
+applies to both: neither may weaken the framework's safety,
+confidentiality, or privacy baseline. See
 [`docs/setup/agentic-overrides.md`](../../docs/setup/agentic-overrides.md)
-for the contract.
+for the full contract including the lookup protocol.
 
 **Golden rule 8 — family membership is declared in
 frontmatter; two families are *always* installed, the rest

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -556,6 +556,7 @@ idempotent — re-add them if they're missing.
 ```text
 /.apache-magpie/
 /.apache-magpie.local.lock
+/.apache-magpie-local/
 /.apache-magpie-sources/
 /.apache-magpie.sources.local.lock
 /.claude/settings.local.json
@@ -757,10 +758,26 @@ in the framework for the full contract.
 **Hard rule**: never modify the snapshot under
 `<repo-root>/.apache-magpie/`. Local mods go here.
 Framework changes go via PR to `apache/magpie`.
+
+**Personal (non-shared) overrides** belong in
+`<repo-root>/.apache-magpie-local/` (gitignored). Use that
+directory for per-developer paths, local tooling, or role-
+specific capability enablements you do not want committed
+to this repo.
 ```
 
 This directory is **committed** (overrides ship with the
 adopter repo).
+
+Tell the user about the personal override surface:
+
+> *"`.apache-magpie-local/` is gitignored (already in
+> `.gitignore`). Create it at any time for per-person
+> overrides that should not be committed — capability
+> enablements, local clone paths, wording you want only
+> for yourself. The framework reads it before the
+> committed `.apache-magpie-overrides/` on every skill
+> invocation."*
 
 ## Step 9b — Scaffold `user.md` (FRESH only)
 

--- a/skills/setup/overrides.md
+++ b/skills/setup/overrides.md
@@ -24,21 +24,57 @@ in the framework. This file is the operational helper.
 
 - `<framework-skill>` — required. The skill name to scaffold
   / open the override for (e.g. `pr-management-triage`).
+- `--local` — place the override in `.apache-magpie-local/`
+  (personal, gitignored) instead of `.apache-magpie-overrides/`
+  (committed, project-wide). Default: prompt.
 
 ## Step 0 — Pre-flight
 
-1. The repo must be adopted (see [`verify.md`](verify.md)
-   check 1 + check 5). If not, redirect to `/magpie-setup
-   adopt`.
-2. The named `<framework-skill>` must exist in the snapshot at
-   `<repo-root>/.apache-magpie/skills/<framework-skill>/`.
-   If not, name the typo and list the available framework
-   skills.
+1. The named `<framework-skill>` must exist in the snapshot at
+   `<repo-root>/.apache-magpie/skills/<framework-skill>/` (or
+   in the in-repo `skills/` for a self-adopted framework
+   checkout). If not, name the typo and list the available
+   framework skills.
+2. For the committed surface (`.apache-magpie-overrides/`): the
+   repo must be adopted (see [`verify.md`](verify.md) check 1 +
+   check 5). If not, redirect to `/magpie-setup adopt` **or**
+   suggest using `--local` to create a personal override
+   without adopting.
+
+## Step 0b — Choose the override surface
+
+If `--local` was passed, route to the personal surface:
+`<override-path>` = `<repo-root>/.apache-magpie-local/<framework-skill>.md`.
+
+If `--local` was not passed and the repo is adopted, offer a
+choice:
+
+> *"Where should this override live?*
+>
+> - **Personal** (`.apache-magpie-local/`, gitignored) —
+>   only you see it; works even on repos you have not adopted
+>   Magpie into.  Use for per-person paths, local tooling,
+>   role-specific capabilities.
+> - **Shared** (`.apache-magpie-overrides/`, committed) —
+>   all contributors see it on their next clone or pull.
+>   Use for project-wide process changes.*"
+
+If the repo is not adopted and `--local` was not passed:
+offer only the personal surface and note that the committed
+surface requires adoption first.
+
+Default to **personal** when the user has not expressed a
+preference.
 
 ## Step 1 — Resolve the override path
 
-`<override-path>` =
-`<repo-root>/.apache-magpie-overrides/<framework-skill>.md`.
+Per the surface chosen in Step 0b:
+- **Personal:** `<override-path>` = `<repo-root>/.apache-magpie-local/<framework-skill>.md`.
+- **Shared:** `<override-path>` = `<repo-root>/.apache-magpie-overrides/<framework-skill>.md`.
+
+Also check the *other* surface: if a file already exists
+there for the same skill, surface its headlines so the user
+can decide whether to consolidate.
 
 If `<override-path>` already exists, this is an *open*
 operation: surface the file's current content, ask the user
@@ -70,12 +106,17 @@ Use the canonical scaffold below.
 
 ## Override file scaffold
 
+Use the same scaffold for both surfaces.  The `Surface:` comment
+distinguishes personal from shared overrides.
+
 ```markdown
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/legal/release-policy.html -->
 
 <!-- apache-magpie agentic override
      Framework skill:    <framework-skill>
+     Surface:            personal (.apache-magpie-local/) OR
+                         shared (.apache-magpie-overrides/)
      Pinned to snapshot: see ../.apache-magpie.lock for the SHA
                           this override was authored against.
      Applied by:         the framework skill at run-time, before
@@ -110,15 +151,20 @@ Whenever the skill scaffolds or opens an override file,
 remind the user:
 
 1. **Never modify the snapshot** at
-   `<repo-root>/.apache-magpie/`. Local mods go in this
-   override file.
-2. **If the override is widely useful, upstream it.** Open a
+   `<repo-root>/.apache-magpie/`. Local mods go in
+   `.apache-magpie-local/` (personal) or
+   `.apache-magpie-overrides/` (shared).
+2. **`.apache-magpie-local/` is gitignored and personal.**
+   Do not commit or push it. If others on the project need
+   the same behaviour, move the override into the committed
+   `.apache-magpie-overrides/` instead.
+3. **If the override is widely useful, upstream it.** Open a
    PR against `apache/magpie` implementing the change
    in the framework skill itself. The framework will then
    apply the change on every adopter's next
    `/magpie-setup upgrade`, and this adopter's override
    becomes redundant — at which point the user deletes it.
-3. **Re-anchor on framework upgrades.** The skill's
+4. **Re-anchor on framework upgrades.** The skill's
    [`upgrade.md`](upgrade.md) sub-action surfaces conflicts
    when a framework upgrade restructures a skill the user has
    an override for. Re-anchor when prompted.
@@ -127,6 +173,11 @@ remind the user:
 
 - **Snapshot missing** → redirect to `/magpie-setup upgrade`.
 - **Skill name typo** → list available skills, ask again.
+- **Non-adopted repo + no `--local` flag** → the committed
+  surface is unavailable; offer the personal surface
+  (`.apache-magpie-local/`) as the fallback and note the
+  user should run `/magpie-setup` to adopt if they want
+  the shared surface.
 - **The override target is on a framework skill that does
   not consult overrides** → the framework treats overrides
   as opt-in per skill (each skill that supports overrides

--- a/tools/skill-evals/evals/setup-status/README.md
+++ b/tools/skill-evals/evals/setup-status/README.md
@@ -5,7 +5,7 @@
 
 Behavioral evals for the `setup-status` skill.
 
-## Suites (14 cases total)
+## Suites (18 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
@@ -13,6 +13,7 @@ Behavioral evals for the `setup-status` skill.
 | step-1-command | Step 1 (collector command selection) | 4 | default, --no-adjust, --format json, injection ignored |
 | step-2-present | Step 1 output rule (verbatim presentation) | 3 | standard, user requests summary, user requests reformat |
 | step-3-adjust-decision | Step 3 (adjust delta detection) | 4 | --no-adjust flag, clean state, target unwired, family not installed |
+| step-4-local-overrides | Step 1 (local override surface) | 4 | local absent, local present, both surfaces, gitignore missing |
 
 ## Run
 
@@ -65,3 +66,12 @@ Given invocation context and collected adoption state, the model detects configu
 - **case-2**: Clean state, no gaps → no offer (adoption fully wired).
 - **case-3**: Registry target `github` present on disk but unwired → offer add-target; delegate to `/magpie-setup adopt agents:universal,claude-code,github`.
 - **case-4**: Two opt-in families not installed → offer install-families; delegate to `/magpie-setup adopt skill-families:security,pr-management,issue`.
+
+### step-4-local-overrides
+
+Given the dashboard output (which now includes both `shared overrides` and `personal overrides` lines), the model correctly reads which override surfaces are present and how many skill files each contains.
+
+- **case-1**: `.apache-magpie-local/` absent, shared overrides present → `local_overrides_present: false`, `shared_overrides_present: true`.
+- **case-2**: `.apache-magpie-local/` present with 3 skills, no shared overrides → `local_overrides_present: true`, count 3.
+- **case-3**: Both surfaces present → `shared_overrides_present: true`, `local_overrides_present: true`.
+- **case-4**: Both present, `.gitignore` missing the local entry → still reads both as present; advisory is a separate concern.

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-1-local-absent/expected.json
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-1-local-absent/expected.json
@@ -1,0 +1,1 @@
+{"shared_overrides_present": true, "local_overrides_present": false, "local_overrides_skill_count": 0, "presentation_mode": "verbatim"}

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-1-local-absent/report.md
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-1-local-absent/report.md
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+The collector emitted this dashboard:
+
+```markdown
+## apache-magpie adoption — myproject
+
+**mode:** git-branch · **pinned:** main · **verdict:** ✅ healthy
+
+### Agent targets
+
+| Target | Dir | Kind | Skills | Status |
+|---|---|---|---|---|
+| universal | `.agents/skills` | canonical-snapshot | 12 | ✅ wired |
+| claude-code | `.claude/skills` | relay | 12 | ✅ wired |
+
+**serves** (which agents read each target dir):
+
+- `universal` — Codex, Cursor, Gemini CLI, GitHub Copilot, OpenCode, Cline, Zed, Warp, Amp, …
+- `claude-code` — Claude Code
+
+### Skill families
+
+| Family | Type | Installed |
+|---|---|---|
+| security | opt-in | ✅ 12 |
+| pr-management | opt-in | — none |
+
+### Drift & integrity
+
+- **drift:** ✅ in sync · **snapshot:** present
+- **shared overrides** (`.apache-magpie-overrides/`): present (1 skill(s)) · **personal overrides** (`.apache-magpie-local/`): —
+- **hook:** installed
+- → deep check (integrity, permissions, worktrees): `/magpie-setup verify`
+```

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-2-local-present/expected.json
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-2-local-present/expected.json
@@ -1,0 +1,1 @@
+{"shared_overrides_present": false, "local_overrides_present": true, "local_overrides_skill_count": 3, "presentation_mode": "verbatim"}

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-2-local-present/report.md
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-2-local-present/report.md
@@ -1,0 +1,33 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+The collector emitted this dashboard:
+
+```markdown
+## apache-magpie adoption — myproject
+
+**mode:** git-branch · **pinned:** main · **verdict:** ✅ healthy
+
+### Agent targets
+
+| Target | Dir | Kind | Skills | Status |
+|---|---|---|---|---|
+| universal | `.agents/skills` | canonical-snapshot | 12 | ✅ wired |
+
+**serves** (which agents read each target dir):
+
+- `universal` — Codex, Cursor, Gemini CLI, GitHub Copilot, OpenCode, Cline, Zed, Warp, Amp, …
+
+### Skill families
+
+| Family | Type | Installed |
+|---|---|---|
+| security | opt-in | ✅ 12 |
+
+### Drift & integrity
+
+- **drift:** ✅ in sync · **snapshot:** present
+- **shared overrides** (`.apache-magpie-overrides/`): — · **personal overrides** (`.apache-magpie-local/`): present (3 skill(s))
+- **hook:** installed
+- → deep check (integrity, permissions, worktrees): `/magpie-setup verify`
+```

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-3-both-surfaces/expected.json
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-3-both-surfaces/expected.json
@@ -1,0 +1,1 @@
+{"shared_overrides_present": true, "local_overrides_present": true, "local_overrides_skill_count": 1, "presentation_mode": "verbatim"}

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-3-both-surfaces/report.md
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-3-both-surfaces/report.md
@@ -1,0 +1,33 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+The collector emitted this dashboard:
+
+```markdown
+## apache-magpie adoption — myproject
+
+**mode:** git-branch · **pinned:** main · **verdict:** ✅ healthy
+
+### Agent targets
+
+| Target | Dir | Kind | Skills | Status |
+|---|---|---|---|---|
+| universal | `.agents/skills` | canonical-snapshot | 12 | ✅ wired |
+
+**serves** (which agents read each target dir):
+
+- `universal` — Codex, Cursor, Gemini CLI, GitHub Copilot, OpenCode, Cline, Zed, Warp, Amp, …
+
+### Skill families
+
+| Family | Type | Installed |
+|---|---|---|
+| security | opt-in | ✅ 12 |
+
+### Drift & integrity
+
+- **drift:** ✅ in sync · **snapshot:** present
+- **shared overrides** (`.apache-magpie-overrides/`): present (2 skill(s)) · **personal overrides** (`.apache-magpie-local/`): present (1 skill(s))
+- **hook:** installed
+- → deep check (integrity, permissions, worktrees): `/magpie-setup verify`
+```

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-4-gitignore-missing/expected.json
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-4-gitignore-missing/expected.json
@@ -1,0 +1,1 @@
+{"shared_overrides_present": true, "local_overrides_present": true, "local_overrides_skill_count": 2, "presentation_mode": "verbatim"}

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-4-gitignore-missing/report.md
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/case-4-gitignore-missing/report.md
@@ -1,0 +1,36 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+The collector emitted this dashboard:
+
+```markdown
+## apache-magpie adoption — myproject
+
+**mode:** git-branch · **pinned:** main · **verdict:** ✅ healthy
+
+### Agent targets
+
+| Target | Dir | Kind | Skills | Status |
+|---|---|---|---|---|
+| universal | `.agents/skills` | canonical-snapshot | 12 | ✅ wired |
+
+**serves** (which agents read each target dir):
+
+- `universal` — Codex, Cursor, Gemini CLI, GitHub Copilot, OpenCode, Cline, Zed, Warp, Amp, …
+
+### Skill families
+
+| Family | Type | Installed |
+|---|---|---|
+| security | opt-in | ✅ 12 |
+
+### Drift & integrity
+
+- **drift:** ✅ in sync · **snapshot:** present
+- **shared overrides** (`.apache-magpie-overrides/`): present (1 skill(s)) · **personal overrides** (`.apache-magpie-local/`): present (2 skill(s))
+- **hook:** installed
+- → deep check (integrity, permissions, worktrees): `/magpie-setup verify`
+```
+
+The raw JSON also showed: `gitignore.local_overrides_ignored: false`
+The `.apache-magpie-local/` directory is present on disk but `/.apache-magpie-local/` is not in `.gitignore`.

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/output-spec.md
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "shared_overrides_present": true | false,
+  "local_overrides_present": true | false,
+  "local_overrides_skill_count": <integer>,
+  "presentation_mode": "verbatim" | "paraphrase"
+}
+```
+
+`shared_overrides_present` is `true` when `.apache-magpie-overrides/` is reported as present.
+`local_overrides_present` is `true` when `.apache-magpie-local/` is reported as present.
+`local_overrides_skill_count` is the number of skill override files in `.apache-magpie-local/` (0 when absent).
+`presentation_mode` is `"verbatim"` when the script output is presented as-is; `"paraphrase"` when the agent would reformat or summarise it.
+The correct answer for `presentation_mode` is always `"verbatim"` — the script owns the rendering.
+Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup-status/SKILL.md",
+  "step_heading": "## Step 1 — Render the dashboard"
+}

--- a/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup-status/step-4-local-overrides/fixtures/user-prompt-template.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Collector script output
+
+{report}
+
+You are at Step 1 of setup-status (render the dashboard). Based on the collector output, identify which override surfaces are present. Return JSON only.

--- a/tools/skill-evals/evals/setup/README.md
+++ b/tools/skill-evals/evals/setup/README.md
@@ -5,11 +5,12 @@
 
 Behavioral evals for the `setup` skill.
 
-## Suites (5 cases total)
+## Suites (9 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
 | step-verify-drift | verify.md § Check 3 (drift) | 5 | clean, method/URL mismatch, ref mismatch, svn-zip SHA-512 mismatch, local lock missing |
+| step-overrides-surface | overrides.md § Step 0b | 4 | adopted no flag (offer choice), --local flag (personal), not adopted (personal only), both surfaces exist |
 
 ## Run
 
@@ -31,3 +32,7 @@ uv run --project tools/skill-evals skill-eval \
 
 - `step-verify-drift` cases are fully auto-comparable: all three output
   fields (`status`, `severity`, `remediation`) are enumerated strings.
+- `step-overrides-surface` tests the new `--local` flag and personal-
+  vs-shared surface selection introduced by the `magpie-local-convention`
+  work item.  The default surface when the repo is adopted and no flag is
+  passed is `"offer-choice"`; `override_path` reports the personal default.

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-1-adopted-no-flag/expected.json
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-1-adopted-no-flag/expected.json
@@ -1,0 +1,1 @@
+{"surface": "offer-choice", "override_path": ".apache-magpie-local/pr-management-triage.md", "requires_adoption": false}

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-1-adopted-no-flag/report.md
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-1-adopted-no-flag/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Invocation: `/magpie-setup override pr-management-triage`
+Flags: none
+Repo is adopted (`.apache-magpie.lock` exists).
+Neither `.apache-magpie-local/pr-management-triage.md` nor `.apache-magpie-overrides/pr-management-triage.md` exists yet.

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-2-local-flag/expected.json
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-2-local-flag/expected.json
@@ -1,0 +1,1 @@
+{"surface": "personal", "override_path": ".apache-magpie-local/pr-management-triage.md", "requires_adoption": false}

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-2-local-flag/report.md
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-2-local-flag/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Invocation: `/magpie-setup override pr-management-triage --local`
+Flags: --local
+Repo is adopted (`.apache-magpie.lock` exists).
+`.apache-magpie-local/pr-management-triage.md` does not yet exist.

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-3-not-adopted/expected.json
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-3-not-adopted/expected.json
@@ -1,0 +1,1 @@
+{"surface": "personal", "override_path": ".apache-magpie-local/pr-management-triage.md", "requires_adoption": false}

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-3-not-adopted/report.md
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-3-not-adopted/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Invocation: `/magpie-setup override pr-management-triage`
+Flags: none
+Repo is NOT adopted (`.apache-magpie.lock` does not exist).
+`.apache-magpie-local/pr-management-triage.md` does not yet exist.

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-4-both-exist/expected.json
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-4-both-exist/expected.json
@@ -1,0 +1,1 @@
+{"surface": "offer-choice", "override_path": ".apache-magpie-local/pr-management-triage.md", "requires_adoption": false}

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-4-both-exist/report.md
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/case-4-both-exist/report.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Invocation: `/magpie-setup override pr-management-triage`
+Flags: none
+Repo is adopted (`.apache-magpie.lock` exists).
+`.apache-magpie-local/pr-management-triage.md` already exists with 2 override sections.
+`.apache-magpie-overrides/pr-management-triage.md` already exists with 1 override section.

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/output-spec.md
@@ -1,0 +1,19 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "surface": "personal" | "shared" | "offer-choice",
+  "override_path": "<relative path to the override file>",
+  "requires_adoption": true | false
+}
+```
+
+`surface` is `"personal"` when `--local` is passed or the repo is not adopted (only personal available); `"shared"` when the user explicitly requests the committed surface; `"offer-choice"` when the repo is adopted and no `--local` flag was passed (the user must choose).
+`override_path` is the relative path to the override file that would be created/opened (relative to the repo root). Use `.apache-magpie-local/<skill>.md` for personal, `.apache-magpie-overrides/<skill>.md` for shared.
+`requires_adoption` is `true` if creating this override requires the repo to be adopted first.
+Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup/overrides.md",
+  "step_heading": "## Step 0b — Choose the override surface"
+}

--- a/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup/step-overrides-surface/fixtures/user-prompt-template.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Invocation context
+
+{report}
+
+You are at Step 0b of `/magpie-setup override`. Choose the correct override surface. Return JSON only.


### PR DESCRIPTION
## Summary

Implement acceptance 5 of the adoption-and-setup spec: a gitignored, per-person override directory read at runtime before the committed .apache-magpie-overrides/ surface.  Precedence: personal-local → committed → organization → framework default (first hit wins).

Changes:
- docs/setup/agentic-overrides.md: document two-directory lookup chain, gitignore requirement, and updated hard rules for both surfaces
- skills/setup/SKILL.md: update Golden rules 4 and 7 for the new surface
- skills/setup/adopt.md: add /.apache-magpie-local/ to Step 7 .gitignore entries; surface the personal override dir to the user in Step 9
- skills/setup/overrides.md: add --local flag, Step 0b surface-choice flow, and updated Step 3 contract reminders for both surfaces
- skills/setup-status/SKILL.md: update Adopter overrides preamble to enumerate both lookup paths
- skills/setup-status/collect.md: document local_overrides field and local_overrides_ignored gitignore flag
- skills/setup-status/scripts/collect_status.py: add override_dir_status() helper; collect local_overrides; update gitignore_coverage to check /.apache-magpie-local/; update Markdown renderer to show both surfaces
- skills/setup-status/render.md: update layout reference for the new two-surface Drift & integrity line
- tools/skill-evals/evals/setup-status/step-4-local-overrides/: 4-case suite exercising dashboard reporting of both override surfaces
- tools/skill-evals/evals/setup/step-overrides-surface/: 4-case suite exercising the new surface-selection step in overrides.md

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

- [X] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [X] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
