### PR TITLE
fix(bitbucket): normalize issue comment deleted flag

### DIFF
--- a/tools/bitbucket/src/magpie_bitbucket/normalize.py
+++ b/tools/bitbucket/src/magpie_bitbucket/normalize.py
@@ -1056,7 +1056,7 @@ def _cloud_issue_comment(raw: dict[str, Any]) -> dict[str, Any]:
         "updated": _cloud_timestamp(raw.get("updated_on")),
         "date": _cloud_timestamp(raw.get("created_on")),
         "kind": "comment",
-        "deleted": raw.get("deleted"),
+        "deleted": _bool_or_none(raw.get("deleted")),
         "permalink": _cloud_link(raw, "html"),
         "raw": raw,
     }

--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -2213,6 +2213,12 @@ def test_normalize_cloud_issue_comments() -> None:
     assert normalized["comments"][0]["kind"] == "comment"
     assert normalized["comments"][0]["deleted"] is False
 
+    deleted_normalized = issue_comments(
+        "cloud",
+        {"issue_id": "7", "values": [{"id": 102, "deleted": True}]},
+    )
+    assert deleted_normalized["comments"][0]["deleted"] is True
+
 
 @patch("magpie_bitbucket.cloud.get_issue_comments")
 def test_cli_issue_comments_cloud(


### PR DESCRIPTION
## Summary

* Normalizes Bitbucket Cloud issue comment `deleted` values through `_bool_or_none()` for consistency with existing PR discussion comment handling.
* Adds test coverage for boolean deleted issue comments.
* Follows up on the optional reviewer nit from #864.

## Type of change

* [x] Python package (`tools/*/` with `pyproject.toml`)

## Test plan

* [x] `PYTHONPATH=src uv run --group dev pytest tests/test_bitbucket.py -q -k "issue_comments or issue_comment"`
* [x] `PYTHONPATH=src uv run --group dev pytest tests/test_bitbucket.py -q`
* [x] `uv run --group dev ruff check src tests --fix`
* [x] `uv run --group dev ruff format src tests`
* [x] `uv run --group dev mypy src tests`
* [x] `git diff --check`

## Linked issues

Refs #606
