### PR TITLE
fix(pr-management-stats): remove unused local variable in test_ready_split.py

### DIFF
--- a/tools/pr-management-stats/tests/test_ready_split.py
+++ b/tools/pr-management-stats/tests/test_ready_split.py
@@ -148,7 +148,6 @@ def test_render_ready_split_oldest_on_left_and_cards():
 
 
 def test_render_ready_split_empty_state():
-    ctx = make_ctx()
     out = dashboard.render_ready_split(
         {"counts": dict.fromkeys(
             ["never-reviewed", "discussed-no-decision", "changes-requested", "approved"], 0),


### PR DESCRIPTION
Fixes #957

Removed the unused local variable `ctx` in `test_render_ready_split_empty_state` inside `tools/pr-management-stats/tests/test_ready_split.py` as `render_ready_split` takes the dict payload directly without needing context.