### PR TITLE
docs(skills/issue-deduplicate): fix mislabeled reference links

### DIFF
--- a/skills/issue-deduplicate/SKILL.md
+++ b/skills/issue-deduplicate/SKILL.md
@@ -397,7 +397,7 @@ links — never bare `#NNN`.
 
 ## References
 
-- [`docs/triage/spec.md`](../../tools/spec-loop/specs/triage-mode.md) —
+- [`tools/spec-loop/specs/triage-mode.md`](../../tools/spec-loop/specs/triage-mode.md) —
   the Known Gap this skill closes.
 - `security-issue-deduplicate` —
   the private-tracker counterpart for security reports.
@@ -405,7 +405,7 @@ links — never bare `#NNN`.
   deduplicating when a stale issue is also a likely duplicate.
 - `issue-triage` — may surface DUPLICATE candidates that feed this
   skill.
-- [`<project-config>/issue-tracker-config.md`](../../projects/_template/) —
+- [`<project-config>/issue-tracker-config.md`](../../projects/_template/issue-tracker-config.md) —
   `url` and `project_key` that this skill reads.
 - [GitHub CLI `gh issue` reference](https://cli.github.com/manual/gh_issue) —
   the commands this skill emits.


### PR DESCRIPTION
## Summary
- Fixed the label on the `spec.md` reference link — it named `docs/triage/spec.md`, a path that never existed, while correctly pointing at `tools/spec-loop/specs/triage-mode.md`.
- Fixed the `<project-config>/issue-tracker-config.md` reference link — it pointed at the `projects/_template/` directory instead of the file it names, now linked directly.

## Test plan
- Manually verified both link targets resolve on disk relative to `skills/issue-deduplicate/SKILL.md`.
- `git diff` reviewed — change is scoped to the two mislabeled lines, no other content touched.

Fixes #947