### PR TITLE
test(validator): add negative controls for independent organizations

### DIFF
--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -3211,6 +3211,48 @@ class TestOrganizationNonASFSmoke:
         vs = list(validate_organization_structure(tmp_path))
         assert vs == []
 
+    def test_unknown_org_is_rejected(self, tmp_path: Path) -> None:
+        """An organization value without a matching profile must fail validation."""
+        self._make_org(tmp_path, "independent")
+        text = (
+            "---\n"
+            "name: magpie-unknown-org\n"
+            "description: d\n"
+            "license: Apache-2.0\n"
+            "capability: capability:platform\n"
+            "organization: missing-org\n"
+            "---\n\n"
+            "## Workflow\n\n"
+            "Use the adopter's configured backend.\n"
+        )
+        path = tmp_path / "SKILL.md"
+        violations = [
+            v for v in validate_frontmatter(path, text, root=tmp_path) if v.category == ORGANIZATION_CATEGORY
+        ]
+
+        assert len(violations) == 1
+        assert "missing-org" in violations[0].message
+
+    def test_independent_org_rejects_asf_coupled_operation(self, tmp_path: Path) -> None:
+        """Independent profiles must flag unguarded ASF-only operations."""
+        self._make_org(tmp_path, "independent")
+        text = (
+            "---\n"
+            "name: magpie-independent-release\n"
+            "description: d\n"
+            "license: Apache-2.0\n"
+            "capability: capability:resolve\n"
+            "organization: independent\n"
+            "---\n\n"
+            "## Workflow\n\n"
+            "Run `svn checkout` before publishing the release artifact.\n"
+        )
+        path = tmp_path / "SKILL.md"
+        violations = list(validate_asf_coupling(path, text))
+
+        assert len(violations) == 1
+        assert "svn command" in violations[0].message
+
 
 # ---------------------------------------------------------------------------
 # Capability sync check: docs/labels-and-capabilities.md ↔ live source


### PR DESCRIPTION
## Summary

- add an invalid-organization negative control to the non-ASF organization smoke suite
- add an ASF-coupling negative control that requires the unguarded `svn checkout` operation to be reported
- keep the existing positive smoke cases unchanged

These cases ensure the validator cannot pass vacuously when organization validation or ASF-coupling detection is accidentally unwired.

## Validation

- `PYTHONPATH=tools/skill-and-tool-validator/src python -m pytest tools/skill-and-tool-validator/tests/test_validator.py -q -k TestOrganizationNonASFSmoke` — 6 passed
- `git diff --check` — passed
- The full validator test file was also run; its pre-existing Windows path/encoding assumptions produce unrelated failures outside this change. The focused class remains green.

Fixes #1009

Generated-by: Codex