### PR TITLE
docs(education): fix first-skill capability examples

### DIFF
--- a/docs/education/your-first-skill.md
+++ b/docs/education/your-first-skill.md
@@ -30,7 +30,7 @@ You do not need any earlier experience with the framework.
 
 This is not the full authoring reference. Once you know the shape of a skill,
 the [`magpie-write-skill`](../../skills/write-skill/SKILL.md)
-skill (you run it with `/write-skill`) takes you through every check, safety
+skill (you run it with `/magpie-write-skill`) takes you through every check, safety
 step, and packaging detail. Come back to it after your first skill has landed
 and you want the complete checklist.
 
@@ -172,8 +172,8 @@ license: Apache-2.0
 
 The `capability:` tag places this skill in the framework's set of categories.
 Look at the existing skills for the tag that fits best. Common values:
-`capability:triage`, `capability:authoring`, `capability:security`,
-`capability:release`, `capability:contributor-growth`.
+`capability:triage`, `capability:authoring`, `capability:review`,
+`capability:fix`, `capability:intake`.
 
 ---
 
@@ -397,7 +397,7 @@ Supporting references for skill-writing:
 
 - **[magpie-write-skill](../../skills/write-skill/SKILL.md)** —
   the full authoring reference, with the security checklist and packaging
-  details. Run it with `/write-skill` once you are ready for the complete
+  details. Run it with `/magpie-write-skill` once you are ready for the complete
   walk-through.
 - **[Pattern catalogue](pattern-catalogue.md)** — ready-to-copy skill, prompt,
   and tool-use patterns.


### PR DESCRIPTION
## Summary
Corrects invalid beginner-guide capability examples and the command used to launch the skill-authoring guide.

## Changes
- replaces three undefined `capability:*` examples with documented capability labels;
- changes both `/write-skill` references to `/magpie-write-skill`.

## Related issue
Closes #974

## Validation
- `git diff --check` — passed
- verified each of the five displayed capability labels is listed in `docs/labels-and-capabilities.md`
- verified both command references use `/magpie-write-skill`
- `uvx --from 'prek>=0.4.9' prek run --all-files` — could not complete locally because the available `uv 0.11.6` is below this repository's declared minimum `>=0.11.8`; the failure occurred in project tooling, before the uv-backed validation hooks could run.

## Notes
This small documentation patch was drafted with AI assistance and reviewed by its submitter. It changes only the file named in the issue.
