### PR TITLE
fix(skill-and-tool-validator): harden three non-blocking review leftovers

### DIFF
--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -2469,8 +2469,8 @@ _LICENSE_PY_MARKERS: tuple[str, ...] = (
     "apache.org/licenses/LICENSE-2.0",
 )
 
-# Files smaller than this threshold (bytes / characters) are treated as
-# empty placeholder stubs and exempted from the license-header check.
+# Files smaller than this threshold (bytes) are treated as empty
+# placeholder stubs and exempted from the license-header check.
 _MIN_LICENSE_FILE_SIZE = 50
 
 # Path components that mark generated or vendored subtrees that must not
@@ -2485,7 +2485,7 @@ def collect_tool_python_files(root: Path | None = None) -> list[Path]:
 
     Excludes generated / vendored subtrees (``.venv``, ``site-packages``,
     ``node_modules``, ``__pycache__``) and empty placeholder files whose
-    content is shorter than ``_MIN_LICENSE_FILE_SIZE`` characters.
+    content is shorter than ``_MIN_LICENSE_FILE_SIZE`` bytes.
     """
     base = (root or find_repo_root()) / TOOLS_DIR
     if not base.exists():
@@ -3297,8 +3297,18 @@ def validate_eval_coverage(root: Path | None = None) -> Iterable[Violation]:
         return
     eval_slugs: set[str] = set()
     if evals_base.exists():
-        eval_slugs = {p.name for p in evals_base.iterdir() if p.is_dir()}
-    for skill_dir in sorted(skills_base.iterdir()):
+        try:
+            eval_slugs = {p.name for p in evals_base.iterdir() if p.is_dir()}
+        except OSError:
+            # Restrictive runners can deny listing; skip rather than crash
+            # (same posture as collect_tool_python_files on OSError).
+            return
+    try:
+        skill_dirs = sorted(skills_base.iterdir())
+    except OSError:
+        # Same posture as collect_tool_python_files: unreadable → skip.
+        return
+    for skill_dir in skill_dirs:
         if not skill_dir.is_dir():
             continue
         # A trusted-external-skill-source pointer dir carries its eval suite

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -20,6 +20,7 @@
 from __future__ import annotations
 
 import subprocess
+from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
@@ -1595,6 +1596,21 @@ _ASF_HEADER = (
 _SPDX_PY_HEADER = "# SPDX-License-Identifier: Apache-2.0\n"
 
 
+def _live_repo_root_for_header_check() -> Path | None:
+    """Return the magpie repo root when the live license-header check can run.
+
+    ``find_repo_root`` never raises — out-of-tree it returns CWD — so the
+    live integration must additionally confirm this checkout actually
+    contains the validator package under ``tools/``. Returns ``None`` when
+    that marker is absent so callers can ``skipif`` instead of aborting.
+    """
+    root = find_repo_root()
+    marker = root / "tools" / "skill-and-tool-validator" / "src" / "skill_and_tool_validator"
+    if marker.is_dir():
+        return root
+    return None
+
+
 class TestValidateLicenseHeader:
     # ------------------------------------------------------------------ #
     # Python (.py) checks                                                 #
@@ -1683,11 +1699,23 @@ class TestValidateLicenseHeader:
     # Integration: real repo passes                                       #
     # ------------------------------------------------------------------ #
 
+    def test_live_repo_header_check_skips_out_of_tree(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Out-of-tree cwd must make the live header-check skipif fire (not error)."""
+        monkeypatch.chdir(tmp_path)
+        assert _live_repo_root_for_header_check() is None
+
+    @pytest.mark.skipif(
+        _live_repo_root_for_header_check() is None,
+        reason="not running inside a magpie repo checkout with tools/",
+    )
     def test_real_repo_tool_python_files_all_have_headers(self) -> None:
         """Every non-trivial tool Python file in the real repo carries a license header."""
         from skill_and_tool_validator import _LICENSE_PY_MARKERS
 
-        repo_root = find_repo_root()
+        repo_root = _live_repo_root_for_header_check()
+        assert repo_root is not None  # skipif above guarantees this
         missing = [
             p
             for p in collect_tool_python_files(repo_root)
@@ -3634,6 +3662,42 @@ class TestValidateEvalCoverage:
         (skills_dir / "README.md").write_text("# skills\n")
         violations = list(validate_eval_coverage(tmp_path))
         assert violations == []
+
+    def test_unreadable_skills_dir_returns_no_violations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PermissionError on skills/.iterdir() must not abort the run."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir(parents=True)
+        self._make_skill(tmp_path, "alpha")
+
+        real_iterdir = Path.iterdir
+
+        def _boom(self: Path) -> Iterator[Path]:
+            if self.resolve() == skills_dir.resolve():
+                raise PermissionError("denied")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", _boom)
+        assert list(validate_eval_coverage(tmp_path)) == []
+
+    def test_unreadable_evals_dir_returns_no_violations(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """PermissionError on evals/.iterdir() must not abort or false-flag skills."""
+        self._make_skill(tmp_path, "alpha")
+        evals_dir = tmp_path / "tools" / "skill-evals" / "evals"
+        evals_dir.mkdir(parents=True)
+
+        real_iterdir = Path.iterdir
+
+        def _boom(self: Path) -> Iterator[Path]:
+            if self.resolve() == evals_dir.resolve():
+                raise PermissionError("denied")
+            return real_iterdir(self)
+
+        monkeypatch.setattr(Path, "iterdir", _boom)
+        assert list(validate_eval_coverage(tmp_path)) == []
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -495,7 +495,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -945,7 +945,7 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mcp", specifier = ">=1.28.1" },
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1359,7 +1359,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1570,7 +1570,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1612,7 +1612,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1633,7 +1633,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1843,7 +1843,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]


### PR DESCRIPTION
## Summary

- Fix the `collect_tool_python_files` docstring (and size-threshold comment) so it says **bytes**, matching `path.stat().st_size`.
- Guard the live license-header integration with a `skipif` when the checkout is not a full magpie tree; add a unit test that proves the skip condition fires out-of-tree.
- Catch `OSError` from `validate_eval_coverage`'s `iterdir()` calls (skills/ and evals/) the same way `collect_tool_python_files` does, so a restrictive runner gets a quiet skip instead of an unhandled `PermissionError`.
- Re-lock root `uv.lock` `mypy` `requires-dev` specifiers to `>=2.3.0` so `prek` stops rewriting the lock when this tool is touched (same correction as #965 — drop that hunk if #965 lands first).

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [x] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `uv run --directory tools/skill-and-tool-validator --group dev pytest` — all passed
- [x] Targeted: live-header skip proving test, live-header integration, unreadable skills/evals `PermissionError` cases
- [x] `prek` commit hooks pass on changed files (`ruff` / `mypy` / workspace `pytest` / `skill-and-tool-validate`)
- [x] Commit is GPG-signed and DCO-signed (`Signed-off-by`)
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [x] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders used in skill / tool prose (N/A for this robustness fix)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes apache/magpie#941