### PR TITLE
build(deps-dev): re-lock uv.lock against the mypy>=2.3.0 dev pins

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -495,7 +495,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -945,7 +945,7 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mcp", specifier = ">=1.28.1" },
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1359,7 +1359,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1570,7 +1570,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1612,7 +1612,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1633,7 +1633,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1843,7 +1843,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]


### PR DESCRIPTION
## Summary

- Re-locks `uv.lock` so the `[package.metadata.requires-dev]` blocks match what the manifests already declare. Eight workspace members were bumped to `mypy>=2.3.0` in their `pyproject.toml` but the lock still recorded `>=2.1.0` for them: `checker`, `generate-cve-json`, `oauth-draft`, `redactor`, `sandbox-lint`, `skill-and-tool-validator`, `skill-evals`, `vulnogram-api`.
- No dependency resolution changes and no manifest edits. `mypy` itself is already pinned at `2.3.0` in the resolved set; this only corrects the recorded specifiers, which are derived from `pyproject.toml`.
- Why it matters: the `prek` hooks invoke `uv run --project <tool>` without `--frozen` or `--locked`, so every hook run re-locks and writes this pending correction into whichever branch happens to be checked out. Contributors keep picking up eight lines of unrelated `uv.lock` churn in feature PRs, which then reads as scope creep in review. Landing the correction on its own clears it for everyone.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [X] Other: dependancy update

## Test plan

- [X] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:
