### PR TITLE
docs/education/training: link facilitator guide (it exists)

### DIFF
--- a/docs/education/training/README.md
+++ b/docs/education/training/README.md
@@ -77,7 +77,7 @@ needed.
 **Instructor-led.** An instructor presents the key ideas from the source page,
 assigns the exercises to pairs or small groups, and uses the self-check
 questions for a brief group debrief before moving on. The facilitator guide
-(planned, not yet shipped) covers room setup, timing, and group discussion
+([`instructor-guide.md`](instructor-guide.md)) covers room setup, timing, and group discussion
 prompts.
 
 **LMS upload.** Each lesson is a Markdown file that can be converted to SCORM,


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Replace "(planned, not yet shipped)" with a link to `instructor-guide.md`, which exists and is 30 KB.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- [x] `prek run --all-files` passes
- [x] Other: Confirmed `instructor-guide.md` exists in the same directory (30 KB, comprehensive facilitator guide).

## RFC-AI-0004 compliance

N/A — documentation-only change.

## Linked issues

Closes #875