### PR TITLE
chore: bump version to 0.2.0.dev0 after 0.1.0 release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@
 # Package name matches the project's canonical name. Not published to
 # PyPI — this name only frames the framework root as a uv-managed project.
 name = "apache-magpie"
-version = "0.1.0"
+version = "0.2.0.dev0"
 description = "Reusable, governance-agnostic framework of agentic skills for maintaining open-source projects."
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -114,7 +114,7 @@ wheels = [
 
 [[package]]
 name = "apache-magpie"
-version = "0.1.0"
+version = "0.2.0.dev0"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Post-release version bump after Apache Magpie 0.1.0 (Step 14 of the release-management lifecycle). Opens the **0.2.0** development cycle.

## Changes

### Version bump
- `pyproject.toml`: `0.1.0` → `0.2.0.dev0`
- `uv.lock`: `0.1.0` → `0.2.0.dev0` (the lock pins the package's own version; it must match `pyproject.toml` or `uv lock --check` fails CI)

## Note on scope
`version_manifest_files` in `projects/magpie/release-management-config.md` currently lists only `pyproject.toml`, but `uv.lock` must move in lockstep. Suggest adding `uv.lock` to `version_manifest_files` so future post-release bumps pick it up automatically — happy to do that in a follow-up (or here, if preferred).

Opened as a **draft** per the release-prepare convention; ready for maintainer review.

Generated by `release-prepare` (magpie-release-prepare).
