### PR TITLE
chore(ai-tutors): regenerate knowledge base for lesson-04-your-first-skill

### DIFF
--- a/ai-tutors/lesson-04-your-first-skill.md
+++ b/ai-tutors/lesson-04-your-first-skill.md
@@ -496,9 +496,15 @@ Apache-2.0 licensed.
 >   patterns that hold the data-not-instructions and sandbox principles in every
 >   skill you write. Covers the injection-flag idiom, the privacy gate, and the
 >   draft-before-post shape.
+> - **Debugging a skill (debugging-skills.md)** — step 6: reading the audit log,
+>   reproducing failures with the eval harness, and isolating prompt vs tool vs
+>   model problems when a skill does not behave as expected.
+> - **Writing portable skills (portable-skills.md)** — step 7: authoring skills
+>   that work for any project and any model, using placeholders and capability
+>   floors so your skill does not break when the project or model changes.
 > - **Eval-driven development (eval-driven-development.md)** — step 8: how to judge
 >   output that can vary, with worked examples from real Magpie skills. Your skill
->   is not finished until it has an eval suite, so read step 5 first and then this.
+>   is not finished until it has an eval suite, so read steps 5–7 first and then this.
 > - **Agentic and autonomous work (agentic-work.md)** — step 9: once a skill is
 >   written, tested, and safe, this is how you let it run without watching every step.
 >


### PR DESCRIPTION
## Summary

Step-6 (debugging-skills) and step-7 (portable-skills) were added to the learning progression after this tutor was authored; the injector now adds them to the "Where to go next" section and renumbers the eval-driven- development reference from step-5 to steps-5–7.

Generated-by: Claude (claude-sonnet-4-6)

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [X ] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
