### PR TITLE
fix(workflow-security-audit): use full 40-char SHA in pin example

### DIFF
--- a/skills/workflow-security-audit/SKILL.md
+++ b/skills/workflow-security-audit/SKILL.md
@@ -235,7 +235,7 @@ changing the tag.
 floating reference.
 
 **Suggested remediation:** pin to the full commit SHA of the version
-you trust — e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af68`
+you trust — e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683`
 — and add a comment with the semantic version for readability.
 
 ### Fork-secret exposure (`fork-secrets`)

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -495,7 +495,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -945,7 +945,7 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mcp", specifier = ">=1.28.1" },
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1359,7 +1359,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1570,7 +1570,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1612,7 +1612,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1633,7 +1633,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1843,7 +1843,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]


### PR DESCRIPTION
## Summary

- Fix the unpinned-actions remediation example in
  `skills/workflow-security-audit/SKILL.md`: the shown commit was 39
  hex characters and does not parse as a git SHA.
- Restore the missing final digit so the example is the real
  `actions/checkout` v4.2.2 commit
  (`11bd71901bbe5b1630ceea73d27597364c9af683`).

## Type of change

- [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Other: `uv.lock` metadata refresh from the vendor-neutrality hook
      when the skill file was staged (mypy specifier sync)

## Test plan

- [x] Example SHA is exactly 40 hex characters
- [x] SHA resolves on `actions/checkout` (`Prepare 4.2.2 Release (#1953)`)
- [x] `rg` confirms no eval fixture asserted on the old 39-char value
- [x] `uv run --project tools/skill-and-tool-validator skill-and-tool-validate` passes
- [x] `prek` commit hooks pass on the changed files

## Linked issues

Closes apache/magpie#952