### PR TITLE
docs(adapters): document current Kiro harness wiring

### DIFF
--- a/docs/adapters/add-a-harness.md
+++ b/docs/adapters/add-a-harness.md
@@ -152,6 +152,7 @@ case "${SPEC_LOOP_HARNESS:-$(basename "$AGENT")}" in
     *cursor*)     HARNESS=cursor ;;
     *gemini*)     HARNESS=gemini ;;
     *opencode*)   HARNESS=opencode ;;
+    *kiro*)       HARNESS=kiro ;;
     *<runtime>*)  HARNESS=<runtime> ;;    # add your case here
     *)            HARNESS=claude ;;
 esac
@@ -208,11 +209,11 @@ README. When your new runtime uses one of these tools, update its line:
 
 | Tool | Current harness declaration |
 |---|---|
-| `tools/agent-guard` | `**Harness:** Claude Code, OpenCode` |
+| `tools/agent-guard` | `**Harness:** Claude Code, OpenCode, Kiro` |
 | `tools/agent-isolation` | `**Harness:** agnostic` |
-| `tools/permission-audit` | `**Harness:** Claude Code, OpenCode` |
-| `tools/sandbox-lint` | `**Harness:** Claude Code, OpenCode` |
-| `tools/spec-loop` | `**Harness:** Claude Code, Codex, Cursor, Gemini CLI, OpenCode` |
+| `tools/permission-audit` | `**Harness:** agnostic` |
+| `tools/sandbox-lint` | `**Harness:** Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Kiro` |
+| `tools/spec-loop` | `**Harness:** Claude Code, Codex, Cursor, Gemini CLI, OpenCode, Kiro` |
 
 `tools/agent-isolation` already exposes a harness-agnostic `agent-iso <cli>` entry
 point — no update needed for new runtimes (see


### PR DESCRIPTION
## Summary
- add Kiro to the spec-loop harness-detection example
- refresh the harness declaration table to match the shipped agent-guard, permission-audit, sandbox-lint, and spec-loop READMEs
- keep the add-a-harness recipe aligned with the current Kiro integration

## Validation
- static checks confirmed the Kiro case and all four current harness declarations
- `git diff --check`
- `bash -n` was attempted for the referenced shell scripts but the Windows checkout's existing CRLF line endings prevent Bash parsing; no shell files are changed here

Closes #886

Generated-by: Codex