### PR TITLE
fix(release-verify-rc): use placeholders in step-6 artefact example

### DIFF
--- a/skills/release-verify-rc/SKILL.md
+++ b/skills/release-verify-rc/SKILL.md
@@ -450,8 +450,8 @@ classification below (matching files become `expected_binaries`, the
 rest `prohibited_found`), not by filtering the command.
 
 `<unpacked-dir>` is the source artefact filename with its archive
-extension removed: `apache-airflow-2.11.0-source-release.tar.gz` unpacks
-to `apache-airflow-2.11.0-source-release`. Do not drop the
+extension removed: `<artefact-source-release>.tar.gz` unpacks
+to `<artefact-source-release>`. Do not drop the
 `-source-release` suffix or substitute a shortened name. Resolve
 `<unpacked-dir>` to this concrete directory before emitting the recipe.
 


### PR DESCRIPTION
## Summary

- Replace the concrete `apache-airflow-2.11.0-source-release` worked example in
  `release-verify-rc` step 6 with the skill's existing `<artefact-source-release>`
  placeholder so the extension-stripping lesson stays project-agnostic.
- Keeps the taught behaviour: strip the archive extension (`.tar.gz` / `.zip`),
  do not drop the `-source-release` suffix.

## Type of change

- [x] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `uv run --project tools/skill-and-tool-validator skill-and-tool-validate` passes
- [x] `tools/dev/check-placeholders.sh` passes
- [x] `prek run --files skills/release-verify-rc/SKILL.md` passes (includes
      `check-placeholders` + `skill-and-tool-validate`)
- [x] Confirmed no remaining concrete artefact name in the step-6 example
- [ ] For skill *behaviour* changes: n/a — prose-only placeholder example swap;
      eval fixtures intentionally keep concrete names under the allowlisted
      `tools/skill-evals/evals/` path

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders used in all skill / tool prose
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes apache/magpie#945