### PR TITLE
docs(spec-loop): drop resolved org-adapter validator gap

### DIFF
--- a/tools/spec-loop/specs/organization-adapters.md
+++ b/tools/spec-loop/specs/organization-adapters.md
@@ -116,15 +116,18 @@ Manual resolution check: a `project.md` with `organization: ASF` and a
 key omitted resolves to the ASF adapter value; `organization: independent`
 resolves to the baseline.
 
+Adapter layout is enforced: `validate_organization_structure` in
+`tools/skill-and-tool-validator` requires every `organizations/<org>/`
+directory except `_template` to contain `README.md` and `organization.md`.
+Omitting either results in a HARD violation, so an incomplete adapter fails
+the validator before any skill can resolve against it.
+
 ## Known gaps
 
 - The reflow of `projects/_template/` + `projects/non-asf-example/` to
   set `organization:` and drop the now-inherited values is not yet done
   (tracked as the next change); until then the ASF defaults exist in both
   `projects/_template/project.md` and `organizations/ASF/`.
-- No structural validator check yet enforces required files in
-  `organizations/<org>/` (currently README + organization.md by
-  convention).
 - The family-level `organization:` scope (replacing `asf: true/false`)
   and the external-adapter discovery index are separate follow-ups.
 - **Smoke coverage is narrow.** The non-ASF profile smoke currently proves


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- Remove the Known Gap in `tools/spec-loop/specs/organization-adapters.md`
  claiming no validator enforces required files in `organizations/<org>/`.
  `validate_organization_structure` has enforced this since #721, so the
  gap is now inconsistent with the code.
- Describe the shipped check in the Validation section, explaining
  `validate_organization_structure` and its HARD violation behaviour.

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ x] Other: spec-loop spec (`tools/spec-loop/specs/`)

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [ ] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [x] Other: 
    - `prek run --files tools/spec-loop/specs/organization-adapters.md`
        passes
    - Confirm described behavior matches `validate_organization_structure` function defined in `tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py`
    - Confirmed the other Known Gap bullets were unmodified
    - `prek run --all-files` does not complete on my Windows environment
        for reasons unrelated to this change (check Notes)

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #975

## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->

This is a documentation-only change to reflect the update to validation implemented in #721. However, I was unable to run `prek run --all-files` to completion on Windows. However, the failures are environmental and the `prek` tests should pass on the maintainer's end.