### PR TITLE
docs: add missing pairing family row to adoption table

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -60,6 +60,7 @@ adapter/config layer, but they carry ASF assumptions the generic families do not
 | Setting up agents safely — sandbox, clean environment, privacy routing | [setup](setup/README.md) | Any project |
 | Security reports that need careful, audited handling | [security](security/README.md) | Any project |
 | A pull-request queue that's out of control | [pr-management](pr-management/README.md) | Any project |
+| Catching implementation-detail nits before you open a PR | [pairing](pairing/README.md) | Any project |
 | An issue backlog full of duplicates and stale reports | [issue-management](issue-management/README.md) | Any project |
 | Repo hygiene slipping — CI runners, dependencies, licenses, flaky tests | [repo-health](repo-health/README.md) | Any project |
 | Releases that are a manual, error-prone slog | [release-management](release-management/README.md) | 🪶 ASF-specific |


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary
<!--
1-3 bullets: what changed and why. The "why" is what reviewers care
about most — a one-line summary of the motivation beats a paragraph
restating the diff.
-->
- Added a row for the `pairing` family to the adoption table in `docs/index.md`
- The pairing family (`pairing-self-review`, `pairing-multi-agent-review`) ships under `skills/` and has its own `docs/pairing/README.md`, but was never added to the adoption table, so adopters browsing the table wouldn't discover it

## Type of change
<!-- Tick all that apply. -->
- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan
<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->
- [x] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [x] Other: confirmed the table now lists 10 families, matching the 10 present under `skills/`; link target `pairing/README.md` resolves and its scope note ("no ASF-specific assumptions") matches the "Any project" scope used in the new row

## RFC-AI-0004 compliance
<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->
- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues
<!-- e.g. Closes #NNN, Refs #NNN. List every related issue. -->
Closes #872

## Notes for reviewers (optional)
<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->
Placed the new row directly after `pr-management` rather than at the end, since pairing is a pre-flight step in the same PR-authoring workflow — open to moving it if a different position reads better. No other doc references needed updating (the doctoc TOC block only tracks headings, not table rows).