### PR TITLE
test(cve-tool-vulnogram): assert CVE_JSON_CONFIG miss does not fall back

### DIFF
--- a/tools/cve-tool-vulnogram/generate-cve-json/tests/test_config_resolution.py
+++ b/tools/cve-tool-vulnogram/generate-cve-json/tests/test_config_resolution.py
@@ -71,3 +71,12 @@ def test_explicit_config_path_does_not_fall_back_to_legacy(tmp_path):
     _write(tmp_path, _LEGACY_REL, "Legacy")
     with pytest.raises(FileNotFoundError):
         _load_config(tmp_path / "explicit-but-missing.toml")
+
+
+def test_env_config_path_does_not_fall_back_to_legacy(tmp_path, monkeypatch):
+    # Same guarantee as --config: $CVE_JSON_CONFIG naming a missing path must
+    # raise, even when the legacy pre-rename config is present on disk.
+    _write(tmp_path, _LEGACY_REL, "Legacy")
+    monkeypatch.setenv("CVE_JSON_CONFIG", str(tmp_path / "missing.toml"))
+    with pytest.raises(FileNotFoundError):
+        _load_config()


### PR DESCRIPTION
## Summary

- Add a regression test that `$CVE_JSON_CONFIG` pointing at a missing file raises `FileNotFoundError` even when the legacy pre-rename config path is present on disk.
- Mirrors the existing `--config` coverage so a later refactor cannot silently widen the legacy fallback to the env-var arm.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `uv run --directory tools/cve-tool-vulnogram/generate-cve-json --group dev pytest` — all passed
- [x] `uv run --directory tools/cve-tool-vulnogram/generate-cve-json --group dev ruff check src tests`
- [x] `uv run --directory tools/cve-tool-vulnogram/generate-cve-json --group dev ruff format --check src tests`
- [x] `uv run --directory tools/cve-tool-vulnogram/generate-cve-json --group dev mypy`
- [x] Negative check: temporarily loosened `_load_config` fallback from `is_default and legacy.is_file()` to `legacy.is_file()` → new test failed with `DID NOT RAISE FileNotFoundError`; condition restored
- [x] `prek` commit hooks passed on the changed file
- [x] Commit is GPG-signed and DCO-signed (`Signed-off-by`)
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [x] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — placeholders used in skill / tool prose (N/A for this test-only change)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #976

## Notes for reviewers (optional)

Production behaviour is unchanged — `_resolve_config_path` already returns `is_default=False` for `$CVE_JSON_CONFIG`, so `_load_config` already raises. This PR only closes the missing env-var arm of the regression suite.