### PR TITLE
docs(mentoring): align spec skill list with the family README

### DIFF
--- a/docs/mentoring/spec.md
+++ b/docs/mentoring/spec.md
@@ -27,16 +27,16 @@
 
 ## Status
 
-Experimental. Seven skills shipped:
+Experimental. Six skills shipped — five native to the family plus one
+cross-listed:
 
 | Skill | Purpose |
 |---|---|
 | [`pr-management-mentor`](../../skills/pr-management-mentor/SKILL.md) | Draft a teaching-register comment on a single GitHub issue or PR thread. |
 | [`good-first-issue-author`](../../skills/good-first-issue-author/SKILL.md) | Draft a single net-new good first issue from a maintainer-supplied candidate. |
 | [`mentoring-welcome`](../../skills/mentoring-welcome/SKILL.md) | Draft a first-contact orientation comment for a first-time contributor on a newly opened issue or PR. |
-| [`contributor-to-committer`](../../skills/contributor-to-committer/SKILL.md) | Read-only readiness tracker mapping a contributor's GitHub activity against the adopter's declared committer/PMC thresholds. |
+| [`contributor-to-committer`](../../skills/contributor-to-committer/SKILL.md) | Read-only readiness tracker mapping a contributor's GitHub activity against the adopter's declared committer/PMC thresholds. (`family: contributor-growth` — cross-listed here for the mentoring path continuity.) |
 | [`good-first-issue-sweep`](../../skills/good-first-issue-sweep/SKILL.md) | Sweep the open issue backlog for issues that could be labelled as good first issues, scoring each against the G1–G7 suitability rubric. |
-| [`onboarding-concierge`](../../skills/onboarding-concierge/SKILL.md) | Answer a newcomer's "how do I contribute here" question from the project's `CONTRIBUTING.md`; classifies the question and hands off to a human for design, security, or out-of-scope queries. |
 | [`newcomer-issue-explainer`](../../skills/newcomer-issue-explainer/SKILL.md) | Explain an open good-first-issue in beginner terms and sketch a concrete approach (file pointers, done-definition, where to ask); an assessment gate declines closed, security-sensitive, or scope-unclear issues; nothing is posted without maintainer confirmation. |
 
 This document is the normative Agentic Mentoring spec: tone guide, hand-off


### PR DESCRIPTION
## Summary

- Update `docs/mentoring/spec.md` to list six skills, matching `README.md` in the same directory: the `onboarding-concierge` row is removed (its `SKILL.md` declares `family: contributor-growth`, so it is not part of the mentoring family).
- Annotate `contributor-to-committer` with the same cross-listed note the README uses (`family: contributor-growth` — cross-listed for mentoring path continuity), so the six break down as five native plus one cross-listed.

`docs/modes.md` still counts 7 for the Mentoring *mode* — that is a different grouping (both cross-family skills carry `mode: Mentoring`), so the spec's cross-reference to it is left untouched.

Fixes #871

## Test plan

- Checked the `family:` frontmatter of `skills/onboarding-concierge/SKILL.md` and `skills/contributor-to-committer/SKILL.md` (both `contributor-growth`).
- Diffed the resulting table against `docs/mentoring/README.md` — same six skills, same cross-listed annotation. No link targets changed.
