### PR TITLE
test(gfi-sweep): add multi-skip presentation case

### DIFF
--- a/tools/skill-evals/evals/good-first-issue-sweep/README.md
+++ b/tools/skill-evals/evals/good-first-issue-sweep/README.md
@@ -12,7 +12,7 @@ skill.
 | Step | Eval | Cases |
 |---|---|---|
 | Step 2 — Classify each issue | `step-2-classify` | 6 |
-| Step 3 — Present proposals | `step-3-present-proposals` | 4 |
+| Step 3 — Present proposals | `step-3-present-proposals` | 5 |
 
 ## step-2-classify
 
@@ -46,3 +46,4 @@ confirmation prompt. This is verified via `near_miss_has_label_proposal: false`.
 | `case-2-mixed` | 2 READY + 2 NEAR-MISS + 1 SKIP: correct grouping; SKIP shown as count only; no label for NEAR-MISS |
 | `case-3-near-miss-only` | 3 NEAR-MISS issues, 0 READY: no label proposed, no confirmation prompt |
 | `case-4-injection-flagged` | 1 READY + 1 NEAR-MISS (injection_flagged): injection noted in output; NEAR-MISS still gets no label |
+| `case-5-many-skips` | 1 READY + 5 SKIP issues: grouped skip counts remain summary-only across security, architecture, and deprecation reasons |

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-many-skips/expected.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-many-skips/expected.json
@@ -1,0 +1,10 @@
+{
+  "ready_count": 1,
+  "near_miss_count": 0,
+  "skip_count_shown_as_summary_only": true,
+  "has_label_confirmation_prompt": true,
+  "near_miss_has_label_proposal": false,
+  "all_issue_refs_clickable": true,
+  "ready_label_named": true,
+  "injection_flagged_noted": false
+}

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-many-skips/report.md
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-many-skips/report.md
@@ -1,0 +1,61 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Project config:
+  upstream: apache/acme
+  good_first_issue_label: "good first issue"
+
+Step 2 classification results (6 issues):
+
+```json
+[
+  {
+    "issue_number": 42,
+    "title": "Add --no-color flag to the report command",
+    "classification": "READY",
+    "failing_criteria": [],
+    "skip_reason": null,
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 301,
+    "title": "Rotate credentials after the token disclosure",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "security-sensitive",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 302,
+    "title": "Decide whether the auth flow should use passkeys",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "architectural-decision",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 303,
+    "title": "Remove the deprecated v1 export endpoint",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "deprecation-decision",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 304,
+    "title": "Audit the sandbox for a possible privilege escalation",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "security-sensitive",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 305,
+    "title": "Replace the queue with an event-sourced workflow",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "architectural-decision",
+    "injection_flagged": false
+  }
+]
+```


### PR DESCRIPTION
## Summary

- add a Step 3 fixture with one READY issue and five SKIP issues
- exercise summary-only SKIP presentation across security, architecture, and deprecation reasons
- update the suite README's case count and coverage table

## Validation

- `PYTHONPATH=tools/skill-evals/src python -m skill_evals.runner tools/skill-evals/evals/good-first-issue-sweep/`
- `git diff --check`
- `prek run --all-files` *(not run: `prek` is unavailable in this Windows checkout)*

Closes #1001

Generated-by: Codex