### PR TITLE
fix(skills): remove hardcoded ASF security address

### DIFF
--- a/skills/security-cve-allocate/SKILL.md
+++ b/skills/security-cve-allocate/SKILL.md
@@ -462,13 +462,12 @@ that point the original triager (or the authorised member) can
 re-invoke this skill with the CVE ID as an override argument to
 resume from Step 4.
 
-**Fallback when no governance-authorised member is reachable:**
-if every authorised member is unavailable or unresponsive, send
-an email to `security@apache.org` with subject
-`CVE request for <one-line description>`. The ASF Security Team
-will allocate the CVE and send the ID back. Re-invoke this skill
-with the returned `CVE-YYYY-NNNNN` as an override to resume from
-Step 4.
+**ASF-specific fallback:** For ASF projects, consult the adapter's
+[PMC-gated allocation guidance](../../tools/cve-tool-vulnogram/allocation.md#pmc-gated-access)
+when every governance-authorised member is unavailable or unresponsive.
+The adapter owns the ASF contact and fallback procedure; the generic skill
+must not prescribe a project-specific security address. Re-invoke this skill
+with the returned `CVE-YYYY-NNNNN` as an override to resume from Step 4.
 
 **Wait for the user** to report back a `CVE-\d{4}-\d+` token. Do
 not proceed to Step 4 until that token has arrived. If the user

--- a/skills/security-issue-sync/github-advisory.md
+++ b/skills/security-issue-sync/github-advisory.md
@@ -126,7 +126,8 @@ path.
 ### Delivery — an email relay (draft, never auto-sent)
 
 Create a **draft** email to the org's advisory-admin security team
-(`<security-team-list>`; for ASF, `security@apache.org`) with
+(`<security-team-list>`; ASF adopters resolve the foundation contact from
+`<asf-security-list>`) with
 `oauth-draft-create` — never send directly (SKILL Golden rule 1; and the
 Gmail MCP mangles the `security/advisories/GHSA-…` URLs into redirects, so
 use oauth-draft). **Always CC the project `<security-list>`** so the


### PR DESCRIPTION
## Summary

- remove the hardcoded `security@apache.org` fallback from the generic CVE-allocation skill
- route ASF-specific fallback guidance through the Vulnogram adapter documentation
- replace a second stale literal found by the acceptance grep with the `<asf-security-list>` placeholder

## Validation

- `rg security@apache.org skills` returns no matches
- `git diff --check`
- adapter file remains unchanged
- `prek run --all-files` *(not run: `prek` is unavailable in this Windows checkout)*

Closes #998

Generated-by: Codex