### PR TITLE
fix: correct README description of MISSION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ files are reproduced in [`NOTICE`](NOTICE).
 
 ## Cross-references
 
-- [`MISSION.md`](MISSION.md) — **draft** project-establishment proposal: motivation, scope, design commitments, initial PMC composition target.
+- [`MISSION.md`](MISSION.md) — founding mission of the established TLP: motivation, scope, design commitments, initial PMC composition target.
 - [`docs/setup/agentic-overrides.md`](docs/setup/agentic-overrides.md) — the contract between adopters who write overrides and framework skills that read them.
 - [`docs/prerequisites.md`](docs/prerequisites.md) — what a maintainer needs installed before invoking any framework skill (Claude Code, Gmail MCP, GitHub auth, browser, `uv`, etc.).
 - [`docs/source-release-contents.md`](docs/source-release-contents.md) — what ships in the signed `apache-magpie-<version>-source.zip` (and what is excluded), with the rationale for the repository-root metadata/config files it keeps.


### PR DESCRIPTION
## Summary\n\nThis PR resolves #1006 by fixing the inconsistent description of MISSION.md in the README.\n\n## Changes\n\n- Changed 'draft project-establishment proposal' to 'founding mission of the established TLP'\n- Now consistent with line 48 and the status banner in MISSION.md\n\n## Verification\n\n- [x] Cross-references entry no longer calls MISSION.md a draft\n- [x] Consistent with line 48 and MISSION.md status banner