### PR TITLE
Fix/skill evals quote helper paths

### DIFF
--- a/tools/skill-evals/tests/test_runner.py
+++ b/tools/skill-evals/tests/test_runner.py
@@ -54,10 +54,10 @@ from skill_evals.runner import (
 )
 
 _TESTS_DIR = Path(__file__).resolve().parent
-_GRADER_YES = f"python3 {_TESTS_DIR / '_grader_yes.py'}"
-_GRADER_NO = f"python3 {_TESTS_DIR / '_grader_no.py'}"
-_JUDGE_YES = f"python3 {_TESTS_DIR / '_judge_yes.py'}"
-_JUDGE_NO = f"python3 {_TESTS_DIR / '_judge_no.py'}"
+_GRADER_YES = f"python3 {shlex.quote(str(_TESTS_DIR / '_grader_yes.py'))}"
+_GRADER_NO = f"python3 {shlex.quote(str(_TESTS_DIR / '_grader_no.py'))}"
+_JUDGE_YES = f"python3 {shlex.quote(str(_TESTS_DIR / '_judge_yes.py'))}"
+_JUDGE_NO = f"python3 {shlex.quote(str(_TESTS_DIR / '_judge_no.py'))}"
 
 
 def _grader_count_cli(counter_path: Path) -> str:

--- a/uv.lock
+++ b/uv.lock
@@ -369,7 +369,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -495,7 +495,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -945,7 +945,7 @@ provides-extras = ["mcp"]
 [package.metadata.requires-dev]
 dev = [
     { name = "mcp", specifier = ">=1.28.1" },
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1359,7 +1359,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1570,7 +1570,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1612,7 +1612,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1633,7 +1633,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]
@@ -1843,7 +1843,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=2.1.0" },
+    { name = "mypy", specifier = ">=2.3.0" },
     { name = "pytest", specifier = ">=9.1.1" },
     { name = "ruff", specifier = ">=0.15.21" },
 ]


### PR DESCRIPTION
## Summary

- Quote the `skill-evals` test helper script paths so grader and judge commands work when the checkout path contains spaces.
- Refresh the workspace lockfile so required hooks do not rewrite it during validation.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [x] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [ ] `prek run --all-files` passes
- [x] Workspace `ruff check`, `ruff format`, `mypy`, and `pytest` hooks pass
- [x] `uv run --directory tools/skill-evals pytest tests/test_runner.py -k 'batch_grade_grader_says_no or compare_with_grader_passes_when_decision_fields_match_and_prose_judged_match or compare_with_grader_handles_nested_list_of_dicts or cli_grader_mode_passes_on_wording_difference or batch_judge_yes'` — 5 passed
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
- [ ] Other:

## RFC-AI-0004 compliance

Not applicable: this change only corrects local Python test command construction and refreshes dependency-lock metadata.

## Linked issues

Closes #991 

## Notes for reviewers (optional)

`run_cli` intentionally uses `shlex.split()` with `shell=False`; quoting the fixture script paths preserves that safety property while allowing paths containing spaces.