### PR TITLE
docs(education): add AI tutor discoverability to education and training READMEs

### DIFF
--- a/docs/education/README.md
+++ b/docs/education/README.md
@@ -13,6 +13,7 @@
   - [What every page also teaches](#what-every-page-also-teaches)
   - [How this connects to the other guides](#how-this-connects-to-the-other-guides)
   - [About the examples](#about-the-examples)
+  - [Learn with an AI tutor](#learn-with-an-ai-tutor)
   - [Licence](#licence)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -139,6 +140,23 @@ Every example uses placeholders in place of real names: `<PROJECT>`,
 `<tracker>`, `<upstream>`, and `<security-list>` (PRINCIPLE 12). When you use a
 skill, you change your own settings, not the example text. If you ever see a
 real project name written into a skill, that is a bug.
+
+## Learn with an AI tutor
+
+Each lesson in the progression above has a matching AI tutor prompt in
+[`ai-tutors/`](../../ai-tutors/README.md). Load one into any capable chat
+model and it teaches that lesson interactively — walking through the ideas one
+at a time, running the exercises, and checking your answers against the lesson
+keys.
+
+**How to load a tutor:** open the matching `lesson-*.md` file under `ai-tutors/`,
+find the `---` separator, and paste everything below that line as the system
+prompt. The notes above the separator are for you; only the text below goes to
+the model. See [`ai-tutors/README.md`](../../ai-tutors/README.md) for
+tool-by-tool instructions (claude.ai Projects, Open WebUI, API).
+
+The tutors are companions to the readable pages, not replacements for them.
+Every lesson in this progression stands on its own without a model.
 
 ## Licence
 

--- a/docs/education/training/README.md
+++ b/docs/education/training/README.md
@@ -12,6 +12,7 @@
   - [Delivery formats](#delivery-formats)
   - [Prerequisites](#prerequisites)
   - [Placeholders](#placeholders)
+  - [Learn with an AI tutor](#learn-with-an-ai-tutor)
   - [Licence](#licence)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -98,6 +99,22 @@ control. Specific technical prerequisites are stated in each lesson.
 
 Exercises use `<PROJECT>` wherever a real project name would appear.
 Substitute your own project name when working through the activities.
+
+## Learn with an AI tutor
+
+Each lesson in the module map above has a matching AI tutor prompt in
+[`ai-tutors/`](../../../ai-tutors/README.md). Load one into any capable chat
+model and it teaches that lesson interactively — working through the
+objectives, exercises, and self-check questions one step at a time.
+
+**How to load a tutor:** open the matching `lesson-*.md` file under `ai-tutors/`,
+find the `---` separator, and paste everything below that line as the system
+prompt. The notes above the separator are for you; only the content below goes
+to the model. See [`ai-tutors/README.md`](../../../ai-tutors/README.md) for
+tool-by-tool instructions (claude.ai Projects, Open WebUI, API).
+
+These prompts are companions to the lesson wrappers, not a replacement for the
+source pages or in-person instruction.
 
 ## Licence
 


### PR DESCRIPTION
## Summary

Add a "Learn with an AI tutor" section to docs/education/README.md and docs/education/training/README.md, pointing learners to ai-tutors/README.md with brief how-to-load instructions (paste below the --- separator as the system prompt). Confirms ai-tutors/README.md already lists all eleven lessons.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
