### PR TITLE
docs(setup): fix pre-Magpie migration steps that became no-ops

### DIFF
--- a/docs/setup/install-recipes.md
+++ b/docs/setup/install-recipes.md
@@ -11,7 +11,7 @@
   - [Method 3 — git branch (defaults to `main`)](#method-3--git-branch-defaults-to-main)
   - [After any recipe — let the skill take over](#after-any-recipe--let-the-skill-take-over)
   - [Subsequent runs and drift detection](#subsequent-runs-and-drift-detection)
-  - [Migrating a pre-Magpie (`apache-magpie`) adopter](#migrating-a-pre-magpie-apache-magpie-adopter)
+  - [Migrating a pre-Magpie (`apache-steward`) adopter](#migrating-a-pre-magpie-apache-steward-adopter)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -262,26 +262,26 @@ and updates the local lock. See
 [`setup/upgrade.md`](../../skills/setup/upgrade.md)
 for the full flow.
 
-## Migrating a pre-Magpie (`apache-magpie`) adopter
+## Migrating a pre-Magpie (`apache-steward`) adopter
 
 A repo that adopted the framework **before** it was renamed from
-`apache-magpie` to **Apache Magpie** is on the old layout: a committed
-`.claude/skills/magpie-setup/` skill, an `.apache-magpie/` snapshot,
-`.apache-magpie.lock` / `.apache-magpie-overrides/`, un-prefixed
-framework symlinks, and `~/.config/apache-magpie/`. The framework
+`apache-steward` to **Apache Magpie** is on the old layout: a committed
+`.claude/skills/setup-steward/` skill, an `.apache-steward/` snapshot,
+`.apache-steward.lock` / `.apache-steward-overrides/`, un-prefixed
+framework symlinks, and `~/.config/apache-steward/`. The framework
 **no longer ships an automated migration** for this layout — migrate by
 hand:
 
-1. Remove the legacy in-repo artefacts: `.apache-magpie*` (snapshot,
+1. Remove the legacy in-repo artefacts: `.apache-steward*` (snapshot,
    locks, overrides), any un-prefixed framework symlinks under the
-   skills dir, and the committed `.claude/skills/magpie-setup/` skill.
+   skills dir, and the committed `.claude/skills/setup-steward/` skill.
 2. Re-adopt from scratch with `/magpie-setup` (see
    [`setup/adopt.md`](../../skills/setup/adopt.md)) so the current
    `.apache-magpie*` layout and `magpie-`-prefixed symlinks are written
-   fresh. Preserve any `.apache-magpie-overrides/*.md` you want to keep
+   fresh. Preserve any `.apache-steward-overrides/*.md` you want to keep
    by moving them into the new `.apache-magpie-overrides/` first.
-3. Move `~/.config/apache-magpie/` (per-user) to
-   `~/.config/apache-magpie/`, and update any `~/.config/apache-magpie/`
+3. Move `~/.config/apache-steward/` (per-user) to
+   `~/.config/apache-magpie/`, and update any `~/.config/apache-steward/`
    entry in your Claude Code sandbox allowlist (project
    `.claude/settings.local.json` / `.claude/settings.json` or user-scope
    `~/.claude/settings.json`) to `~/.config/apache-magpie/` — otherwise


### PR DESCRIPTION
## Summary

The "Migrating a pre-Magpie adopter" recipe in `docs/setup/install-recipes.md` got caught by the `apache-steward` → `apache-magpie` rename: the source-side (old-layout) names were renamed too, so the steps now move/rename paths to themselves. Step 3 — "move `~/.config/apache-magpie/` to `~/.config/apache-magpie/`" — is the no-op in #867.

This restores the old-layout names to `apache-steward` in the heading, intro, step 1, step 2's overrides-preserve clause, and step 3; the destination paths stay `apache-magpie`. I took the direction from d856ce2 (#440), which moved the XDG dir `~/.config/apache-steward/` → `~/.config/apache-magpie/` — still what `skills/setup/upgrade.md` does today. The TOC anchor is updated to match the renamed heading.

## Test plan

- `git diff` is +11/-11, all inside the one section.
- `doctoc` regenerates the TOC with no change, and nothing else in the repo links to the old anchor.
- I didn't run the full `prek` locally — happy to fix anything doctoc / markdownlint / lychee flags.

Fixes #867