### PR TITLE
fix(specs): remove stale reviewer-routing modes-table gap from two specs

### DIFF
--- a/tools/spec-loop/specs/issue-management-family.md
+++ b/tools/spec-loop/specs/issue-management-family.md
@@ -206,7 +206,7 @@ uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-valid
   fixes exceed the skill's scope and must be handed back to a human-led
   workflow. This boundary is intentional, not a tooling gap, but adopters
   should be aware of it.
-- **`reviewer-routing` row missing from `docs/modes.md` Triage table.**
-  `issue-backlog-stats` and `issue-deduplicate` now appear in the Agentic
-  Triage table; however, `reviewer-routing` (mode: Triage) still lacks a
-  row — tracked as a separate work item (`modes-doc-reviewer-routing-row`).
+- **`reviewer-routing` row is present in `docs/modes.md` Triage table.**
+  The row was added in #701. The Privacy-LLM gate preflight that
+  `reviewer-routing.md` was waiting on landed separately in #731. The
+  `modes-doc-reviewer-routing-row` work item is resolved.

--- a/tools/spec-loop/specs/reviewer-routing.md
+++ b/tools/spec-loop/specs/reviewer-routing.md
@@ -125,8 +125,6 @@ uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/reviewer-r
 - **`experimental` — no adopter pilot has run.** The skill ships but no
   end-to-end routing workflow has been exercised in a live maintainer
   session; signal weights and roster-match heuristics may change.
-- **Temporarily absent from `docs/modes.md` Triage table.** The skill is
-  under active development (Privacy-LLM gate preflight being added to
-  Step 0); it was removed from the Triage table pending that work landing.
-  The skill itself remains at `mode: Triage` and `experimental`; it will
-  re-enter the modes table once the preflight addition is complete.
+- **Row present in `docs/modes.md` Triage table.** The row was added in
+  #701; the Privacy-LLM gate preflight (Step 0) landed separately in #731.
+  The skill remains at `mode: Triage` and `experimental`.


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

Both `issue-management-family.md` and `reviewer-routing.md` claimed the `reviewer-routing` row was missing from `docs/modes.md` Triage table. The row is already present, and the Privacy-LLM gate preflight it was waiting on landed in #731. This PR rewrites both bullets to reflect the current state.

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [x] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [x] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #937  

## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->