### PR TITLE
fix(ai-tutors): handle nested code fences

### DIFF
--- a/ai-tutors/inject-knowledge-base.py
+++ b/ai-tutors/inject-knowledge-base.py
@@ -59,6 +59,7 @@ DOCTOC_RE = re.compile(
     re.DOTALL,
 )
 SPDX_RE = re.compile(r"<!-- SPDX-License-Identifier:.*?-->\n*", re.DOTALL)
+CODE_FENCE_RE = re.compile(r"^(?P<indent>\s*)(?P<fence>`{3,})(?P<info>[^`]*)$")
 
 
 @dataclass(frozen=True)
@@ -128,24 +129,22 @@ def tag_bare_code_fences(text: str, default_lang: str = "text") -> str:
     that already name a language are left untouched.
     """
     lines = text.split("\n")
-    in_code = False
-    fence_len = 0  # backticks in the opening fence of the current block
+    open_fence_length: int | None = None
     for i, line in enumerate(lines):
-        stripped = line.strip()
-        if not stripped.startswith("```"):
+        match = CODE_FENCE_RE.match(line)
+        if not match:
             continue
-        backticks = len(stripped) - len(stripped.lstrip("`"))
-        if not in_code:
-            in_code = True
-            fence_len = backticks
-            if stripped == "```":  # opening fence with no language
-                indent = line[: len(line) - len(line.lstrip())]
-                lines[i] = f"{indent}```{default_lang}"
-        elif backticks >= fence_len:
-            # a closing fence must be at least as long as the opening fence
-            in_code = False
-            fence_len = 0
-        # a shorter backtick run inside the block is literal content; leave as-is
+
+        fence = match.group("fence")
+        info = match.group("info").strip()
+        fence_length = len(fence)
+
+        if open_fence_length is None:
+            open_fence_length = fence_length
+            if not info:  # opening fence with no language
+                lines[i] = f"{match.group('indent')}{fence}{default_lang}"
+        elif not info and fence_length >= open_fence_length:
+            open_fence_length = None
     return "\n".join(lines)
 
 

--- a/ai-tutors/lesson-04-your-first-skill.md
+++ b/ai-tutors/lesson-04-your-first-skill.md
@@ -145,7 +145,7 @@ Apache-2.0 licensed.
 >
 > This is not the full authoring reference. Once you know the shape of a skill,
 > the `magpie-write-skill` (../../skills/write-skill/SKILL.md)
-> skill (you run it with `/write-skill`) takes you through every check, safety
+> skill (you run it with `/magpie-write-skill`) takes you through every check, safety
 > step, and packaging detail. Come back to it after your first skill has landed
 > and you want the complete checklist.
 >
@@ -287,8 +287,8 @@ Apache-2.0 licensed.
 >
 > The `capability:` tag places this skill in the framework's set of categories.
 > Look at the existing skills for the tag that fits best. Common values:
-> `capability:triage`, `capability:authoring`, `capability:security`,
-> `capability:release`, `capability:contributor-growth`.
+> `capability:triage`, `capability:authoring`, `capability:review`,
+> `capability:fix`, `capability:intake`.
 >
 > ---
 >
@@ -496,9 +496,15 @@ Apache-2.0 licensed.
 >   patterns that hold the data-not-instructions and sandbox principles in every
 >   skill you write. Covers the injection-flag idiom, the privacy gate, and the
 >   draft-before-post shape.
+> - **Debugging a skill (debugging-skills.md)** — step 6: reading the audit log,
+>   reproducing failures with the eval harness, and isolating prompt vs tool vs
+>   model problems when a skill does not behave as expected.
+> - **Writing portable skills (portable-skills.md)** — step 7: authoring skills
+>   that work for any project and any model, using placeholders and capability
+>   floors so your skill does not break when the project or model changes.
 > - **Eval-driven development (eval-driven-development.md)** — step 8: how to judge
 >   output that can vary, with worked examples from real Magpie skills. Your skill
->   is not finished until it has an eval suite, so read step 5 first and then this.
+>   is not finished until it has an eval suite, so read steps 5–7 first and then this.
 > - **Agentic and autonomous work (agentic-work.md)** — step 9: once a skill is
 >   written, tested, and safe, this is how you let it run without watching every step.
 >
@@ -506,7 +512,7 @@ Apache-2.0 licensed.
 >
 > - **magpie-write-skill (../../skills/write-skill/SKILL.md)** —
 >   the full authoring reference, with the security checklist and packaging
->   details. Run it with `/write-skill` once you are ready for the complete
+>   details. Run it with `/magpie-write-skill` once you are ready for the complete
 >   walk-through.
 > - **Pattern catalogue (pattern-catalogue.md)** — ready-to-copy skill, prompt,
 >   and tool-use patterns.

--- a/ai-tutors/test_inject_knowledge_base.py
+++ b/ai-tutors/test_inject_knowledge_base.py
@@ -76,9 +76,26 @@ def test_nested_four_backtick_block_does_not_invert_state():
 
 
 def test_shorter_fence_inside_block_is_literal():
-    # a 3-backtick line inside a 4-backtick block is content, not a close
+    # a 3-backtick line inside a 4-backtick block is content, not a close.
+    # The bare 4-backtick opening fence still names no language, so MD040
+    # applies to it too and it gets tagged — at its own fence length.
     out = tag_bare_code_fences("````\n```\n````")
-    assert out == "````\n```\n````"
+    assert out == "````text\n```\n````"
+
+
+def test_bare_longer_opening_fence_is_tagged_at_its_own_length():
+    # Regression: tagging must preserve the opening fence's length rather than
+    # rewriting it to three backticks, which would break the block.
+    out = tag_bare_code_fences("`````\ncontent\n`````")
+    assert out == "`````text\ncontent\n`````"
+
+
+def test_info_string_line_does_not_close_a_block():
+    # CommonMark: a closing fence carries no info string. Treating "```python"
+    # as a close made the *real* closing fence look like an opening one and get
+    # tagged, corrupting the document.
+    out = tag_bare_code_fences("```\na\n```python\nb\n```")
+    assert out == "```text\na\n```python\nb\n```"
 
 
 def test_longer_closing_fence_closes_shorter_block():
@@ -88,3 +105,45 @@ def test_longer_closing_fence_closes_shorter_block():
     assert lines[0] == "```text", "opening bare fence tagged"
     assert lines[2] == "````", "longer fence closes the block"
     assert lines[3] == "```text", "trailing bare fence tagged after close"
+
+
+def test_tag_bare_code_fences_handles_nested_longer_fence():
+    # End-to-end case from #1010: a 4-backtick block that names a language keeps
+    # its inner bare triple fence literal, a later indented bare fence is still
+    # tagged, and an already-tagged fence is untouched.
+    text = """before
+````markdown
+outer block keeps its language
+```
+inner bare triple fence stays literal
+```
+````
+
+  ```
+  later indented bare fence gets tagged
+  ```
+
+```python
+print("already tagged")
+```
+after"""
+
+    assert (
+        tag_bare_code_fences(text)
+        == """before
+````markdown
+outer block keeps its language
+```
+inner bare triple fence stays literal
+```
+````
+
+  ```text
+  later indented bare fence gets tagged
+  ```
+
+```python
+print("already tagged")
+```
+after"""
+    )


### PR DESCRIPTION
## Summary

- Fix `tag_bare_code_fences` to track the length of the currently open backtick fence.
- Leave shorter nested fences inside longer fenced blocks untouched while still tagging later top-level bare fences.
- Add a regression test for the nested four-backtick/triple-backtick case and refresh the generated tutor prompt so `--check` passes.

Closes #1008.

## Validation

- `uv run pytest ai-tutors/test_inject_knowledge_base.py`
- `python3 ai-tutors/inject-knowledge-base.py --check`
- `uv run ruff check ai-tutors/inject-knowledge-base.py ai-tutors/test_inject_knowledge_base.py`
- `uv run ruff format --check ai-tutors/inject-knowledge-base.py ai-tutors/test_inject_knowledge_base.py`
- `uv run prek run --all-files`

## Generative AI Disclosure

This PR was prepared with AI assistance.

Generated-by: Codex (GPT-5)
