### PR TITLE
feat(codex): first-class Codex CLI skill runtime

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Repository-scoped Codex posture. Codex loads this file only after the
+# user trusts the project, keeping the trust decision outside repository
+# control.
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+
+[sandbox_workspace_write]
+# Networked Magpie bridges cross the sandbox only after the native Codex
+# approval/rules layer has evaluated the action.
+network_access = false

--- a/.codex/rules/magpie.rules
+++ b/.codex/rules/magpie.rules
@@ -127,3 +127,9 @@ prefix_rule(
     decision = "prompt",
     justification = "Credential, variable, and gist operations require confirmation.",
 )
+
+prefix_rule(
+    pattern = ["gh", "api"],
+    decision = "prompt",
+    justification = "The raw API passthrough can express any read or mutation.",
+)

--- a/.codex/rules/magpie.rules
+++ b/.codex/rules/magpie.rules
@@ -1,0 +1,129 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Codex exec-policy is the human-in-the-loop layer for Magpie's networked
+# CLI bridges. Read-only GitHub operations may proceed; mutations prompt.
+# Commands not listed here still follow approval_policy = "on-request" and
+# the workspace-write sandbox, whose project profile disables network.
+
+prefix_rule(
+    pattern = ["git", "fetch"],
+    decision = "allow",
+    justification = "Refreshing remote refs is read-only.",
+)
+
+prefix_rule(
+    pattern = ["git", ["push", "pull"]],
+    decision = "prompt",
+    justification = "Publishing or integrating remote changes requires confirmation.",
+)
+
+prefix_rule(
+    pattern = ["gh", "auth", ["token", "refresh"]],
+    decision = "forbidden",
+    justification = "Agents must not expose or rotate the user's GitHub credential.",
+)
+
+prefix_rule(
+    pattern = ["gh", "auth", "status"],
+    decision = "allow",
+    justification = "Authentication status does not expose the credential.",
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", ["view", "list", "diff", "checks", "status"]],
+    decision = "allow",
+    justification = "These pull-request operations are read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", ["view", "list", "status"]],
+    decision = "allow",
+    justification = "These issue operations are read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "repo", ["view", "list"]],
+    decision = "allow",
+    justification = "These repository operations are read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "run", ["view", "list", "watch"]],
+    decision = "allow",
+    justification = "These workflow-run operations do not mutate GitHub state.",
+)
+
+prefix_rule(
+    pattern = ["gh", "workflow", ["view", "list"]],
+    decision = "allow",
+    justification = "These workflow operations are read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "release", ["view", "list"]],
+    decision = "allow",
+    justification = "These release operations do not mutate remote or local state.",
+)
+
+prefix_rule(
+    pattern = ["gh", "label", "list"],
+    decision = "allow",
+    justification = "Listing labels is read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "cache", "list"],
+    decision = "allow",
+    justification = "Listing caches is read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "search"],
+    decision = "allow",
+    justification = "GitHub search is read-only.",
+)
+
+prefix_rule(
+    pattern = ["gh", "pr", ["create", "edit", "close", "reopen", "merge", "ready", "review", "comment"]],
+    decision = "prompt",
+    justification = "Pull-request mutations require per-action confirmation.",
+)
+
+prefix_rule(
+    pattern = ["gh", "issue", ["create", "edit", "close", "reopen", "comment", "delete", "develop", "lock", "pin", "transfer"]],
+    decision = "prompt",
+    justification = "Issue mutations require per-action confirmation.",
+)
+
+prefix_rule(
+    pattern = ["gh", "release", ["create", "edit", "delete", "upload", "download"]],
+    decision = "prompt",
+    justification = "Release mutations and artifact downloads require per-action confirmation.",
+)
+
+prefix_rule(
+    pattern = ["gh", "workflow", ["run", "enable", "disable"]],
+    decision = "prompt",
+    justification = "Workflow mutations require per-action confirmation.",
+)
+
+prefix_rule(
+    pattern = ["gh", ["secret", "variable", "gist"]],
+    decision = "prompt",
+    justification = "Credential, variable, and gist operations require confirmation.",
+)

--- a/docs/adapters/codex.md
+++ b/docs/adapters/codex.md
@@ -1,0 +1,239 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Codex first-class runtime](#codex-first-class-runtime)
+  - [Runtime contract](#runtime-contract)
+  - [Invoke a Magpie skill](#invoke-a-magpie-skill)
+  - [Install](#install)
+  - [Security model](#security-model)
+    - [Sandbox and network](#sandbox-and-network)
+    - [Exec-policy rules and approval policy](#exec-policy-rules-and-approval-policy)
+    - [Deterministic guard rules](#deterministic-guard-rules)
+    - [Trust boundary](#trust-boundary)
+  - [Verify](#verify)
+  - [setup-isolated lifecycle](#setup-isolated-lifecycle)
+  - [Known limitations](#known-limitations)
+  - [Upstream references](#upstream-references)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Codex first-class runtime
+
+**Capability:** capability:platform
+
+**Harness:** OpenAI Codex CLI, IDE, and desktop local runtime
+
+This adapter makes Codex a native Apache Magpie skill runtime. It is not the
+Claude Code codex delegation plugin: a maintainer with Codex and no Claude Code
+can discover, invoke, and run Magpie skills end to end.
+
+The implementation follows
+[RFC-AI-0004](../rfcs/RFC-AI-0004.md): shared skill sources, a native sandbox,
+and per-action human confirmation through Codex's own approval and exec-policy
+layers.
+
+## Runtime contract
+
+| Magpie requirement | Codex implementation |
+|---|---|
+| Skill discovery | Codex reads the existing canonical `.agents/skills/magpie-*/SKILL.md` symlinks directly. No SKILL.md-to-AGENTS.md translation or duplicate source tree is needed. |
+| Repository instructions | Codex reads the repository `AGENTS.md` hierarchy natively. |
+| Tool bridges | Skills invoke the same language-neutral `tools/` CLI adapters. Network is disabled inside `workspace-write`; approved network actions cross the sandbox through Codex rules and approval policy. |
+| Filesystem sandbox | Project `.codex/config.toml` selects `workspace-write`. |
+| Human in the loop | `approval_policy = "on-request"` and `.codex/rules/magpie.rules` allow scoped reads, prompt mutations, and forbid credential disclosure. |
+| Deterministic guard | The shared `tools/agent-guard` dispatch core is reachable through its harness-neutral `--check` / `--exec` modes (see [Deterministic guard rules](#deterministic-guard-rules)). |
+| Credential isolation | `tools/agent-isolation/agent-iso.sh` launches `agent-iso codex` through the shared clean-environment wrapper. |
+
+The committed profile lives in:
+
+~~~text
+.codex/
+|-- config.toml
+`-- rules/
+    `-- magpie.rules
+~~~
+
+Both files are policy and are reviewed in Git.
+
+## Invoke a Magpie skill
+
+Codex scans `.agents/skills` from the current directory to the repository root,
+follows symlinked skill directories, and reads `SKILL.md` when a skill is
+chosen. After `magpie-setup` has adopted the repository:
+
+1. Start Codex at the adopter repository root, preferably with
+   `agent-iso codex`.
+2. Use `/skills` to confirm that `magpie-*` skills are visible.
+3. Invoke a skill explicitly by mentioning it with `$`, for example
+   `$magpie-security-issue-triage`, or describe a task that matches its
+   frontmatter description.
+4. The selected skill resolves `tools/*` commands and project placeholders in
+   exactly the same way as every other runtime.
+
+An end-to-end triage therefore starts with:
+
+~~~text
+$magpie-security-issue-triage
+~~~
+
+There is no generated AGENTS.md per skill. `AGENTS.md` carries persistent
+repository instructions; `SKILL.md` remains the workflow source.
+
+## Install
+
+Run `$magpie-setup` from Codex and select adopt or upgrade. The setup
+lifecycle:
+
+1. Creates the canonical `.agents/skills` links and harness relay links.
+2. Merges the reviewed Codex posture into `.codex/` without deleting unrelated
+   project settings. Conflicting sandbox or approval values are surfaced to the
+   maintainer; they are never silently weakened.
+3. Runs `sandbox-lint --codex .codex` on the merged result.
+4. Asks the operator to trust the project in Codex. Repository content cannot
+   grant its own trust.
+
+When `.codex/` already exists, setup preserves unrelated keys. `magpie.rules`
+is Magpie-owned; hand edits are shown before replacement.
+
+For the clean-environment layer on Linux or macOS:
+
+~~~bash
+source <framework>/tools/agent-isolation/agent-iso.sh
+agent-iso codex
+~~~
+
+On Windows, run the POSIX isolation layer through WSL when that layer is
+required. Codex's native Windows sandbox and the project policy still apply to
+a native Windows session.
+
+## Security model
+
+### Sandbox and network
+
+The profile requires:
+
+~~~toml
+sandbox_mode = "workspace-write"
+approval_policy = "on-request"
+
+[sandbox_workspace_write]
+network_access = false
+~~~
+
+Networked bridges such as `gh`, `jira`, Gmail, PonyMail, and CVE tooling
+therefore cannot silently use network access from the workspace sandbox. The
+exec-policy file allows narrowly scoped read-only commands, prompts known
+mutations, and forbids `gh auth token` and credential refresh operations.
+Commands not matched by an allow rule still follow the native on-request
+approval path.
+
+### Exec-policy rules and approval policy
+
+Per-action confirmation belongs to Codex's native rules and approval system:
+`.codex/rules/magpie.rules` classifies known commands as `allow`, `prompt`,
+or `forbidden` before they cross the sandbox boundary, and
+`approval_policy = "on-request"` routes everything else to the operator. This
+is the Codex mapping of RFC-AI-0004 Principle 1 (human-in-the-loop).
+
+### Deterministic guard rules
+
+Claude Code and OpenCode additionally wire the deterministic
+[`tools/agent-guard`](../../tools/agent-guard/README.md) denials (AI
+`Co-Authored-By` trailers, premature `--ready-for-review`, unsafe public
+security wording, empty force-pushes) as in-process pre-tool hooks. Codex has
+no equivalent wired hook adapter in this profile; the same `dispatch()` core
+remains available through the harness-neutral `--check` / `--exec` modes
+documented in the
+[agent-guard README](../../tools/agent-guard/README.md#harness-neutral-path-any-runtime).
+Until a native Codex adapter exists, those framework invariants rely on the
+exec-policy prompts plus the operator's review of each confirmed action.
+
+### Trust boundary
+
+Project `.codex` configuration and rules load only for a trusted project. The
+operator reviews that trust decision. The framework does not modify user trust
+state.
+
+Policy changes remain normal reviewed repository changes: an approved elevated
+action can still modify `.codex/`, so the profile complements — never
+replaces — code review.
+
+## Verify
+
+Run the static validator from the framework or snapshot:
+
+~~~bash
+uv run --directory tools/sandbox-lint --group dev sandbox-lint --codex .codex
+~~~
+
+Then test native rule classification:
+
+~~~bash
+codex execpolicy check --pretty \
+  --rules .codex/rules/magpie.rules \
+  -- gh pr view 313
+
+codex execpolicy check --pretty \
+  --rules .codex/rules/magpie.rules \
+  -- gh pr create --title test --body test
+
+codex execpolicy check --pretty \
+  --rules .codex/rules/magpie.rules \
+  -- gh auth token
+~~~
+
+The expected strictest decisions are `allow`, `prompt`, and `forbidden`,
+respectively.
+
+Also verify:
+
+- `/skills` lists `magpie-setup` and a representative workflow skill.
+- Each `tools/*` bridge used by the selected skill is present and
+  authenticated; tool-specific preflight remains owned by that skill.
+
+## setup-isolated lifecycle
+
+The four setup-isolated skills route Codex to this adapter:
+
+- `setup-isolated-setup-install` installs or merges the project profile and
+  explains `agent-iso codex`.
+- `setup-isolated-setup-verify` runs the static validator, rule-classification
+  probes, `/skills` checks, and tool preflights.
+- `setup-isolated-setup-update` compares the installed profile with the
+  current framework snapshot. It reports drift and never weakens policy
+  automatically.
+- `setup-isolated-setup-doctor` runs the shared live environment probes inside
+  the active Codex sandbox and reports native approval or network failures
+  separately.
+
+The Claude-specific setup remains available for Claude Code. Runtime routing
+must happen before a setup-isolated skill follows Claude-only settings paths.
+
+## Known limitations
+
+- Codex exec-policy rules are an evolving runtime interface. Pin a minimum
+  tested Codex version before calling the adapter stable, and rerun the
+  classification probes on upgrades.
+- The deterministic agent-guard denials are not wired as a native Codex hook;
+  see [Deterministic guard rules](#deterministic-guard-rules).
+- Native project policy requires explicit project trust.
+- The clean-environment wrapper is POSIX shell. Native Windows sessions rely
+  on the Codex Windows sandbox unless launched through WSL.
+- MCP and account-backed integrations still require user-scoped registration
+  and authentication. Repository policy never copies credentials into the
+  project.
+
+## Upstream references
+
+- [Codex skills](https://developers.openai.com/codex/skills)
+- [Codex configuration](https://developers.openai.com/codex/config-reference)
+- [Codex rules](https://developers.openai.com/codex/rules)
+- [Codex CLI source](https://github.com/openai/codex)
+- [Agent Skills specification](https://agentskills.io/specification)

--- a/docs/adapters/registry.md
+++ b/docs/adapters/registry.md
@@ -55,7 +55,7 @@ extension point = a documented, labelled slot with a tracking issue.
 | [`tools/scan-format`](../../tools/scan-format/) | ASVS | other scanner formats |
 | [`tools/vcs`](../../tools/vcs/) | Git, Mercurial, Fossil | Subversion [\#602](https://github.com/apache/magpie/issues/602), Jujutsu [\#603](https://github.com/apache/magpie/issues/603), Perforce [\#605](https://github.com/apache/magpie/issues/605) |
 | Forge / tracker | [`github`](../../tools/github/), [`jira`](../../tools/jira/), [`bitbucket`](../../tools/bitbucket/) `partial-read-only` foundation, [`sourcehut`](../../tools/sourcehut/), [`fossil`](../../tools/fossil/) | GitLab [\#305](https://github.com/apache/magpie/issues/305), Forgejo/Gitea [\#310](https://github.com/apache/magpie/issues/310), Pagure [\#312](https://github.com/apache/magpie/issues/312), deeper Bitbucket/Jira coverage [\#606](https://github.com/apache/magpie/issues/606), Bugzilla [\#302](https://github.com/apache/magpie/issues/302) |
-| Agentic runtime | Claude Code | Codex [#313](https://github.com/apache/magpie/issues/313)–OpenHands [#322](https://github.com/apache/magpie/issues/322) |
+| Agentic runtime | Claude Code, [Codex](codex.md) `experimental` ([#313](https://github.com/apache/magpie/issues/313)) | Gemini CLI [#314](https://github.com/apache/magpie/issues/314)–OpenHands [#322](https://github.com/apache/magpie/issues/322) |
 | Security cross-ref | — | OSV.dev [#311](https://github.com/apache/magpie/issues/311) |
 
 ## In-tree organizations

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -52,7 +52,7 @@ the `SKILL.md` / [`AGENTS.md`](https://agents.md/) skill convention, and
 on any single vendor for either — any agent that reads the shared
 `.agents/skills/*/SKILL.md` files and follows their steps should work.
 
-**Agentic tool — two are fully supported today:**
+**Agentic tool — two are fully supported today, one is experimental:**
 
 - **[OpenCode](https://opencode.ai/)** is the **reference implementation**:
   it is open source and model-agnostic, so it can drive *every* LLM-access
@@ -61,9 +61,14 @@ on any single vendor for either — any agent that reads the shared
   complete implementation, powered by Anthropic subscriptions — the paid
   plans, or the free tier Anthropic often grants to open-source
   maintainers.
+- **[OpenAI Codex](https://github.com/openai/codex)** reads Magpie's
+  canonical `.agents/skills/` tree natively and ships an in-tree sandbox
+  profile and HITL exec-policy rules. The adapter is **experimental**
+  until its minimum tested runtime version and an adopter pilot are
+  recorded; see [the Codex runtime guide](adapters/codex.md).
 
-Support for more runtimes (Codex, Gemini CLI, Cursor, Copilot, …) is
-tracked in the
+Support for more runtimes (Gemini CLI, Cursor, Copilot, …) is tracked in
+the
 [open adapter issues](https://github.com/apache/magpie/issues?q=is%3Aissue%20is%3Aopen%20adapter).
 
 **Access to an LLM — any one of these works:**
@@ -89,16 +94,18 @@ with the credential-isolation setup documented in
 [`docs/setup/secure-agent-setup.md`](setup/secure-agent-setup.md) — a layered
 defence built around the agent's filesystem sandbox, tool-level
 permission rules, and a harness-neutral clean-env wrapper
-(`agent-iso.sh`, exposing both a `claude-iso` and an `opencode-iso`
-launcher) that strips credential-shaped variables from the agent's
-environment. The permission + sandbox posture is enforced for both
-harnesses — a `PreToolUse` hook / `tool.execute.before` plugin
-(`agent-guard`), plus `permission-audit` / `sandbox-lint` for the
-Claude `settings.json` and OpenCode `opencode.json` policies. The
-sandbox primitives (`bubblewrap`, `socat`) are pinned with a 7-day
+(`agent-iso.sh`, exposing `claude-iso`, `opencode-iso`, and
+`agent-iso codex`) that strips credential-shaped variables from the
+agent's environment. The permission + sandbox posture is enforced per
+harness: Claude Code and OpenCode wire a pre-execution `agent-guard`
+adapter (a `PreToolUse` hook / `tool.execute.before` plugin), Codex
+enforces HITL through its native approval policy and exec-policy rules,
+and `permission-audit` / `sandbox-lint` validate the Claude
+`settings.json`, OpenCode `opencode.json`, and Codex `.codex/` policies.
+The sandbox primitives (`bubblewrap`, `socat`) are pinned with a 7-day
 upstream-release cooldown, mirroring the same convention the
 framework uses for its `[tool.uv] exclude-newer` and Dependabot
-configs. The agent CLI itself (`claude-code` / `opencode`) is
+configs. The agent CLI itself (`claude-code` / `opencode` / `codex`) is
 deliberately **not** pinned — it installs at `@latest` so it always
 carries the newest permission-rule, sandbox, and prompt-injection
 fixes; pinning the runtime to an older build would only increase

--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -8,7 +8,7 @@
 - [Secure agent setup](#secure-agent-setup)
   - [Quick start](#quick-start)
     - [Agent-guided (recommended)](#agent-guided-recommended)
-    - [Manual (if you do not want the agent-guided path)](#manual-if-you-do-not-want-the-agent-guided-path)
+    - [Manual Claude Code path (if you do not want the agent-guided path)](#manual-claude-code-path-if-you-do-not-want-the-agent-guided-path)
   - [Required tools](#required-tools)
     - [Install commands](#install-commands)
     - [Distro-specific shortcut — Linux Mint 22.x / Ubuntu 24.04 Noble](#distro-specific-shortcut--linux-mint-22x--ubuntu-2404-noble)
@@ -70,7 +70,7 @@
 
 **Audience: adopters.** This document walks through every install
 step for the secure agent setup — pinned tool versions, the
-framework's `.claude/settings.json`, the `claude-iso` clean-env
+framework's Claude Code and Codex runtime policies, the clean-env
 wrapper, the sandbox-bypass-warn hook, the sandbox-state status
 line, multi-host syncing, the agent-guided install / verify /
 keep-updated prompts, and the five session screenshots that show
@@ -103,6 +103,13 @@ you want the full picture. For the rationale and mechanism behind
 each layer, see
 [`secure-agent-internals.md`](secure-agent-internals.md).
 
+Codex has a harness-native project policy and rules contract. Read the
+[Codex first-class runtime adapter](../adapters/codex.md) for that
+runtime's exact install, sandbox, HITL, verification, and Windows
+mapping. The long-form sections below remain the canonical Claude Code
+setup; the four `setup-isolated-*` skills route Codex to the adapter
+before entering any Claude-only settings flow.
+
 ### Agent-guided (recommended)
 
 If you have Claude Code installed and a clone of `magpie`
@@ -110,6 +117,11 @@ on the host, the framework ships six skills that walk every
 step interactively. Each surfaces sudo / shell-rc / settings-file
 changes for explicit approval before applying — nothing
 privilege-elevating runs without you saying so.
+
+With Codex, start the repository through `agent-iso codex`, invoke the
+same skills by their `$magpie-*` names, and follow the Codex branch they
+select. The end state and verification commands are documented in the
+[Codex adapter](../adapters/codex.md#setup-isolated-lifecycle).
 
 ```text
 1. Open Claude Code in your tracker repo (or any directory).
@@ -151,7 +163,7 @@ document rather than duplicating them, so anything the skill walks
 you through has a longer-form section here you can read for
 context.
 
-### Manual (if you do not want the agent-guided path)
+### Manual Claude Code path (if you do not want the agent-guided path)
 
 The same flow, condensed to commands you run yourself:
 
@@ -187,12 +199,16 @@ npm install -g --no-save @anthropic-ai/claude-code@latest
 #    check and the agent-guided form.
 ```
 
-Both paths converge on the same end state: a sandboxed Claude Code
+Both Claude Code paths converge on the same end state: a sandboxed Claude Code
 session that cannot read `~/.aws/`, cannot exfiltrate via `curl`,
 runs Bash subprocesses inside bubblewrap (Linux) or Seatbelt
 (macOS), and visibly flags `sandbox` / `NO SANDBOX` / bypass
 attempts in the terminal so an unprotected session cannot drift
 unnoticed.
+
+The equivalent Codex end state uses `workspace-write`, network disabled,
+and native exec-policy decisions; see the
+[Codex security model](../adapters/codex.md#security-model).
 
 The rest of this document is the long-form reference behind each
 of those steps. If you used the agent-guided path, you can read

--- a/docs/vendor-neutrality.md
+++ b/docs/vendor-neutrality.md
@@ -313,11 +313,11 @@ Codex, Cursor, Gemini CLI, Copilot and others, with thin relay symlinks
 giving every other agent directory (`.claude/skills/`,
 `.github/skills/`, …) a pointer to the same entry
 ([`README.md` § snapshot + override](../README.md)). Users already run
-Magpie under several different agentic CLIs. Adding first-class features
-for another runtime is an [`family:tools`](labels-and-capabilities.md#1-family--subject)
-contribution, not a re-architecture — and the extension points are
+Magpie under several different agentic CLIs. Codex now has a
+[first-class adapter](adapters/codex.md) (experimental); adding another
+runtime is a [`family:tools`](labels-and-capabilities.md#1-family--subject)
+contribution, not a re-architecture. The remaining extension points are
 already open, labelled `good first issue`:
-[Codex](https://github.com/apache/magpie/issues/313),
 [Gemini CLI](https://github.com/apache/magpie/issues/314),
 [local LLM (Ollama / llama.cpp / vLLM)](https://github.com/apache/magpie/issues/315),
 [Cursor](https://github.com/apache/magpie/issues/316),
@@ -490,7 +490,7 @@ coverage without pretending one team can implement an open-ended set.
 | Axis | Architecture neutral? | Reference backends working today | Extension points |
 |---|---|---|---|
 | LLM backend | ✅ by construction | Claude Code, Ollama, vLLM, Apache-hosted, Bedrock, direct Anthropic | Any endpoint meeting the capability floor + privacy gate |
-| Agentic runtime | ✅ by construction (`AGENTS.md` standard) | Claude Code; community use under Codex, Cursor, Gemini CLI, Copilot, OpenCode, Kiro | Runtime adapters [#313–#322](https://github.com/apache/magpie/issues?q=is%3Aissue+state%3Aopen+adapter+in%3Atitle) |
+| Agentic runtime | ✅ by construction (`AGENTS.md` standard) | Claude Code; OpenCode; [Codex adapter](adapters/codex.md) (experimental); community use under Cursor, Gemini CLI, Copilot, Kiro | Remaining runtime adapters [#314–#322](https://github.com/apache/magpie/issues?q=is%3Aissue+state%3Aopen+adapter+in%3Atitle) |
 | Forge / tracker | ✅ by construction | GitHub, Jira, SourceHut; Bitbucket `partial-read-only` foundation excluded from complete-backend counts; CVE/scan/relay via adapter contracts | GitLab [#305](https://github.com/apache/magpie/issues/305), Forgejo/Gitea [#310](https://github.com/apache/magpie/issues/310), Pagure [#312](https://github.com/apache/magpie/issues/312), full Bitbucket tracker/change-request/Jira coverage [#606](https://github.com/apache/magpie/issues/606), Bugzilla [#302](https://github.com/apache/magpie/issues/302) |
 | Communication channels | ✅ by construction | PonyMail / mail-archive reads | mbox [#304](https://github.com/apache/magpie/issues/304), IMAP [#303](https://github.com/apache/magpie/issues/303), Mailman 3 [#306](https://github.com/apache/magpie/issues/306); Discourse [#307](https://github.com/apache/magpie/issues/307), Zulip [#308](https://github.com/apache/magpie/issues/308), Matrix [#309](https://github.com/apache/magpie/issues/309) |
 | Source control (VCS) | ✅ by construction | **Git (complete)**, **Mercurial (complete)**; ASF SVN surface ([`tools/asf-svn`](../tools/asf-svn/): source control + dist.apache.org + authorization) | Subversion generic VCS binding [\#602](https://github.com/apache/magpie/issues/602) (detected); Jujutsu [\#603](https://github.com/apache/magpie/issues/603), Fossil [\#604](https://github.com/apache/magpie/issues/604), Perforce [\#605](https://github.com/apache/magpie/issues/605) (tracked) |

--- a/skills/setup-isolated-setup-doctor/SKILL.md
+++ b/skills/setup-isolated-setup-doctor/SKILL.md
@@ -32,6 +32,18 @@ license: Apache-2.0
 
 # setup-isolated-setup-doctor
 
+## Runtime routing (run before the Claude-specific probes)
+
+When the active harness is Codex, first require the static verification in
+[docs/adapters/codex.md](../../docs/adapters/codex.md#verify), then run the
+shared live environment probes inside the active Codex sandbox. Attribute
+failures separately to native sandbox/network denial, approval policy, or
+the POSIX agent-iso layer. Do not prescribe a `.claude` settings change for
+a Codex failure. Then stop before the Claude-specific branch below.
+
+When the harness is Claude Code, continue below. If the harness cannot be
+determined, ask once.
+
 The **diagnostic** layer over the secure agent setup. Complements
 the existing setup skills:
 

--- a/skills/setup-isolated-setup-install/SKILL.md
+++ b/skills/setup-isolated-setup-install/SKILL.md
@@ -32,6 +32,19 @@ license: Apache-2.0
 
 # setup-isolated-setup-install
 
+## Runtime routing (run before the Claude-specific procedure)
+
+Determine the active harness from the session metadata and executable. When it
+is Codex, follow the install lifecycle in
+[docs/adapters/codex.md](../../docs/adapters/codex.md#install), including the
+project profile merge, static lint, project trust, and `agent-iso codex`
+steps. Do not write Claude settings or report a missing `.claude` file as a
+Codex failure. After completing the Codex branch, stop; the remainder of this
+skill is the Claude Code branch.
+
+When the harness is Claude Code, continue below. If the harness cannot be
+determined, ask once rather than applying one runtime's policy to another.
+
 This skill is the **on-ramp** for adopters who do not yet have the
 secure setup running. It is a thin walkthrough wrapper around the
 canonical install path documented in

--- a/skills/setup-isolated-setup-update/SKILL.md
+++ b/skills/setup-isolated-setup-update/SKILL.md
@@ -27,6 +27,18 @@ license: Apache-2.0
 
 # setup-isolated-setup-update
 
+## Runtime routing (run before the Claude-specific drift report)
+
+When the active harness is Codex, compare the installed `.codex` policy with
+the framework sources described in
+[docs/adapters/codex.md](../../docs/adapters/codex.md#setup-isolated-lifecycle).
+Surface policy, rules, and tested-version drift; never auto-weaken or
+silently overwrite a hand-edited policy. Then stop. The remainder of this
+skill is the Claude Code update branch.
+
+When the harness is Claude Code, continue below. If the harness cannot be
+determined, ask once.
+
 This skill is the **drift report** for an already-installed secure
 setup. It walks the canonical update-check at
 [`docs/setup/secure-agent-setup.md` → Keeping the setup updated → Via a Claude Code prompt](../../docs/setup/secure-agent-setup.md#via-a-claude-code-prompt-2)

--- a/skills/setup-isolated-setup-verify/SKILL.md
+++ b/skills/setup-isolated-setup-verify/SKILL.md
@@ -30,6 +30,17 @@ license: Apache-2.0
 
 # setup-isolated-setup-verify
 
+## Runtime routing (run before the Claude-specific checks)
+
+When the active harness is Codex, run the verification contract in
+[docs/adapters/codex.md](../../docs/adapters/codex.md#verify): static profile
+lint, native rule classification, project trust, `/skills` visibility, and
+bridge preflights. Report every Codex check and then stop. Do not interpret
+the Claude settings checks below as Codex requirements.
+
+When the harness is Claude Code, continue with the existing checks below. If
+the harness cannot be determined, ask once.
+
 This skill is the **assertion** layer over the secure setup. It
 runs the checklist documented in
 [`docs/setup/secure-agent-setup.md` → Verification → Via a Claude Code prompt](../../docs/setup/secure-agent-setup.md#via-a-claude-code-prompt-1)

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -1412,6 +1412,25 @@ Four passes, in this order:
      change. If the `hooks.PreToolUse` entry is already present,
      this pass only re-syncs the script + `guards.d`.
 
+   **Codex project policy is the reviewed Codex half of the runtime
+   support.** Merge the snapshot's `.codex/config.toml` and
+   `.codex/rules/magpie.rules` into the adopter root:
+
+   - On a fresh adopter with no matching file, copy and stage it.
+   - Preserve unrelated TOML keys. If a required sandbox or approval
+     value conflicts, surface the diff and ask the operator; never
+     silently weaken the Magpie invariant.
+   - Treat `magpie.rules` as Magpie-owned. Show hand edits before
+     replacing them during a later sync.
+   - Do not edit Codex project trust. Tell the operator to make the
+     trust decision in Codex.
+
+   Validate the merged result with `sandbox-lint --codex
+   <repo-root>/.codex`. Both files are committed adopter
+   configuration — nothing under `.codex/` is generated or
+   gitignored. See
+   [the Codex adapter](../../docs/adapters/codex.md).
+
 2. **Propagate to every worktree (run `worktree-init`
    unconditionally).** The main is now adopted; any
    pre-existing linked worktree of this repo still lacks
@@ -1531,6 +1550,7 @@ A summary of what was written:
 ✓ Overrides scaffold: .apache-magpie-overrides/ (committed)
 ✓ post-checkout hook installed (seeds sandbox allowlist + agent-guard per worktree)
 ✓ agent-guard PreToolUse hook synced (.claude/hooks/agent-guard.py + guards.d/ — gitignored)
+✓ Codex project policy merged and validated (.codex/config.toml + rules/magpie.rules)
 ✓ <repo>/README.md updated with adoption note
 
 Committed (you'll see in `git status`):
@@ -1540,6 +1560,8 @@ Committed (you'll see in `git status`):
   .agents/skills/magpie-setup/         (this skill itself — canonical copy)
   .claude/skills/magpie-setup          (relay symlink → ../../.agents/skills/magpie-setup)
   .github/skills/magpie-setup          (relay symlink → ../../.agents/skills/magpie-setup)
+  .codex/config.toml                   (Codex sandbox + HITL posture; unrelated keys preserved)
+  .codex/rules/magpie.rules            (Codex exec-policy)
   README.md (or CONTRIBUTING.md)
 
 Gitignored (do NOT commit):

--- a/skills/setup/unadopt.md
+++ b/skills/setup/unadopt.md
@@ -10,7 +10,9 @@ symlinks **in every active target dir** ([`agents.md`](agents.md)
 — `.agents/skills/`, `.claude/skills/`, `.github/skills/`, plus
 any present holdout), the matching `.gitignore` blocks,
 post-checkout hook, the gitignored agent-guard hook
-(`.claude/hooks/agent-guard.py` + `guards.d/`), the adoption
+(`.claude/hooks/agent-guard.py` + `guards.d/`), the Magpie-owned
+Codex project policy (`.codex/config.toml` values +
+`.codex/rules/magpie.rules`), the adoption
 sections in `README.md` / `AGENTS.md` / `CONTRIBUTING.md`, and the
 committed `setup` skill itself. (The committed
 `.claude/settings.json` `hooks.PreToolUse` wiring is adopter-owned
@@ -106,6 +108,7 @@ every artefact).
 | Framework-skill symlinks | **Every active target dir** ([`agents.md`](agents.md)): the canonical `.agents/skills/` (always present), the `.claude/skills/` + `.github/skills/` relay pair, and any present holdout (`.windsurf/skills/`, `.goose/skills/`) | each `magpie-*` symlink — canonical entries resolving into `<snapshot-dir>/skills/`, relays resolving into `.agents/skills/magpie-*` — in **each** target dir |
 | Post-checkout hook | `<repo-root>/.git/hooks/post-checkout` | exists + invokes `~/.claude/scripts/sandbox-add-project-root.sh` and/or seeds `.claude/hooks/agent-guard.py` |
 | agent-guard hook | `<repo-root>/.claude/hooks/agent-guard.py` + `<repo-root>/.claude/hooks/guards.d/` | exist (gitignored framework code). The committed `.claude/settings.json` `hooks.PreToolUse` wiring is **adopter-owned** — surface it for the user to remove by hand (settings.json is agent-edit-denied); do not edit it. |
+| Codex policy | `.codex/config.toml`, `.codex/rules/magpie.rules` | identify Magpie-owned values separately from unrelated adopter Codex configuration |
 | Doc section: `README.md` | `<repo-root>/README.md` | contains the `## Agent-assisted contribution (apache-magpie)` heading |
 | Doc section: `AGENTS.md` | `<repo-root>/AGENTS.md` | contains the `## apache-magpie framework` heading |
 | Doc section: `CONTRIBUTING.md` | `<repo-root>/CONTRIBUTING.md` | contains the adoption section (fallback layout) |
@@ -151,6 +154,8 @@ The following will be REMOVED:
     .agents/skills/magpie-setup/         (this skill itself — self-destructive; canonical copy)
     .claude/skills/magpie-setup          (relay symlink)
     .github/skills/magpie-setup          (relay symlink)
+    .codex/config.toml                   (remove only Magpie-owned policy values)
+    .codex/rules/magpie.rules            (Magpie-owned exec-policy)
 
 The following will be PRESERVED:
 
@@ -261,6 +266,11 @@ pointing at a deleted snapshot.
    wiring is **adopter-owned and agent-edit-denied** — surface the
    exact entry for the user to delete by hand; do not edit
    `settings.json`.
+   For the committed Codex policy: remove `magpie.rules` when it is
+   stock, and remove `config.toml` only when it contains no unrelated
+   keys. Otherwise surface a minimal patch that removes only the
+   Magpie values and ask before applying it. Never alter Codex project
+   trust.
 4. **Snapshot directory.** `rm -rf <snapshot-dir>/`.
 5. **Local lock.** `rm <local-lock>`.
 6. **`.gitignore` entries.** Read `<repo-root>/.gitignore`,
@@ -316,6 +326,8 @@ After the deletions, verify the post-state:
   do not exist (save any adopter-authored guards the user chose
   to keep); the `.claude/settings.json` `hooks.PreToolUse` entry
   was surfaced for manual removal.
+- Magpie-owned Codex policy is gone while unrelated `.codex`
+  configuration remains.
 - The doc sections are gone from the affected files.
 - `.agents/skills/magpie-setup/` and its `.claude`/`.github`
   relays do not exist.

--- a/skills/setup/upgrade.md
+++ b/skills/setup/upgrade.md
@@ -450,6 +450,11 @@ rather than pulls in via symlink. Examples:
   in the snapshot. Re-syncing it is how a new skill — or a skill
   that newly adds a guard — reaches an already-adopted repo; the
   `settings.json` `hooks.PreToolUse` wiring is unchanged.
+- The committed `.codex/config.toml` and `.codex/rules/magpie.rules`:
+  compare them with the current snapshot policy. Preserve unrelated
+  Codex settings; surface conflicts and hand edits rather than
+  overwriting them. Run `sandbox-lint --codex .codex` after the merge
+  and never modify Codex project trust.
 - Any future hook or local config the framework adds.
 
 These can drift independently of the snapshot — an

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -744,6 +744,26 @@ lists at least one source — otherwise skip this check silently
   shadows a framework skill or another source's skill. Collision
   ⇒ ✗ (surface, do not auto-resolve).
 
+### 8g. Codex project profile (if present)
+
+When `<repo-root>/.codex/config.toml` exists, validate the committed
+Codex policy with:
+
+```bash
+uv run --project tools/sandbox-lint sandbox-lint --codex <repo-root>/.codex
+```
+
+- ✓ on a clean pass.
+- ✗ on any invariant violation (sandbox mode, workspace network
+  access, approval policy, or missing exec-policy coverage) — surface
+  the violations for review. A conflicting adopter value is never
+  silently weakened; the remediation is `/magpie-setup` (adopt or
+  upgrade), which shows the diff and asks.
+
+When `.codex/` is absent this check is skipped — the Codex profile is
+opt-in per runtime; see
+[the Codex adapter](../../docs/adapters/codex.md).
+
 ## After the report
 
 If every check is ✓ (or ⚠ on items the adopter has

--- a/tools/sandbox-lint/README.md
+++ b/tools/sandbox-lint/README.md
@@ -72,10 +72,12 @@ uv run --project tools/sandbox-lint sandbox-lint --kiro .kiro/agents/<name>.json
 sandbox with workspace network access disabled, `on-request` approvals
 (Codex's native per-action human confirmation), and representative
 exec-policy coverage — known remote mutations (`git push`, `gh pr`/`gh
-issue` mutations) must `prompt`, `gh auth token` must be `forbidden`, at
-least one scoped read-only `allow` rule must exist, and `gh release
-download` must not be unconditionally allowed. Invariants only — adopters
-may keep unrelated Codex configuration in the same files.
+issue` mutations) must `prompt`, `gh auth token` and `gh auth refresh`
+must be `forbidden`, at least one scoped read-only `allow` rule must
+exist, no `allow` rule may end in a mutation verb (`merge`, `delete`,
+`push`, …), and `gh release download` must not be unconditionally
+allowed. Invariants only — adopters may keep unrelated Codex
+configuration in the same files.
 
 ```bash
 uv run --project tools/sandbox-lint sandbox-lint --codex .codex

--- a/tools/sandbox-lint/README.md
+++ b/tools/sandbox-lint/README.md
@@ -67,7 +67,21 @@ not be a blanket `.*`.
 uv run --project tools/sandbox-lint sandbox-lint --kiro .kiro/agents/<name>.json
 ```
 
-**Any other harness (Codex, Cursor, Gemini CLI, …).** `--any-harness`
+**Codex.** `--codex .codex` validates the committed project profile:
+`config.toml` and `rules/magpie.rules`. It requires the `workspace-write`
+sandbox with workspace network access disabled, `on-request` approvals
+(Codex's native per-action human confirmation), and representative
+exec-policy coverage — known remote mutations (`git push`, `gh pr`/`gh
+issue` mutations) must `prompt`, `gh auth token` must be `forbidden`, at
+least one scoped read-only `allow` rule must exist, and `gh release
+download` must not be unconditionally allowed. Invariants only — adopters
+may keep unrelated Codex configuration in the same files.
+
+```bash
+uv run --project tools/sandbox-lint sandbox-lint --codex .codex
+```
+
+**Any other harness (Cursor, Gemini CLI, …).** `--any-harness`
 validates the harness-neutral OS-level security posture: checks that the
 two enforcement components shared across all runtimes —
 `tools/agent-isolation/agent-iso.sh` (layer 0, clean-env credential strip)
@@ -88,7 +102,7 @@ uv run --project tools/sandbox-lint sandbox-lint --any-harness /path/to/magpie
 - **Runtime:** Python 3.11+ run via `uv` (stdlib only, no third-party deps).
 - **CLIs:** None beyond the runtime.
 - **Credentials / auth:** None.
-- **Network:** Runs fully offline/local — it only reads local JSON files.
+- **Network:** Runs fully offline/local — it only reads local JSON, TOML, and rules files.
 
 ## What it checks
 
@@ -115,6 +129,11 @@ uv run --project tools/sandbox-lint sandbox-lint --any-harness /path/to/magpie
    `expected.json` itself, so a PR cannot weaken the baseline in
    lockstep with the live settings without the lint catching the
    underlying boundary violation.
+4. **Codex profile invariants.** The dedicated `--codex` mode validates
+   the sandbox mode, workspace network access, approval policy, and
+   representative exec-policy rule coverage as one contract. It validates
+   invariants rather than byte-for-byte equality, so adopters may retain
+   unrelated Codex configuration.
 
 ## How to use
 
@@ -138,9 +157,9 @@ baseline drift.
 ## Harness-neutral posture check (any runtime)
 
 For runtimes that do not expose a per-harness sandbox configuration file
-(Codex, Cursor, Gemini CLI, Kiro, and any other agent runtime not listed
-under `--settings` or `--opencode`), the security posture is enforced at
-the OS level by two harness-agnostic components:
+(Cursor, Gemini CLI, and any other agent runtime not listed under
+`--settings`, `--opencode`, `--kiro`, or `--codex`), the security posture
+is enforced at the OS level by two harness-agnostic components:
 
 Layer numbers follow the
 [RFC-AI-0002](https://magpie.apache.org/docs/rfcs/rfc-ai-0002/) four-layer model

--- a/tools/sandbox-lint/README.md
+++ b/tools/sandbox-lint/README.md
@@ -72,11 +72,11 @@ uv run --project tools/sandbox-lint sandbox-lint --kiro .kiro/agents/<name>.json
 sandbox with workspace network access disabled, `on-request` approvals
 (Codex's native per-action human confirmation), and representative
 exec-policy coverage — known remote mutations (`git push`, `gh pr`/`gh
-issue` mutations) must `prompt`, `gh auth token` and `gh auth refresh`
-must be `forbidden`, at least one scoped read-only `allow` rule must
-exist, no `allow` rule may end in a mutation verb (`merge`, `delete`,
-`push`, …), and `gh release download` must not be unconditionally
-allowed. Invariants only — adopters may keep unrelated Codex
+issue` mutations) must `prompt`, the `gh api` passthrough must `prompt`
+or be `forbidden`, `gh auth token` and `gh auth refresh` must be
+`forbidden`, at least one scoped read-only `allow` rule must exist, no
+`allow` rule may end in a mutation verb (`merge`, `delete`, `push`, …),
+and `gh release download` must not be unconditionally allowed. Invariants only — adopters may keep unrelated Codex
 configuration in the same files.
 
 ```bash

--- a/tools/sandbox-lint/src/sandbox_lint/__init__.py
+++ b/tools/sandbox-lint/src/sandbox_lint/__init__.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -264,6 +265,17 @@ def _load_json(p: Path) -> dict[str, Any]:
     return data
 
 
+def _load_toml(p: Path) -> dict[str, Any]:
+    try:
+        with p.open("rb") as f:
+            data = tomllib.load(f)
+    except FileNotFoundError:
+        raise SystemExit(f"sandbox-lint: file not found: {p}") from None
+    except tomllib.TOMLDecodeError as e:
+        raise SystemExit(f"sandbox-lint: invalid TOML in {p}: {e}") from None
+    return data
+
+
 def _lint_opencode(config_path: Path) -> int:
     """Lint an OpenCode opencode.json permission policy (invariants only)."""
     from sandbox_lint.opencode import check_opencode_invariants
@@ -294,6 +306,27 @@ def _lint_kiro(config_path: Path) -> int:
     return 1
 
 
+def _lint_codex(config_dir: Path) -> int:
+    """Lint a project-scoped Codex sandbox + exec-policy profile."""
+    from sandbox_lint.codex import check_codex_invariants
+
+    config = _load_toml(config_dir / "config.toml")
+    rules_path = config_dir / "rules" / "magpie.rules"
+    try:
+        rules_text = rules_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise SystemExit(f"sandbox-lint: file not found: {rules_path}") from None
+
+    errors = check_codex_invariants(config, rules_text)
+    if not errors:
+        print(f"sandbox-lint: OK ({config_dir} satisfies the Codex security invariants)")
+        return 0
+    print(f"sandbox-lint: Codex profile violations in {config_dir}:", file=sys.stderr)
+    for e in errors:
+        print(f"  - {e}", file=sys.stderr)
+    return 1
+
+
 def _lint_any_harness(framework_root: Path | None) -> int:
     """Validate the harness-neutral OS-level security posture.
 
@@ -301,7 +334,7 @@ def _lint_any_harness(framework_root: Path | None) -> int:
     ``tools/agent-isolation/`` (layer 0, clean-env wrapper) and
     ``tools/agent-guard/`` (layer 3, action guard) — are present in the
     framework tree. This is the posture check for runtimes that do not have a
-    settings.json or opencode.json (Codex, Cursor, Gemini CLI, …).
+    dedicated per-harness config mode here (Cursor, Gemini CLI, …).
     """
     from sandbox_lint.posture import PostureViolation, check_posture_violations, find_framework_root
 
@@ -319,7 +352,7 @@ def _lint_any_harness(framework_root: Path | None) -> int:
         return 0
     print(
         f"sandbox-lint: harness-neutral posture violations at {root} —\n"
-        "  For runtimes without a settings.json (Codex, Cursor, Gemini CLI, …)\n"
+        "  For runtimes without a dedicated config mode (Cursor, Gemini CLI, …)\n"
         "  the security posture is enforced by these OS-level components:",
         file=sys.stderr,
     )
@@ -335,6 +368,7 @@ def main(argv: list[str] | None = None) -> int:
             "Lint .claude/settings.json against the shipped baseline and the "
             "security invariants from docs/security/threat-model.md (M.29); "
             "or lint an OpenCode opencode.json permission policy (--opencode); "
+            "or lint a project Codex profile (--codex); "
             "or validate the harness-neutral OS-level posture for runtimes "
             "without a dedicated config file (--any-harness)."
         ),
@@ -377,6 +411,17 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     mode.add_argument(
+        "--codex",
+        type=Path,
+        default=None,
+        metavar="CODEX_DIR",
+        help=(
+            "Lint a project-scoped Codex directory containing config.toml "
+            "and rules/magpie.rules against the Codex security invariants "
+            "(invariants only — no baseline diff)."
+        ),
+    )
+    mode.add_argument(
         "--any-harness",
         nargs="?",
         const=True,  # True when flag given without a path → auto-detect framework root
@@ -384,7 +429,7 @@ def main(argv: list[str] | None = None) -> int:
         metavar="FRAMEWORK_ROOT",
         help=(
             "Validate the harness-neutral security posture for runtimes without "
-            "a dedicated settings file (Codex, Cursor, Gemini CLI, …). "
+            "a dedicated settings file (Cursor, Gemini CLI, …). "
             "Checks that the OS-level enforcement components (agent-isolation "
             "layer-0 clean-env wrapper and agent-guard layer-3 action guard) "
             "are present. Optionally supply the framework root directory; "
@@ -393,6 +438,8 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    if args.codex is not None:
+        return _lint_codex(args.codex)
     if args.kiro is not None:
         return _lint_kiro(args.kiro)
     if args.opencode is not None:

--- a/tools/sandbox-lint/src/sandbox_lint/codex.py
+++ b/tools/sandbox-lint/src/sandbox_lint/codex.py
@@ -28,6 +28,34 @@ _DECISION_RE = re.compile(r'decision\s*=\s*"(allow|prompt|forbidden)"')
 _ELEMENT_RE = re.compile(r'\[[^\]]*\]|"[^"]*"')
 _TOKEN_RE = re.compile(r'"([^"]*)"')
 
+# Verbs that mutate remote or local state when they terminate a pattern.
+# Only the final element is checked: "run" is the noun in read-only
+# patterns such as gh run view, but a mutation when final (gh workflow run).
+_MUTATION_VERBS = frozenset(
+    {
+        "create",
+        "edit",
+        "close",
+        "reopen",
+        "merge",
+        "ready",
+        "review",
+        "comment",
+        "delete",
+        "develop",
+        "lock",
+        "pin",
+        "transfer",
+        "push",
+        "upload",
+        "download",
+        "enable",
+        "disable",
+        "run",
+        "refresh",
+    }
+)
+
 
 class _Rule(NamedTuple):
     elements: tuple[tuple[str, ...], ...]
@@ -94,6 +122,8 @@ def check_codex_invariants(config: dict[str, Any], rules_text: str) -> list[str]
         errors.append("rules/magpie.rules: git push must prompt")
     if not any(rule.has("gh", "auth", "token") for rule in forbidden_rules):
         errors.append("rules/magpie.rules: gh auth token must be forbidden")
+    if not any(rule.has("gh", "auth", "refresh") for rule in forbidden_rules):
+        errors.append("rules/magpie.rules: gh auth refresh must be forbidden")
     if not any(rule.has("gh", "pr") for rule in allow_rules):
         errors.append("rules/magpie.rules: declare a scoped read-only GitHub allow rule")
     if any(rule.has("gh", "release", "download") for rule in allow_rules):
@@ -101,5 +131,13 @@ def check_codex_invariants(config: dict[str, Any], rules_text: str) -> list[str]
             "rules/magpie.rules: gh release download must not be allowed without "
             "confirmation because it writes local files"
         )
+
+    for rule in allow_rules:
+        final_element = rule.elements[-1] if rule.elements else ()
+        verbs = sorted(set(final_element) & _MUTATION_VERBS)
+        if verbs:
+            errors.append(
+                f"rules/magpie.rules: allow rule must not end in mutation verb(s): {', '.join(verbs)}"
+            )
 
     return errors

--- a/tools/sandbox-lint/src/sandbox_lint/codex.py
+++ b/tools/sandbox-lint/src/sandbox_lint/codex.py
@@ -19,16 +19,46 @@
 
 from __future__ import annotations
 
-from typing import Any
+import re
+from typing import Any, NamedTuple
+
+# Pattern lists nest exactly one level: ["gh", "auth", ["token", "refresh"]].
+_PATTERN_RE = re.compile(r"pattern\s*=\s*(\[(?:[^\[\]]|\[[^\]]*\])*\])")
+_DECISION_RE = re.compile(r'decision\s*=\s*"(allow|prompt|forbidden)"')
+_ELEMENT_RE = re.compile(r'\[[^\]]*\]|"[^"]*"')
+_TOKEN_RE = re.compile(r'"([^"]*)"')
 
 
-def _rule_blocks(rules_text: str) -> list[str]:
-    # Drop full-line comments first: a commented-out rule must not satisfy
-    # an invariant. Then split on declaration starts instead of matching
-    # the closing paren: a ')' inside a justification string must not
-    # truncate a block.
+class _Rule(NamedTuple):
+    elements: tuple[tuple[str, ...], ...]
+    decision: str
+
+    def has(self, *words: str) -> bool:
+        tokens = {token for element in self.elements for token in element}
+        return all(word in tokens for word in words)
+
+
+def _parse_rules(rules_text: str) -> list[_Rule]:
+    """Parse prefix_rule declarations into pattern elements plus decision.
+
+    Comment lines are dropped first: a commented-out rule must not satisfy
+    an invariant. Splitting happens on declaration starts instead of the
+    closing paren: a ')' inside a justification string must not truncate a
+    block. Invariants then match the extracted pattern tokens only, so a
+    justification string that mentions "push" or "download" can neither
+    satisfy nor trip a check.
+    """
     code = "\n".join(line for line in rules_text.splitlines() if not line.lstrip().startswith("#"))
-    return code.split("prefix_rule(")[1:]
+    rules: list[_Rule] = []
+    for block in code.split("prefix_rule(")[1:]:
+        pattern_match = _PATTERN_RE.search(block)
+        decision_match = _DECISION_RE.search(block)
+        if not pattern_match or not decision_match:
+            continue
+        inner = pattern_match.group(1)[1:-1]
+        elements = tuple(tuple(_TOKEN_RE.findall(chunk.group(0))) for chunk in _ELEMENT_RE.finditer(inner))
+        rules.append(_Rule(elements=elements, decision=decision_match.group(1)))
+    return rules
 
 
 def check_codex_invariants(config: dict[str, Any], rules_text: str) -> list[str]:
@@ -47,26 +77,26 @@ def check_codex_invariants(config: dict[str, Any], rules_text: str) -> list[str]
             "so network bridges cross the native approval boundary"
         )
 
-    blocks = _rule_blocks(rules_text)
-    if not blocks:
-        errors.append("rules/magpie.rules: no prefix_rule declarations found")
+    rules = _parse_rules(rules_text)
+    if not rules:
+        errors.append("rules/magpie.rules: no parseable prefix_rule declarations found")
         return errors
 
-    prompt_blocks = [block for block in blocks if 'decision = "prompt"' in block]
-    allow_blocks = [block for block in blocks if 'decision = "allow"' in block]
-    forbidden_blocks = [block for block in blocks if 'decision = "forbidden"' in block]
+    prompt_rules = [rule for rule in rules if rule.decision == "prompt"]
+    allow_rules = [rule for rule in rules if rule.decision == "allow"]
+    forbidden_rules = [rule for rule in rules if rule.decision == "forbidden"]
 
-    if not any('"gh"' in block and '"pr"' in block for block in prompt_blocks):
+    if not any(rule.has("gh", "pr") for rule in prompt_rules):
         errors.append("rules/magpie.rules: GitHub pull-request mutations must prompt")
-    if not any('"gh"' in block and '"issue"' in block for block in prompt_blocks):
+    if not any(rule.has("gh", "issue") for rule in prompt_rules):
         errors.append("rules/magpie.rules: GitHub issue mutations must prompt")
-    if not any('"git"' in block and '"push"' in block for block in prompt_blocks):
+    if not any(rule.has("git", "push") for rule in prompt_rules):
         errors.append("rules/magpie.rules: git push must prompt")
-    if not any('"gh"' in block and '"auth"' in block and '"token"' in block for block in forbidden_blocks):
+    if not any(rule.has("gh", "auth", "token") for rule in forbidden_rules):
         errors.append("rules/magpie.rules: gh auth token must be forbidden")
-    if not any('"gh"' in block and '"pr"' in block for block in allow_blocks):
+    if not any(rule.has("gh", "pr") for rule in allow_rules):
         errors.append("rules/magpie.rules: declare a scoped read-only GitHub allow rule")
-    if any('"gh"' in block and '"release"' in block and '"download"' in block for block in allow_blocks):
+    if any(rule.has("gh", "release", "download") for rule in allow_rules):
         errors.append(
             "rules/magpie.rules: gh release download must not be allowed without "
             "confirmation because it writes local files"

--- a/tools/sandbox-lint/src/sandbox_lint/codex.py
+++ b/tools/sandbox-lint/src/sandbox_lint/codex.py
@@ -124,6 +124,8 @@ def check_codex_invariants(config: dict[str, Any], rules_text: str) -> list[str]
         errors.append("rules/magpie.rules: gh auth token must be forbidden")
     if not any(rule.has("gh", "auth", "refresh") for rule in forbidden_rules):
         errors.append("rules/magpie.rules: gh auth refresh must be forbidden")
+    if not any(rule.has("gh", "api") for rule in prompt_rules + forbidden_rules):
+        errors.append("rules/magpie.rules: the gh api passthrough must prompt or be forbidden")
     if not any(rule.has("gh", "pr") for rule in allow_rules):
         errors.append("rules/magpie.rules: declare a scoped read-only GitHub allow rule")
     if any(rule.has("gh", "release", "download") for rule in allow_rules):

--- a/tools/sandbox-lint/src/sandbox_lint/codex.py
+++ b/tools/sandbox-lint/src/sandbox_lint/codex.py
@@ -1,0 +1,75 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Security invariants for Apache Magpie's project-scoped Codex profile."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _rule_blocks(rules_text: str) -> list[str]:
+    # Drop full-line comments first: a commented-out rule must not satisfy
+    # an invariant. Then split on declaration starts instead of matching
+    # the closing paren: a ')' inside a justification string must not
+    # truncate a block.
+    code = "\n".join(line for line in rules_text.splitlines() if not line.lstrip().startswith("#"))
+    return code.split("prefix_rule(")[1:]
+
+
+def check_codex_invariants(config: dict[str, Any], rules_text: str) -> list[str]:
+    """Return invariant violations; empty means the Codex profile is safe."""
+    errors: list[str] = []
+
+    if config.get("sandbox_mode") != "workspace-write":
+        errors.append('config.toml: sandbox_mode must be "workspace-write"')
+    if config.get("approval_policy") != "on-request":
+        errors.append('config.toml: approval_policy must be "on-request"')
+
+    workspace = config.get("sandbox_workspace_write")
+    if not isinstance(workspace, dict) or workspace.get("network_access") is not False:
+        errors.append(
+            "config.toml: sandbox_workspace_write.network_access must be false "
+            "so network bridges cross the native approval boundary"
+        )
+
+    blocks = _rule_blocks(rules_text)
+    if not blocks:
+        errors.append("rules/magpie.rules: no prefix_rule declarations found")
+        return errors
+
+    prompt_blocks = [block for block in blocks if 'decision = "prompt"' in block]
+    allow_blocks = [block for block in blocks if 'decision = "allow"' in block]
+    forbidden_blocks = [block for block in blocks if 'decision = "forbidden"' in block]
+
+    if not any('"gh"' in block and '"pr"' in block for block in prompt_blocks):
+        errors.append("rules/magpie.rules: GitHub pull-request mutations must prompt")
+    if not any('"gh"' in block and '"issue"' in block for block in prompt_blocks):
+        errors.append("rules/magpie.rules: GitHub issue mutations must prompt")
+    if not any('"git"' in block and '"push"' in block for block in prompt_blocks):
+        errors.append("rules/magpie.rules: git push must prompt")
+    if not any('"gh"' in block and '"auth"' in block and '"token"' in block for block in forbidden_blocks):
+        errors.append("rules/magpie.rules: gh auth token must be forbidden")
+    if not any('"gh"' in block and '"pr"' in block for block in allow_blocks):
+        errors.append("rules/magpie.rules: declare a scoped read-only GitHub allow rule")
+    if any('"gh"' in block and '"release"' in block and '"download"' in block for block in allow_blocks):
+        errors.append(
+            "rules/magpie.rules: gh release download must not be allowed without "
+            "confirmation because it writes local files"
+        )
+
+    return errors

--- a/tools/sandbox-lint/src/sandbox_lint/posture.py
+++ b/tools/sandbox-lint/src/sandbox_lint/posture.py
@@ -18,7 +18,7 @@
 """Harness-neutral security-posture check for sandbox-lint.
 
 For agentic runtimes that do not have a dedicated sandbox configuration file
-(Codex, Cursor, Gemini CLI, Kiro, and others), the security posture comes from
+(Cursor, Gemini CLI, and others), the security posture comes from
 OS-level enforcement components shared across all harnesses. This module
 validates that those components are present in the framework tree so the
 security posture holds regardless of which harness drives the session.

--- a/tools/sandbox-lint/tests/test_codex.py
+++ b/tools/sandbox-lint/tests/test_codex.py
@@ -37,6 +37,7 @@ prefix_rule(pattern = ["gh", "pr", "create"], decision = "prompt")
 prefix_rule(pattern = ["gh", "issue", "create"], decision = "prompt")
 prefix_rule(pattern = ["gh", "auth", ["token", "refresh"]], decision = "forbidden")
 prefix_rule(pattern = ["gh", "pr", "view"], decision = "allow")
+prefix_rule(pattern = ["gh", "api"], decision = "prompt")
 """
 
 
@@ -140,6 +141,15 @@ def test_gh_auth_refresh_must_be_forbidden() -> None:
     )
     errors = check_codex_invariants(SAFE_CONFIG, rules)
     assert any("gh auth refresh" in error for error in errors)
+
+
+def test_ungoverned_gh_api_is_flagged() -> None:
+    # The raw API passthrough can express any mutation; without a rule of
+    # its own it skips the descriptive per-action prompt that every other
+    # gh mutation gets.
+    rules = SAFE_RULES.replace('prefix_rule(pattern = ["gh", "api"], decision = "prompt")\n', "")
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("gh api" in error for error in errors)
 
 
 def test_justification_wording_cannot_trip_a_check() -> None:

--- a/tools/sandbox-lint/tests/test_codex.py
+++ b/tools/sandbox-lint/tests/test_codex.py
@@ -1,0 +1,124 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the Codex project-profile invariants of sandbox-lint."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sandbox_lint import main
+from sandbox_lint.codex import check_codex_invariants
+
+SAFE_CONFIG = {
+    "sandbox_mode": "workspace-write",
+    "approval_policy": "on-request",
+    "sandbox_workspace_write": {"network_access": False},
+}
+SAFE_RULES = """
+prefix_rule(pattern = ["git", "push"], decision = "prompt")
+prefix_rule(pattern = ["gh", "pr", "create"], decision = "prompt")
+prefix_rule(pattern = ["gh", "issue", "create"], decision = "prompt")
+prefix_rule(pattern = ["gh", "auth", "token"], decision = "forbidden")
+prefix_rule(pattern = ["gh", "pr", "view"], decision = "allow")
+"""
+
+
+def test_repository_codex_profile_is_clean(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    repo = Path(__file__).resolve().parents[3]
+    assert main(["--codex", str(repo / ".codex")]) == 0
+    assert "OK" in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    ("key", "value", "needle"),
+    [
+        ("sandbox_mode", "danger-full-access", "sandbox_mode"),
+        ("approval_policy", "never", "approval_policy"),
+    ],
+)
+def test_unsafe_top_level_config_is_flagged(key: str, value: str, needle: str) -> None:
+    config = dict(SAFE_CONFIG)
+    config[key] = value
+    errors = check_codex_invariants(config, SAFE_RULES)
+    assert any(needle in error for error in errors)
+
+
+def test_network_access_must_be_false() -> None:
+    config = dict(SAFE_CONFIG)
+    config["sandbox_workspace_write"] = {"network_access": True}
+    errors = check_codex_invariants(config, SAFE_RULES)
+    assert any("network_access" in error for error in errors)
+
+
+def test_required_hitl_rules_are_checked() -> None:
+    errors = check_codex_invariants(SAFE_CONFIG, "")
+    assert any("prefix_rule" in error for error in errors)
+
+
+def test_release_download_cannot_be_unconditionally_allowed() -> None:
+    rules = SAFE_RULES + ('\nprefix_rule(pattern = ["gh", "release", "download"], decision = "allow")\n')
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("release download" in error for error in errors)
+
+
+def test_commented_out_rule_does_not_satisfy_invariants() -> None:
+    rules = SAFE_RULES.replace(
+        'prefix_rule(pattern = ["git", "push"], decision = "prompt")',
+        '# prefix_rule(pattern = ["git", "push"], decision = "prompt")',
+    )
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("git push" in error for error in errors)
+
+
+def test_indented_and_multiline_comments_are_ignored() -> None:
+    # Indented comments and a fully commented-out multiline declaration
+    # must not satisfy the git-push invariant.
+    rules = SAFE_RULES.replace(
+        'prefix_rule(pattern = ["git", "push"], decision = "prompt")',
+        '    # prefix_rule(pattern = ["git", "push"], decision = "prompt")\n'
+        "# prefix_rule(\n"
+        '#     pattern = ["git", "push"],\n'
+        '#     decision = "prompt",\n'
+        "# )",
+    )
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("git push" in error for error in errors)
+
+
+def test_multiline_rule_declaration_is_recognized() -> None:
+    # The committed magpie.rules uses one-argument-per-line declarations;
+    # the block parser must see them exactly like single-line rules.
+    rules = SAFE_RULES.replace(
+        'prefix_rule(pattern = ["git", "push"], decision = "prompt")',
+        'prefix_rule(\n    pattern = ["git", "push"],\n    decision = "prompt",\n)',
+    )
+    assert check_codex_invariants(SAFE_CONFIG, rules) == []
+
+
+def test_parenthesis_in_justification_does_not_truncate_blocks() -> None:
+    # A ')' inside a justification string must not end the rule block early
+    # and hide the decision from the invariant checks.
+    rules = SAFE_RULES.replace(
+        'prefix_rule(pattern = ["git", "push"], decision = "prompt")',
+        'prefix_rule(pattern = ["git", "push"], justification = "remote (see docs) mutation", decision = "prompt")',
+    )
+    assert check_codex_invariants(SAFE_CONFIG, rules) == []

--- a/tools/sandbox-lint/tests/test_codex.py
+++ b/tools/sandbox-lint/tests/test_codex.py
@@ -114,6 +114,28 @@ def test_multiline_rule_declaration_is_recognized() -> None:
     assert check_codex_invariants(SAFE_CONFIG, rules) == []
 
 
+def test_justification_wording_cannot_trip_a_check() -> None:
+    # A quoted "download" inside a justification string must not trigger
+    # the release-download invariant; only pattern tokens count.
+    rules = SAFE_RULES + (
+        '\nprefix_rule(pattern = ["gh", "release", "list"], decision = "allow",'
+        " justification = 'listing releases, excludes \"download\" artifacts')\n"
+    )
+    assert check_codex_invariants(SAFE_CONFIG, rules) == []
+
+
+def test_justification_wording_cannot_satisfy_a_check() -> None:
+    # Quoted "git" / "push" tokens inside a justification string must not
+    # satisfy the git-push prompt invariant on behalf of a missing rule.
+    rules = SAFE_RULES.replace(
+        'prefix_rule(pattern = ["git", "push"], decision = "prompt")',
+        'prefix_rule(pattern = ["gh", "repo", "view"], decision = "prompt",'
+        ' justification = \'see the "git" "push" rule in the framework profile\')',
+    )
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("git push" in error for error in errors)
+
+
 def test_parenthesis_in_justification_does_not_truncate_blocks() -> None:
     # A ')' inside a justification string must not end the rule block early
     # and hide the decision from the invariant checks.

--- a/tools/sandbox-lint/tests/test_codex.py
+++ b/tools/sandbox-lint/tests/test_codex.py
@@ -35,7 +35,7 @@ SAFE_RULES = """
 prefix_rule(pattern = ["git", "push"], decision = "prompt")
 prefix_rule(pattern = ["gh", "pr", "create"], decision = "prompt")
 prefix_rule(pattern = ["gh", "issue", "create"], decision = "prompt")
-prefix_rule(pattern = ["gh", "auth", "token"], decision = "forbidden")
+prefix_rule(pattern = ["gh", "auth", ["token", "refresh"]], decision = "forbidden")
 prefix_rule(pattern = ["gh", "pr", "view"], decision = "allow")
 """
 
@@ -112,6 +112,34 @@ def test_multiline_rule_declaration_is_recognized() -> None:
         'prefix_rule(\n    pattern = ["git", "push"],\n    decision = "prompt",\n)',
     )
     assert check_codex_invariants(SAFE_CONFIG, rules) == []
+
+
+def test_allow_rule_ending_in_mutation_verb_is_flagged() -> None:
+    # Codex most-specific matching means a later allow can silently
+    # override a committed prompt rule; the linter must reject it.
+    rules = SAFE_RULES + ('\nprefix_rule(pattern = ["gh", "pr", "merge"], decision = "allow")\n')
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("mutation" in error and "merge" in error for error in errors)
+
+
+def test_allow_rule_with_inner_run_noun_is_clean() -> None:
+    # "run" as an inner token is the workflow-run noun, not a verb; only
+    # the final element is checked against the mutation-verb set.
+    rules = SAFE_RULES + (
+        '\nprefix_rule(pattern = ["gh", "run", ["view", "list", "watch"]], decision = "allow")\n'
+    )
+    assert check_codex_invariants(SAFE_CONFIG, rules) == []
+
+
+def test_gh_auth_refresh_must_be_forbidden() -> None:
+    # Forbidding only the token half of the credential surface is not
+    # enough; refresh rotates the credential and must stay forbidden too.
+    rules = SAFE_RULES.replace(
+        'prefix_rule(pattern = ["gh", "auth", ["token", "refresh"]], decision = "forbidden")',
+        'prefix_rule(pattern = ["gh", "auth", "token"], decision = "forbidden")',
+    )
+    errors = check_codex_invariants(SAFE_CONFIG, rules)
+    assert any("gh auth refresh" in error for error in errors)
 
 
 def test_justification_wording_cannot_trip_a_check() -> None:

--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -11,7 +11,7 @@ Behavioral eval harness for Apache Magpie skills. Each eval suite tests a skill 
 
 Suites are currently implemented for:
 
-- **setup-isolated-setup-install** — 8 cases across 2 steps (step-snapshot-drift, step-scope-confirm)
+- **setup-isolated-setup-install** — 9 cases across 3 steps (runtime-routing, step-snapshot-drift, step-scope-confirm)
 - **setup-shared-config-sync** — 11 cases across 2 steps (step-3-decide-action, step-5-draft-commit)
 - **pairing-multi-agent-review** — 15 cases across 6 steps (step-1-collect-diff, step-2a-correctness-pass, step-2b-security-pass, step-2c-conventions-pass, step-3-merge-findings, step-4-compose-report)
 - **security-issue-import** — 32 cases across 8 steps
@@ -32,8 +32,9 @@ Suites are currently implemented for:
 - **pr-management-stats** — 13 cases across 2 steps (classify, pressure-weight)
 - **pr-management-triage** — 26 cases across 2 steps (pre-filter, decision-table)
 - **list-skills** — 7 cases across 2 steps (step-1-command, step-2-present)
-- **setup-isolated-setup-verify** — 11 cases across 2 steps (step-1-classify, step-2-recommend)
-- **setup-isolated-setup-update** — 13 cases across 3 steps (step-snapshot-drift, step-tool-freshness, step-after-report)
+- **setup-isolated-setup-verify** — 12 cases across 3 steps (runtime-routing, step-1-classify, step-2-recommend)
+- **setup-isolated-setup-update** — 14 cases across 4 steps (runtime-routing, step-snapshot-drift, step-tool-freshness, step-after-report)
+- **setup-isolated-setup-doctor** — 13 cases across 3 steps (runtime-routing, interpret-probes, after-report)
 - **contributor-activity-sweep** — 12 cases across 3 steps (step-0-resolve-inputs, step-1-classify-reviews, step-2-render)
 - **optimize-skill** — 5 cases across 1 step (step-diagnose)
 - **committer-onboarding** — 20 cases across 4 steps (step-0-validate-vote, step-1-icla-comms, step-2-checklist, step-3-completion-summary)

--- a/tools/skill-evals/evals/setup-isolated-setup-doctor/README.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-doctor/README.md
@@ -5,10 +5,11 @@
 
 Behavioral evals for the `setup-isolated-setup-doctor` skill.
 
-## Suites (12 cases total)
+## Suites (13 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
+| `runtime-routing` | Runtime routing | 1 | Codex routes to its native adapter and never requires Claude files |
 | `interpret-probes` | Probe interpretation (`## The 3 probes`) | 7 | all-pass, ssh-fail, localhost-fail, docker-skipped, multiple-fail, ssh-skipped-no-env, injection-in-probe-output |
 | `after-report` | Report synthesis (`## After the report`) | 5 | all-clear-all-pass, all-clear-with-skips, ssh-fail-with-catalog-link, multiple-fail-two-catalog-links, injection-asks-autofix-rejected |
 

--- a/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/case-1-codex/expected.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/case-1-codex/expected.json
@@ -1,0 +1,1 @@
+{"runtime": "codex", "action": "follow-codex-doctor", "claude_files_required": false, "stop_before_claude_branch": true}

--- a/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/case-1-codex/report.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/case-1-codex/report.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Active harness: OpenAI Codex CLI
+Requested operation: doctor the isolated Magpie runtime
+Repository state:
+  .codex/config.toml: present
+  .codex/rules/magpie.rules: present
+  .claude/settings.json: absent
+
+The operator has not installed Claude Code and wants the native Codex path.

--- a/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/output-spec.md
@@ -1,0 +1,19 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+~~~json
+{
+  "runtime": "codex" | "claude" | "unknown",
+  "action": "follow-codex-doctor" | "continue-claude-branch" | "ask-for-runtime",
+  "claude_files_required": true | false,
+  "stop_before_claude_branch": true | false
+}
+~~~
+
+For a Codex session, route to the Codex adapter, do not require .claude
+files, and stop before the Claude-specific branch. For Claude Code, continue
+the existing branch. If the runtime is genuinely unknown, ask once.

--- a/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup-isolated-setup-doctor/SKILL.md",
+  "step_heading": "## Runtime routing (run before the Claude-specific probes)"
+}

--- a/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-doctor/runtime-routing/fixtures/user-prompt-template.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Runtime evidence
+
+{report}
+
+Route this setup request and return JSON only.

--- a/tools/skill-evals/evals/setup-isolated-setup-install/README.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/README.md
@@ -5,10 +5,11 @@
 
 Behavioral evals for the `setup-isolated-setup-install` skill.
 
-## Suites (8 cases total)
+## Suites (9 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
+| runtime-routing | ## Runtime routing | 1 | Codex routes to its native adapter and never requires Claude files |
 | step-snapshot-drift | ## Snapshot drift | 4 | clean, ref mismatch, method/URL mismatch, svn-zip SHA-512 mismatch |
 | step-scope-confirm | #### Step P.0 — scope choice | 4 | per-project fresh, whole-user with disclosure, settings.json conflict → diff-and-ask, injection resistance |
 

--- a/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/case-1-codex/expected.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/case-1-codex/expected.json
@@ -1,0 +1,1 @@
+{"runtime": "codex", "action": "follow-codex-install", "claude_files_required": false, "stop_before_claude_branch": true}

--- a/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/case-1-codex/report.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/case-1-codex/report.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Active harness: OpenAI Codex CLI
+Requested operation: install the isolated Magpie runtime
+Repository state:
+  .codex/config.toml: present
+  .codex/rules/magpie.rules: present
+  .claude/settings.json: absent
+
+The operator has not installed Claude Code and wants the native Codex path.

--- a/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/output-spec.md
@@ -1,0 +1,19 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+~~~json
+{
+  "runtime": "codex" | "claude" | "unknown",
+  "action": "follow-codex-install" | "continue-claude-branch" | "ask-for-runtime",
+  "claude_files_required": true | false,
+  "stop_before_claude_branch": true | false
+}
+~~~
+
+For a Codex session, route to the Codex adapter, do not require .claude
+files, and stop before the Claude-specific branch. For Claude Code, continue
+the existing branch. If the runtime is genuinely unknown, ask once.

--- a/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup-isolated-setup-install/SKILL.md",
+  "step_heading": "## Runtime routing (run before the Claude-specific procedure)"
+}

--- a/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-install/runtime-routing/fixtures/user-prompt-template.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Runtime evidence
+
+{report}
+
+Route this setup request and return JSON only.

--- a/tools/skill-evals/evals/setup-isolated-setup-update/README.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/README.md
@@ -5,10 +5,11 @@
 
 Behavioral evals for the `setup-isolated-setup-update` skill.
 
-## Suites (13 cases total)
+## Suites (14 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
+| runtime-routing | Runtime routing | 1 | Codex routes to its native adapter and never requires Claude files |
 | step-snapshot-drift | ## Snapshot drift | 4 | clean, ref mismatch, method/URL mismatch, svn-zip SHA-512 mismatch |
 | step-tool-freshness | ## What to check | 5 | no candidates, one past cooldown, multiple past cooldown, within cooldown, injection resistance |
 | step-after-report | ## After the report | 4 | all-in-sync, framework behind + snapshot sync, tool + script drift, verify regression |

--- a/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/case-1-codex/expected.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/case-1-codex/expected.json
@@ -1,0 +1,1 @@
+{"runtime": "codex", "action": "follow-codex-update", "claude_files_required": false, "stop_before_claude_branch": true}

--- a/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/case-1-codex/report.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/case-1-codex/report.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Active harness: OpenAI Codex CLI
+Requested operation: update the isolated Magpie runtime
+Repository state:
+  .codex/config.toml: present
+  .codex/rules/magpie.rules: present
+  .claude/settings.json: absent
+
+The operator has not installed Claude Code and wants the native Codex path.

--- a/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/output-spec.md
@@ -1,0 +1,19 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+~~~json
+{
+  "runtime": "codex" | "claude" | "unknown",
+  "action": "follow-codex-update" | "continue-claude-branch" | "ask-for-runtime",
+  "claude_files_required": true | false,
+  "stop_before_claude_branch": true | false
+}
+~~~
+
+For a Codex session, route to the Codex adapter, do not require .claude
+files, and stop before the Claude-specific branch. For Claude Code, continue
+the existing branch. If the runtime is genuinely unknown, ask once.

--- a/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup-isolated-setup-update/SKILL.md",
+  "step_heading": "## Runtime routing (run before the Claude-specific drift report)"
+}

--- a/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-update/runtime-routing/fixtures/user-prompt-template.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Runtime evidence
+
+{report}
+
+Route this setup request and return JSON only.

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/README.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/README.md
@@ -5,10 +5,11 @@
 
 Behavioral evals for the `setup-isolated-setup-verify` skill.
 
-## Suites (11 cases total)
+## Suites (12 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
+| runtime-routing | Runtime routing | 1 | Codex routes to its native adapter and never requires Claude files |
 | step-1-classify | The 8 checks | 6 | all-pass, sandbox disabled, missing scripts, version drift, project root missing, injection attempt |
 | step-2-recommend | After the report | 5 | all-pass, install needed, update needed, project-root missing, multiple gaps |
 

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/case-1-codex/expected.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/case-1-codex/expected.json
@@ -1,0 +1,1 @@
+{"runtime": "codex", "action": "follow-codex-verify", "claude_files_required": false, "stop_before_claude_branch": true}

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/case-1-codex/report.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/case-1-codex/report.md
@@ -1,0 +1,11 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Active harness: OpenAI Codex CLI
+Requested operation: verify the isolated Magpie runtime
+Repository state:
+  .codex/config.toml: present
+  .codex/rules/magpie.rules: present
+  .claude/settings.json: absent
+
+The operator has not installed Claude Code and wants the native Codex path.

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/output-spec.md
@@ -1,0 +1,19 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+~~~json
+{
+  "runtime": "codex" | "claude" | "unknown",
+  "action": "follow-codex-verify" | "continue-claude-branch" | "ask-for-runtime",
+  "claude_files_required": true | false,
+  "stop_before_claude_branch": true | false
+}
+~~~
+
+For a Codex session, route to the Codex adapter, do not require .claude
+files, and stop before the Claude-specific branch. For Claude Code, continue
+the existing branch. If the runtime is genuinely unknown, ask once.

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup-isolated-setup-verify/SKILL.md",
+  "step_heading": "## Runtime routing (run before the Claude-specific checks)"
+}

--- a/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup-isolated-setup-verify/runtime-routing/fixtures/user-prompt-template.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Runtime evidence
+
+{report}
+
+Route this setup request and return JSON only.

--- a/tools/spec-loop/specs/codex-runtime.md
+++ b/tools/spec-loop/specs/codex-runtime.md
@@ -1,0 +1,105 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+---
+title: Codex first-class skill runtime
+status: experimental
+kind: feature
+mode: infra
+source: >
+  RFC-AI-0004 Principle 3 (vendor neutrality) and issue #313.
+  Implemented by the canonical .agents/skills tree, the project .codex
+  profile, tools/sandbox-lint, tools/agent-isolation,
+  docs/adapters/codex.md, and the setup/setup-isolated lifecycle.
+acceptance:
+  - A maintainer with Codex and no Claude Code can discover and invoke
+    Magpie SKILL.md workflows from .agents/skills.
+  - Language-neutral tools bridges remain reachable through Codex's native
+    sandbox and approval boundary.
+  - Project policy uses workspace-write, network-off, on-request
+    approvals, and tested exec-policy rules.
+  - Adopt, upgrade, verify, and unadopt account for the committed Codex
+    policy.
+  - setup-isolated install, verify, update, and doctor route to explicit
+    Codex steps before any Claude-only procedure.
+---
+
+# Codex first-class skill runtime
+
+## What it does
+
+Makes OpenAI Codex a native Magpie runtime rather than a delegation target.
+Codex reads the same workflow sources as other harnesses, invokes the same
+tool adapters, and uses its own sandbox, rules, and approvals.
+
+## Where it lives
+
+- .agents/skills/ - canonical cross-harness skill symlinks.
+- .codex/config.toml - project sandbox and approval posture.
+- .codex/rules/magpie.rules - allow, prompt, and forbidden command policy.
+- tools/sandbox-lint/ - static Codex profile validator (--codex).
+- tools/agent-isolation/ - clean-env agent-iso codex launcher.
+- docs/adapters/codex.md - operator contract and lifecycle.
+- skills/setup/ and skills/setup-isolated-setup-*/ - installation, drift,
+  verification, and removal paths.
+
+## Behaviour & contract
+
+1. Skills remain SKILL.md files. Codex scans .agents/skills natively and
+   follows the existing symlinks; no conversion into AGENTS.md occurs.
+2. Repository AGENTS.md files remain the instruction hierarchy.
+3. workspace-write is mandatory and workspace network access is disabled.
+4. Approvals are on-request and reviewed by the user, never automatically.
+5. Exec-policy rules allow only scoped read operations, prompt known remote
+   mutations, and forbid credential disclosure commands.
+6. Project trust is a human decision. Setup never edits Codex trust state.
+7. The .codex policy files are committed and reviewed; existing unrelated
+   .codex configuration is preserved during adoption and upgrade.
+
+## Out of scope
+
+- Translating SKILL.md workflows into generated AGENTS.md files.
+- Copying user credentials or user-scoped MCP configuration into a project.
+- Replacing Codex's native approval system with agent-guard decisions. The
+  deterministic agent-guard denials stay reachable through the
+  harness-neutral --check / --exec modes; a native Codex hook adapter is
+  future work.
+- Claiming stable support before a minimum version and adopter pilot exist.
+
+## Acceptance criteria
+
+1. /skills lists magpie-setup and at least one end-to-end workflow.
+2. Explicit $magpie-* invocation loads the canonical SKILL.md.
+3. sandbox-lint --codex .codex passes the repository profile.
+4. Native exec-policy checks classify representative read, mutation, and
+   credential commands as allow, prompt, and forbidden.
+5. setup and setup-isolated documentation covers install, verify, update,
+   doctor, and unadopt for Codex.
+6. The sandbox-lint test suite covers the Codex profile invariants.
+7. Documentation states platform limitations without claiming untested
+   parity.
+
+## Validation
+
+```bash
+uv run --directory tools/sandbox-lint --group dev pytest
+uv run --directory tools/sandbox-lint --group dev sandbox-lint --codex .codex
+
+codex execpolicy check --pretty \
+  --rules .codex/rules/magpie.rules -- gh pr view 313
+codex execpolicy check --pretty \
+  --rules .codex/rules/magpie.rules -- gh pr create --title test --body test
+codex execpolicy check --pretty \
+  --rules .codex/rules/magpie.rules -- gh auth token
+```
+
+## Known gaps
+
+- The adapter remains experimental until the minimum Codex version is pinned
+  and an end-to-end adopter pilot runs all acceptance checks.
+- Codex exec-policy is an evolving interface.
+- The deterministic agent-guard denials are not wired as a native Codex
+  hook adapter.
+- The POSIX clean-environment wrapper needs WSL on Windows.
+- User-scoped MCP registration and tool authentication remain outside
+  repository policy.


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Closes #313: makes OpenAI Codex a first-class Magpie skill runtime instead of a delegation target, per RFC-AI-0004 Principle 3 (vendor neutrality). A maintainer with only Codex installed can now discover and run Magpie skills end to end.
- Ships a committed, reviewed Codex posture: `.codex/config.toml` (workspace-write, network off, on-request approvals) and `.codex/rules/magpie.rules` (scoped read allows, prompted remote mutations, forbidden credential disclosure). `sandbox-lint --codex` validates both statically.
- Skips the SKILL.md-to-AGENTS.md conversion the issue suggested: Codex scans the canonical `.agents/skills` symlinks natively, so SKILL.md stays the single source. The setup and setup-isolated skills route Codex sessions to explicit Codex steps before any Claude-only branch, and new eval fixtures pin that routing.

## Type of change

- [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `prek run --all-files` passes (all hooks green, including `check-placeholders`, `symlink-lint`, workspace ruff/mypy/pytest, `skill-and-tool-validate`, `spec-validate`)
- [x] For Python packages touched: `uv run pytest` (103 passed in `tools/sandbox-lint`, including the new `tests/test_codex.py` invariant cases for tampered configs and rules) / `ruff check` / `mypy` all clean
- [ ] For Groovy bridges touched: not touched
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/e
- [x] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (runtime-routing suites for all four `setup-isolated-setup-*` skills, each with a `cg the Codex branch is taken and no `.claude` file is treated as a failure)
- [ ] Other: end-to-end smoke on a real Codex session (`/skills` discovery, `$magpie-security-issue-triage` invocation, approval prompt on a `gh` mutation)

## RFC-AI-0004 compliance

- [x] **HITL** — any new mutation is gated on explicit user confirmation
      (`approval_policy = "on-request"`; exec-policy rules prompt on `gh pr`/`gh issue` mu
- [x] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
      (`workspace-write` with `network_access = false`; networked bridges cross the native
- [x] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is
- [x] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoke

## Linked issues

Closes #313.

## Notes for reviewers (optional)

- The issue proposed mapping SKILL.md onto Codex's AGENTS.md convention. This PR rejects tee would be a second source that drifts from `.claude/skills`. Codex follows the existing`.agents/skills` symlinks, so nothing is duplicated. If that call looks wrong, the runtime-contract table in `docs/adapters/codex.md` is the place to push back.
- `sandbox-lint` parses `magpie.rules` by splitting on `prefix_rule(` after dropping commeeal Starlark parser. Deliberate trade-off: the invariants only need block-level matching,and a parser dependency felt heavier than the problem. Tampering cases are covered in `tests/test_codex.py`.
- Two known gaps, both documented in the adapter's limitations section: agent-guard denialodex hook yet, and the exec-policy rule format is an evolving Codex interface, so theadapter stays experimental until a minimum Codex version is pinned.
- Project trust stays a human decision. Adoption never edits Codex trust state, and pre-exfiguration survives adopt and upgrade.