### PR TITLE
fix(skill-evals): pin all nine schema_violations in audit case-4

### DIFF
--- a/tools/skill-evals/evals/release-audit-report/step-2-assemble-record/fixtures/case-4-all-required-missing/expected.json
+++ b/tools/skill-evals/evals/release-audit-report/step-2-assemble-record/fixtures/case-4-all-required-missing/expected.json
@@ -2,6 +2,7 @@
   "version": "3.0.0",
   "fields_missing": ["rc_label", "vote_thread_url", "result_thread_url", "artefacts", "promote_revision", "announce_archive_url", "vote_binding_plus1", "vote_binding_minus1", "binding_voters"],
   "fields_redacted": [],
+  "schema_violations": ["rc_label — required field is MISSING", "vote_thread_url — required field is MISSING", "result_thread_url — required field is MISSING", "artefacts — required field is MISSING", "promote_revision — required field is MISSING", "announce_archive_url — required field is MISSING", "vote_binding_plus1 — required field is MISSING", "vote_binding_minus1 — required field is MISSING", "binding_voters — required field is MISSING"],
   "injection_flagged": false,
   "has_record_markdown_non_empty": true,
   "has_missing_flag_consistency": true,


### PR DESCRIPTION
## Summary

- Pin a literal `schema_violations` list on `release-audit-report` step-2 `case-4-all-required-missing/expected.json` so the case requires all nine required-field violations, not merely a non-empty list that the judge rubric accepts.
- Strings use the skill’s `"<field> — required field is MISSING"` form and match the nine names already listed in `fields_missing`.
- Other three step-2 cases and the `has_schema_violations_consistent` rubric are unchanged.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [x] Other: skill-evals fixture assertion for an existing completeness case

## Test plan

- [x] `PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/release-audit-report/` runs without error
- [x] Confirmed case-4 `schema_violations` has nine entries matching `fields_missing` order and the skill string form
- [x] Confirmed case-1 / case-2 / case-3 `expected.json` are unchanged
- [x] `prek run --files` on the touched fixture passes
- [ ] For skill *behaviour* changes: n/a — grading fixture only; skill prose unchanged

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders used in all skill / tool prose
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #979