### PR TITLE
docs: clarify agent runtime update policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,8 +428,10 @@ with default-permissive access to `~/`, env vars, and arbitrary network
 egress is a real exfiltration risk. See
 [`docs/setup/secure-agent-setup.md`](docs/setup/secure-agent-setup.md)
 for the layered defence the framework dogfoods (sandbox + tool
-permissions + clean-env wrapper, system tools pinned with a 7-day
-upstream cooldown).
+permissions + clean-env wrapper). The low-level sandbox primitives are
+pinned with a 7-day upstream cooldown, while the `claude-code` agent runtime
+is deliberately unpinned and tracks `@latest` behind its configured
+`min_version` floor so security fixes arrive without a cooldown.
 
 **Tool credentials live under `$HOME`, never in the project tree.** Any
 persistent token, API key, OAuth refresh token, or session cookie a


### PR DESCRIPTION
## Summary

- correct `AGENTS.md`'s supply-chain summary to distinguish the two update policies
- keep the 7-day cooldown for pinned sandbox primitives (`bubblewrap`, `socat`)
- document that the `claude-code` runtime intentionally tracks `@latest` behind its `min_version` floor

## Validation

- `git diff --check`
- `prek run --all-files` *(not run: `prek` is unavailable in this Windows checkout)*

Closes #1002

Generated-by: Codex