### PR TITLE
fix(skill-evals): remove Tier-B exclusivity qualifier from stage-2 fixture

### DIFF
--- a/tools/skill-evals/evals/pr-management-quick-merge/stage-2-triviality/fixtures/system-prompt.md
+++ b/tools/skill-evals/evals/pr-management-quick-merge/stage-2-triviality/fixtures/system-prompt.md
@@ -53,7 +53,7 @@ Assign the tier **only** when `disposition == "candidate"`:
 
 - **Tier A** — every changed file matches a Tier A allow glob.
 - **Tier B** — every changed file matches a Tier A **or** Tier B glob,
-  and at least one file matches a Tier B glob only.
+  and at least one file matches a Tier B glob.
 
 ## Output format
 


### PR DESCRIPTION
Fixes #950

Removed the redundant "only" qualifier from the Tier B definition in `tools/skill-evals/evals/pr-management-quick-merge/stage-2-triviality/fixtures/system-prompt.md` to match `candidate-rules.md`.