### PR TITLE
docs(skill-evals): enable CLI grading in audit READMEs

### DIFF
--- a/tools/skill-evals/evals/license-compliance-audit/README.md
+++ b/tools/skill-evals/evals/license-compliance-audit/README.md
@@ -16,13 +16,16 @@ Behavioral evals for the `license-compliance-audit` skill.
 
 ```bash
 # All cases
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/license-compliance-audit/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/license-compliance-audit/
 
 # Single suite
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/license-compliance-audit/step-scope-selection/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/license-compliance-audit/step-scope-selection/
 
 # Single case
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-1-explicit-repo/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-1-explicit-repo/
 ```
 
 ## What the suites cover

--- a/tools/skill-evals/evals/workflow-security-audit/README.md
+++ b/tools/skill-evals/evals/workflow-security-audit/README.md
@@ -16,14 +16,15 @@ Behavioral evals for the `workflow-security-audit` skill.
 
 ```bash
 # All cases
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/workflow-security-audit/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/workflow-security-audit/
 
 # Single suite
-uv run --project tools/skill-evals skill-eval \
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
     tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/
 
 # Single case
-uv run --project tools/skill-evals skill-eval \
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
     tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-1-explicit-repo
 ```
 


### PR DESCRIPTION
## Summary

- add the model CLI flag to all documented workflow-security-audit run commands
- add the same grading flag to all license-compliance-audit run commands
- align both READMEs with sibling suites so runs grade instead of silently returning MANUAL

## Validation

- both READMEs contain the CLI flag on all three invocation forms
- git diff --check
- uv unavailable in this Windows checkout, so no model-backed suite run was possible
- prek run --all-files not run: prek unavailable in this Windows checkout

Closes #943

Generated-by: Codex