### PR TITLE
docs(spec-loop): mark branch-name confidentiality check as shipped

### DIFF
--- a/tools/spec-loop/specs/privacy-llm-gate.md
+++ b/tools/spec-loop/specs/privacy-llm-gate.md
@@ -90,7 +90,12 @@ uv run --project tools/privacy-llm --group dev pytest
 
 - `stable`; gaps surface as new PII patterns or new public-emission
   surfaces not yet covered by the scrub — caught as drift by the plan pass.
-- **Branch-name confidentiality validation is missing.** Security-fix
-  workflows already require neutral branch names, but no deterministic
-  check scans skill/docs examples for CVE IDs or embargoed terms in
-  generated branch names.
+- **Branch-name confidentiality validation is shipped** as a SOFT
+  advisory in `tools/skill-and-tool-validator`
+  (`validate_branch_name_confidentiality`, category
+  `branch-name-confidentiality`). It scans `git checkout -b` and
+  `git switch -c` / `--create` examples in fenced code blocks under
+  `skills/` and `docs/`, and flags concrete branch names that contain a
+  CVE ID (`CVE-YYYY-NNNNN`), `security`, `vulnerability` / `vuln`, or
+  `advisory`. Placeholder names and explicit bad-example lines are
+  exempt. Advisory only unless `--strict`.


### PR DESCRIPTION
## Summary

- Rewrite the stale `Known gaps` bullet in `tools/spec-loop/specs/privacy-llm-gate.md`: branch-name confidentiality validation is no longer missing.
- Document the shipped SOFT check `validate_branch_name_confidentiality` in `tools/skill-and-tool-validator` — scans `git checkout -b` / `git switch -c` examples in fenced code blocks under `skills/` and `docs/`, flags CVE IDs, `security`, `vulnerability`/`vuln`, and `advisory`, advisory unless `--strict`.
- Keeps the plan beat from selecting already-finished work from a closed gap.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other: `tools/spec-loop/specs/` sync (spec Known gaps)

## Test plan

- [x] `uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/` — OK
- [x] `prek run --files tools/spec-loop/specs/privacy-llm-gate.md` — passes
- [x] Confirmed call sites at `skill_and_tool_validator/__init__.py` (skills pass + docs pass) before rewriting the bullet
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders used in skill / tool prose (N/A — prose-only spec sync)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [x] **Privacy LLM** — documents the existing branch-name confidentiality scrub; no new private-content routing

## Linked issues

Closes #933

## Notes for reviewers (optional)

Verified by call site, not definition alone: `validate_branch_name_confidentiality` is invoked from `run_validation` over skill `.md` files and again over `collect_doc_files()` (`docs/` + `projects/_template/`). Category `branch-name-confidentiality` is in `SOFT_CATEGORIES`.