### PR TITLE
docs(education): Correct the <project-config> and <tracker> placehold…

### DIFF
--- a/docs/education/pattern-catalogue.md
+++ b/docs/education/pattern-catalogue.md
@@ -212,9 +212,9 @@ and where its value comes from.
 
 ```markdown
 <!-- Placeholder convention (see AGENTS.md#placeholder-convention):
-     <project-config>   → adopter's project-config directory
-                          (typically `.apache-magpie/` in the adopter repo)
-     <tracker>          → URL of the project's security / issue tracker
+     <project-config>   → adopter's project-config directory (sits alongside
+                          the gitignored framework snapshot, not inside it)
+     <tracker>          → project's security tracker repository (owner/name)
                           (resolves from <project-config>/project.md)
      <upstream>         → adopter's public source repository (owner/name)
      <default-branch>   → upstream's default branch (main / master)


### PR DESCRIPTION
## Summary

- Replace the `<project-config>` description in Pattern 4 of `docs/education/pattern-catalogue.md` ("typically `.apache-magpie/` in the adopter repo") with the `AGENTS.md` definition: the config directory sits *alongside* the gitignored snapshot, not inside it. `.apache-magpie/` is a different placeholder (`<framework>`), and it is the one directory `AGENTS.md` says agents never modify.
- Replace the `<tracker>` description ("URL of the project's security / issue tracker") with the `owner/name` slug form `AGENTS.md` defines; the URL form is a separate placeholder, `<issue-tracker>`.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] Confirmed both rewritten rows match the `AGENTS.md` table under *Placeholder convention used in skill files* (`<project-config>`, `<tracker>`)
- [x] Confirmed the literal string `.apache-magpie/` no longer appears anywhere in the Pattern 4 block
- [x] Confirmed the diff is 3 lines and preserves the block's layout — 5-space indent, `→` at column 25, continuation lines at 26
- [x] `prek run --all-files` passes — run on Linux with `--skip workspace-pytest`, matching this repo's own prek CI job, where pytest runs separately as the `tests.yml` matrix
- [ ] For skill *behaviour* changes: n/a — docs-only

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** — the page corrected here teaches the placeholder convention itself; no new skill / tool prose is added, so `check-placeholders` (which globs `skills/` and `tools/`, not `docs/`) does not gate it
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #973
