### PR TITLE
test(skill-and-tool-validator): assert org-structure check via run_validation

### DIFF
--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -3086,6 +3086,18 @@ class TestOrganizationStructure:
     def test_organization_category_is_hard(self) -> None:
         assert ORGANIZATION_CATEGORY in HARD_CATEGORIES
 
+    def test_missing_file_reached_via_run_validation(self, tmp_path: Path) -> None:
+        """Guard the single wiring line in run_validation.
+
+        Direct unit tests call validate_organization_structure themselves, so
+        they stay green if that call is deleted from run_validation. This test
+        goes through the entry point so the check cannot be silently unwired.
+        """
+        self._make_org(tmp_path, "MyOrg", ["organization.md"])  # missing README.md
+        vs = [v for v in run_validation(tmp_path) if v.category == ORGANIZATION_CATEGORY]
+        assert len(vs) == 1
+        assert "README.md" in vs[0].message
+
 
 # ---------------------------------------------------------------------------
 # Non-ASF organization profile smoke coverage


### PR DESCRIPTION
## Summary

- Add one `TestOrganizationStructure` case that builds an org missing `README.md` under `tmp_path` and asserts the violation via `run_validation(tmp_path)`, filtered by `ORGANIZATION_CATEGORY`.
- Direct unit tests call `validate_organization_structure` themselves, so deleting its single wiring line in `run_validation` left the suite green; this routes through the entry point so the check cannot be silently unwired.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `uv run --project tools/skill-and-tool-validator pytest tools/skill-and-tool-validator/tests/` — 452 passed
- [x] Confirmed `test_missing_file_reached_via_run_validation` fails when `violations.extend(validate_organization_structure(repo_root))` is removed from `run_validation`, then restored
- [x] `prek run --files tools/skill-and-tool-validator/tests/test_validator.py` passes
- [ ] For skill *behaviour* changes: n/a — test-only wiring guard

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders used in all skill / tool prose
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #977