### PR TITLE
docs(spec-loop): show helpers and tests in layout

### DIFF
--- a/docs/spec-driven-development.md
+++ b/docs/spec-driven-development.md
@@ -204,20 +204,22 @@ finishes. Run it after a batch of normal PRs merges, or on a schedule.
 tools/spec-loop/
 ├── README.md              operator quickstart
 ├── AGENTS.md              loop-scoped operational context
+├── lib.sh                 deterministic runner helpers
 ├── loop.sh                the runner (plan / build / update / consolidate)
 ├── PROMPT_plan.md         gap analysis → plan
 ├── PROMPT_build.md        implement one work item on its own branch
 ├── PROMPT_update.md       back-fill specs from contributed code
 ├── PROMPT_consolidate.md  shrink the plan
 ├── IMPLEMENTATION_PLAN.md prioritised work items (the gaps)
-└── specs/                 functional description of the product
-    ├── overview.md
-    ├── triage-mode.md     mentoring-mode.md   drafting-mode.md   pairing-mode.md
-    ├── security-issue-lifecycle.md            privacy-llm-gate.md
-    ├── agent-isolation-sandbox.md             cve-tooling.md
-    ├── adoption-and-setup.md                  adapters.md
-    ├── meta-and-quality-tooling.md            spec-loop-runner.md
-    └── security-reporting.md                  reviewer-routing.md
+├── specs/                 functional description of the product
+│   ├── overview.md
+│   ├── triage-mode.md     mentoring-mode.md   drafting-mode.md   pairing-mode.md
+│   ├── security-issue-lifecycle.md            privacy-llm-gate.md
+│   ├── agent-isolation-sandbox.md             cve-tooling.md
+│   ├── adoption-and-setup.md                  adapters.md
+│   ├── meta-and-quality-tooling.md            spec-loop-runner.md
+│   └── security-reporting.md                  reviewer-routing.md
+└── tests/                 deterministic runner fixture tests
 ```
 
 ## Quick start


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Add the existing `lib.sh` and `tests/` entries to the spec-loop layout diagram.
- Update the tree connectors so the documented hierarchy remains accurate.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other: N/A

## Test plan

- [x] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes — N/A (documentation-only change)
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end — N/A
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`) — N/A
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md) — N/A
- [x] Other: `git diff --check`

## RFC-AI-0004 compliance

N/A — this documentation-only layout correction introduces no mutations,
host access, vendor coupling, agent behaviour, write access, or private-data flow.

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #873

## Notes for reviewers (optional)

The descriptions for `lib.sh` and `tests/` reflect their current roles in the
spec-loop runner and fixture suite.

Generated-by: Codex (GPT-5)
