### PR TITLE
docs: add .lycheecache to source-release exclusions, fix tools/*/.gitignore glob

### DIFF
--- a/docs/source-release-contents.md
+++ b/docs/source-release-contents.md
@@ -43,7 +43,7 @@ the vote.
 | `.apache-magpie.lock` | The committed self-adoption pin (Magpie adopts itself: `method: local`, `source: skills/`). Part of the framework's own adoption wiring, read by `/magpie-setup`. |
 | `.claude/settings.json` | Agent development-environment configuration for working on the framework from source. Part of the dev environment rather than a personal preference; more agent configs may be added over time. |
 | `.github/ISSUE_TEMPLATE/`, `.github/PULL_REQUEST_TEMPLATE.md` | Not just GitHub chrome — these are referenced by shipped GitHub-vendor skills (PR / issue triage tooling) and cross-checked by validation hooks that verify inter-file links resolve. Stripping them would break those skills and fail the validators. (The genuinely CI/bot-only parts of `.github/` are excluded — see below.) |
-| `.gitignore` files — the repository root one plus the nested ones (`projects/_template/.gitignore`, `tools/*/.gitignore`, `.apache-magpie-overrides/.gitignore`) | Development-environment configuration. The repository-root `.gitignore` keeps a from-source dev checkout of the framework clean; `projects/_template/.gitignore` is example content shipped for adopters to copy; the `tools/*` ones keep a from-source dev checkout of each tool package clean. |
+| `.gitignore` files — the repository root one plus the nested ones (`projects/_template/.gitignore`, `tools/**/.gitignore`, `.apache-magpie-overrides/.gitignore`) | Development-environment configuration. The repository-root `.gitignore` keeps a from-source dev checkout of the framework clean; `projects/_template/.gitignore` is example content shipped for adopters to copy; the `tools/**` ones (nesting depth varies by package — e.g. `tools/egress-gateway/.gitignore` one level down, `tools/gmail/oauth-draft/.gitignore` and `tools/privacy-llm/checker/.gitignore` two levels down) keep a from-source dev checkout of each tool package clean. |
 | `.agents/skills/*` (symlinks) | The canonical agent skill view — single-hop symlinks that resolve straight to the real `skills/*` directories — kept so the shipped agent view resolves out of the box. The relay chains other agent dirs use (`.claude/skills/`, `.github/skills/`, `.kiro/skills/`) are excluded because they chain symlink → symlink, which a safe archive extractor rejects. |
 
 ## Files deliberately excluded
@@ -54,7 +54,8 @@ source consumer never needs:
 
 - **Repository-root VCS / dev metadata:** `.gitattributes`,
   `.pre-commit-config.yaml`, the linter configs (`.lychee.toml`,
-  `.markdownlint.json`, `.typos.toml`, `.zizmor.yml`), and
+  `.markdownlint.json`, `.typos.toml`, `.zizmor.yml`), the lychee
+  link-checker's generated cache file (`.lycheecache`), and
   `.apache-magpie.session-state.json`. (The repository-root `.gitignore`
   is **not** excluded — it ships as dev-environment config, above.)
 - **Editor metadata:** `.idea/`.


### PR DESCRIPTION
Clarified the description of nested .gitignore files and added details about their structure.

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

Add `.lycheecache` to the excluded-files list in `docs/source-release-contents.md`.
Also clarify the imprecise `tools/*/.gitignore` glob description.

Closes #874 

## Why

`.lycheecache` is already marked `export-ignore` in `.gitattributes` (it sits
right next to `.lychee.toml`), but it was never listed in the doc's "Files
deliberately excluded" section — the doc undercounts what `.gitattributes`
actually excludes.

-

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [tick ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

Doc-only change, no code or behavior affected. Verified both edits against
the current `.gitattributes` and the real `tools/` tree

- [ ] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

<!-- e.g. Closes #NNN, Refs #NNN. List every related issue. -->

## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->
