### PR TITLE
docs(release): SVN revision in vote email + personal-email vote resolution

### DIFF
--- a/projects/magpie/pmc-roster.md
+++ b/projects/magpie/pmc-roster.md
@@ -28,7 +28,7 @@ Whimsy first. The roster below reflects the founding PMC recorded in
 
 | Apache ID | Name | Primary email | Binding since |
 |---|---|---|---|
-| `potiuk` | Jarek Potiuk (Chair) | `potiuk@apache.org` | `[resolution]` |
+| `potiuk` | Jarek Potiuk (Chair) | `potiuk@apache.org`, `jarek@potiuk.com` | `[resolution]` |
 | `pkarwasz` | Piotr Karwasz | `pkarwasz@apache.org` | `[resolution]` |
 | `eladkal` | Elad Kalif | `eladkal@apache.org` | `[resolution]` |
 | `zeroshade` | Matthew Topol | `zeroshade@apache.org` | `[resolution]` |
@@ -56,7 +56,10 @@ non-binding.**
 
 A `[VOTE]` reply counts as binding when:
 
-1. The `From:` address matches a row's `Primary email` exactly, **or**
+1. The `From:` address matches any address in a row's `Primary email`
+   cell exactly — the cell may list several comma-separated addresses
+   (e.g. an `@apache.org` address plus a personal address the member
+   votes from), **or**
 2. The `From:` address contains `@apache.org` and the local part
    matches a row's `Apache ID` exactly.
 
@@ -78,7 +81,8 @@ Rule (2) is the fallback because PMC members occasionally vote from
 `release-vote-tally`'s resolution algorithm:
 
 1. Normalise the `From:` header to `local@domain` form.
-2. Try exact match against `Primary email` (case-insensitive).
+2. Try exact match (case-insensitive) against each comma-separated
+   address listed in the `Primary email` cell.
 3. If `domain == apache.org`, try the local part against the
    `Apache ID` column.
 4. If neither hits, the vote is classified non-binding, flagged

--- a/skills/release-promote/SKILL.md
+++ b/skills/release-promote/SKILL.md
@@ -242,6 +242,9 @@ Read the following from the planning issue and
 | `target_url` | constructed | render `dist_url_template` with `<bucket>=release` and `<version>=<version>` (strip the `-rcN` suffix) |
 | `result_vote_url` | planning issue body or `--result-vote-url` | Archive URL of the `[RESULT] [VOTE]` thread; used in the `svn commit` message for `release_dist_backend = svnpubsub` |
 | `promote_command_template` | `release-management-config.md` | `release_publish_command_template` (required when `dist_backend = self-hosted`; ignored for the other backends, which have built-in recipes) |
+| `rc_commit_sha` | git / planning issue body | commit the `<version>-rc<N>` tag points to; the final `<version>` tag is cut on this SAME commit (no rebuild). `git rev-list -n1 <version>-rc<N>` |
+| `rm_gpg_fingerprint` | RM `user.md` | `release_manager.gpg_fingerprint`; the release key the final `<version>` tag is signed with |
+| `git_upstream_remote` | `release-management-config.md` | `git_upstream_remote`; the remote the final `<version>` tag is pushed to |
 
 Surface the loaded metadata to the RM for a brief sanity check before
 proceeding to Step 2.
@@ -270,15 +273,26 @@ The command set a PMC member would run:
 Whether or not a hand-off is needed, the svn command block is:
 
 ```text
-# Step 1 of 2 — move RC to release (release_dist_backend=svnpubsub)
+# Step 1 of 3 — move RC to release (release_dist_backend=svnpubsub)
 svn mv \  # release_dist_backend=svnpubsub
   https://dist.apache.org/repos/dist/dev/<project>/<version>-rc<N>/ \  # release_dist_backend=svnpubsub
   https://dist.apache.org/repos/dist/release/<project>/<version>/ \  # release_dist_backend=svnpubsub
   --username <apache_id> \
   -m "Promoting Apache <product-name> <version> (from rc<N>). [RESULT]: <result_vote_url>"
 
-# Step 2 of 2 — verify the move landed (release_dist_backend=svnpubsub)
+# Step 2 of 3 — verify the move landed (release_dist_backend=svnpubsub)
 svn list https://dist.apache.org/repos/dist/release/<project>/<version>/  # release_dist_backend=svnpubsub
+
+# Step 3 of 3 — cut and push the FINAL release tag on the SAME commit the
+# approved RC was built from (no rebuild). Downstream links (changelog,
+# [ANNOUNCE], site) must reference this final <version> tag, never <version>-rc<N>.
+# git signs tags via gpg.format=ssh globally, so override to openpgp to use the
+# RM's release key (<rm_gpg_fingerprint> from the RM user.md; YubiKey inserted).
+git -c gpg.format=openpgp tag -s -u <rm_gpg_fingerprint> \
+  <version> <rc-commit-sha> \
+  -m "Apache <product-name> <version>"
+git push <git_upstream_remote> refs/tags/<version>
+git -c gpg.format=openpgp tag -v <version>   # confirm the release key signed it
 ```
 
 Followed by the mirror-propagation and announce timing note (see *Mirror

--- a/skills/release-vote-draft/SKILL.md
+++ b/skills/release-vote-draft/SKILL.md
@@ -206,6 +206,7 @@ Read the following from the planning issue body and
 | `version` | trigger argument | `<version>` |
 | `rc_number` | trigger argument | `<rcN>` |
 | `staging_url` | planning issue body | URL under `dist/dev/<project>/<version>-<rcN>/` (for `release_dist_backend = svnpubsub`) |
+| `svn_revision` | `svn info <staging_url>` | the committed SVN revision of the staged RC directory (**required** when `release_dist_backend = svnpubsub`; omit for other backends). Read it with `svn info --show-item last-changed-revision <staging_url>` (or `svn log -l1`). SVN branches are mutable, so this pins exactly which artefacts voters reviewed. |
 | `tag_url` | planning issue body | URL to the RC git tag |
 | `keys_url` | `release-management-config.md` | `keys_file_url` |
 | `changelog_url` | planning issue body | URL to changelog |
@@ -247,6 +248,7 @@ I propose we release the following artifacts as <Product Name> <version>.
 
 The release artifacts, signatures, and checksums are available at:
   <staging_url>
+  (SVN revision: r<svn_revision>)  ← include when release_dist_backend = svnpubsub
 
 The release tag to be voted upon:
   <tag_url>


### PR DESCRIPTION
Three follow-ups from the Apache Magpie 0.1.0 release vote thread on dev@:

- **release-vote-draft** — include the staged SVN revision in the `[VOTE]`
  email body (svnpubsub backend). SVN branches are mutable, so the revision
  pins exactly which artefacts each voter reviewed. Raised by Sebb.
- **pmc-roster** — the `Primary email` cell may now list several
  comma-separated addresses, so a PMC member who votes from a personal
  address resolves as binding. Adds `jarek@potiuk.com` to the chair row.
- **release-promote** — emit a final-tag step (Step 3 of 3) that cuts and
  pushes the GPG-signed `<version>` tag on the same commit as the approved
  RC, so changelog / [ANNOUNCE] / site links reference the final tag, not
  `<version>-rcN`. Surfaced by the 0.1.0 release.

Documentation/config changes to the release tooling only; no code paths affected.
