### PR TITLE
fix(release-promote): grade svn mv -m, not a separate svn commit

### DIFF
--- a/skills/release-promote/SKILL.md
+++ b/skills/release-promote/SKILL.md
@@ -175,7 +175,7 @@ non-blocking.
 |---|---|
 | `<version>-rc<N>` (positional) | Version string and RC number of the release candidate to promote |
 | `--planning-issue <url>` | Explicit planning issue URL (auto-detected from `<upstream>` if omitted) |
-| `--result-vote-url <url>` | Archive URL of the `[RESULT] [VOTE]` thread (used in `svn commit` message for `release_dist_backend = svnpubsub`; auto-read from planning issue if present) |
+| `--result-vote-url <url>` | Archive URL of the `[RESULT] [VOTE]` thread (used in the `svn mv -m` message for `release_dist_backend = svnpubsub`; auto-read from planning issue if present) |
 | `--non-asf` | Signal that this is a non-ASF adopter; skips PMC membership check and ASF-specific policy notes |
 
 ---
@@ -240,7 +240,7 @@ Read the following from the planning issue and
 | `dist_url_template` | `release-management-config.md` | `release_dist_url_template` |
 | `staging_url` | planning issue body | URL under `dist/dev/<project>/<version>-rcN/` (for `release_dist_backend = svnpubsub`, or backend-equivalent staging location) |
 | `target_url` | constructed | render `dist_url_template` with `<bucket>=release` and `<version>=<version>` (strip the `-rcN` suffix) |
-| `result_vote_url` | planning issue body or `--result-vote-url` | Archive URL of the `[RESULT] [VOTE]` thread; used in the `svn commit` message for `release_dist_backend = svnpubsub` |
+| `result_vote_url` | planning issue body or `--result-vote-url` | Archive URL of the `[RESULT] [VOTE]` thread; used in the `svn mv -m` message for `release_dist_backend = svnpubsub` |
 | `promote_command_template` | `release-management-config.md` | `release_publish_command_template` (required when `dist_backend = self-hosted`; ignored for the other backends, which have built-in recipes) |
 | `rc_commit_sha` | git / planning issue body | commit the `<version>-rc<N>` tag points to; the final `<version>` tag is cut on this SAME commit (no rebuild). `git rev-list -n1 <version>-rc<N>` |
 | `rm_gpg_fingerprint` | RM `user.md` | `release_manager.gpg_fingerprint`; the release key the final `<version>` tag is signed with |

--- a/tools/skill-evals/evals/release-promote/step-2-emit-commands/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/release-promote/step-2-emit-commands/fixtures/output-spec.md
@@ -24,7 +24,7 @@ Grading rules:
   for `svnpubsub`, or the backend-appropriate release location.
 - `command_block` must contain the correct backend-shaped promotion command.
 - For `svnpubsub`: must contain `svn mv` with the correct source and target
-  URLs, and that `svn mv`'s `-m` referencing the `[RESULT] [VOTE]` URL.
+  URLs, and that `svn mv`'s `-m` references the `[RESULT] [VOTE]` URL.
 - For `github-releases`: must contain `gh release edit` with `--draft=false`.
 - For `s3`: must contain `aws s3 mv --recursive` with the correct prefixes.
 - `handoff_note` must be non-null (and non-empty) when `rm_is_pmc = false`.

--- a/tools/skill-evals/evals/release-promote/step-2-emit-commands/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/release-promote/step-2-emit-commands/fixtures/output-spec.md
@@ -24,7 +24,7 @@ Grading rules:
   for `svnpubsub`, or the backend-appropriate release location.
 - `command_block` must contain the correct backend-shaped promotion command.
 - For `svnpubsub`: must contain `svn mv` with the correct source and target
-  URLs, and `svn commit -m` referencing the `[RESULT] [VOTE]` URL.
+  URLs, and that `svn mv`'s `-m` referencing the `[RESULT] [VOTE]` URL.
 - For `github-releases`: must contain `gh release edit` with `--draft=false`.
 - For `s3`: must contain `aws s3 mv --recursive` with the correct prefixes.
 - `handoff_note` must be non-null (and non-empty) when `rm_is_pmc = false`.

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -495,7 +495,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -945,7 +945,7 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mcp", specifier = ">=1.28.1" },
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1359,7 +1359,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1570,7 +1570,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1612,7 +1612,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1633,7 +1633,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1843,7 +1843,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]


### PR DESCRIPTION
## Summary

- Fix the `release-promote` step-2 eval grading rule so `svnpubsub` requires
  `svn mv` with inline `-m` referencing the `[RESULT] [VOTE]` URL, not a
  separate `svn commit -m` that the skill never emits and SVN does not need
  for URL-to-URL moves.
- Retarget two `release-promote` SKILL.md lines from "svn commit message" to
  "svn mv -m message" so the prose matches the paste-ready command block.

## Type of change

- [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Other: `uv.lock` metadata refresh from the vendor-neutrality hook when
      the skill file was staged (mypy specifier sync)

## Test plan

- [x] `PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/release-promote/` loads all 8 cases; step-2 system prompt shows the corrected svnpubsub grading rule
- [x] Case-1 (svnpubsub) assertion checks pass against skill-shaped output (`svn mv` + `-m` with RESULT URL; no separate `svn commit`)
- [x] `prek` commit hooks pass on changed files
- [x] Commit is GPG-signed and DCO-signed (`Signed-off-by`)

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders used in all skill / tool prose
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes apache/magpie#939