### PR TITLE
docs(setup): remove obsolete organization override layer

### DIFF
--- a/docs/setup/personal-use-unadopted-repo.md
+++ b/docs/setup/personal-use-unadopted-repo.md
@@ -240,8 +240,9 @@ install will shadow your `~/.claude/skills/magpie-*` links for that repo.
 Your `.apache-magpie-local/` files continue to work: the project adoption
 adds the `.gitignore` entry automatically (idempotent — the line is
 already there if you added it in Step 2), and the override lookup chain
-(`personal-local → committed → organization → framework default`) honours
-them as the highest-precedence layer.
+(`personal-local → committed → framework default`) honours
+them as the highest-precedence layer. The lookup has only two override
+surfaces: the personal-local file and the committed project file.
 
 You can delete the personal directory once the project is adopted and any
 overrides you care about have been upstreamed into


### PR DESCRIPTION
## Summary
- remove the non-existent organization layer from the personal-use override lookup chain
- describe the two actual override surfaces and their precedence

## Validation
- confirmed the document no longer references an organization override layer
- `git diff --check`

Closes #883

Generated-by: Codex