### PR TITLE
docs: align MISSION cross-reference with project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ files are reproduced in [`NOTICE`](NOTICE).
 
 ## Cross-references
 
-- [`MISSION.md`](MISSION.md) — **draft** project-establishment proposal: motivation, scope, design commitments, initial PMC composition target.
+- [`MISSION.md`](MISSION.md) — founding mission and historical establishment proposal: motivation, scope, design commitments, initial PMC composition target.
 - [`docs/setup/agentic-overrides.md`](docs/setup/agentic-overrides.md) — the contract between adopters who write overrides and framework skills that read them.
 - [`docs/prerequisites.md`](docs/prerequisites.md) — what a maintainer needs installed before invoking any framework skill (Claude Code, Gmail MCP, GitHub auth, browser, `uv`, etc.).
 - [`docs/source-release-contents.md`](docs/source-release-contents.md) — what ships in the signed `apache-magpie-<version>-source.zip` (and what is excluded), with the rationale for the repository-root metadata/config files it keeps.


### PR DESCRIPTION
## Summary

Update the `MISSION.md` cross-reference in `README.md` so it matches the project's established Top-Level Project status and the historical-record banner in `MISSION.md`.

## Validation

- `git diff --check` — passed

Fixes #1006

Generated-by: Codex