### PR TITLE
docs(spec-loop): align reviewer-routing coverage claim

### DIFF
--- a/tools/spec-loop/specs/reviewer-routing.md
+++ b/tools/spec-loop/specs/reviewer-routing.md
@@ -120,8 +120,9 @@ uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/reviewer-r
 - **Non-ASF roster shape is now exercised.** `projects/non-asf-example/reviewer-roster.md`
   provides a Velox Stream roster with no ASF-specific fields; the
   `non-asf-profile-smoke/step-reviewer-routing/` eval suite asserts that
-  area-match routing and load-aware fallback both work under the
-  `organization: independent` profile. Gap cleared.
+  area-match routing and the no-area-match empty eligible set both work
+  under the `organization: independent` profile. The suite does not cover
+  load-aware fallback; that remains an implementation-defined gap above.
 - **`experimental` — no adopter pilot has run.** The skill ships but no
   end-to-end routing workflow has been exercised in a live maintainer
   session; signal weights and roster-match heuristics may change.


### PR DESCRIPTION
## Summary

- align the reviewer-routing spec with the non-ASF smoke fixtures
- document the area-match and no-area-match assertions actually covered
- leave load-aware fallback explicitly identified as an uncovered implementation-defined gap

## Validation

- `git diff --check`
- confirmed only `tools/spec-loop/specs/reviewer-routing.md` changed
- `prek run --all-files` *(not run: `prek` is unavailable in this Windows checkout)*

Closes #999

Generated-by: Codex