### PR TITLE
docs(skills): fix truncated SHA in workflow-security-audit example

### DIFF
--- a/skills/workflow-security-audit/SKILL.md
+++ b/skills/workflow-security-audit/SKILL.md
@@ -235,7 +235,7 @@ changing the tag.
 floating reference.
 
 **Suggested remediation:** pin to the full commit SHA of the version
-you trust — e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af68`
+you trust — e.g. `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` (v4.2.2)
 — and add a comment with the semantic version for readability.
 
 ### Fork-secret exposure (`fork-secrets`)


### PR DESCRIPTION
## Summary

- Fix the truncated SHA in the unpinned-actions remediation example in `skills/workflow-security-audit/SKILL.md` (line 238). It pinned `actions/checkout` to a 39-character value; a git SHA-1 is 40 hex characters, so the example in the rule that teaches SHA-pinning did not itself parse as a SHA.

Fixes #952

## Test plan

- The corrected value `11bd71901bbe5b1630ceea73d27597364c9af683` is exactly 40 hex characters and is the **real** `actions/checkout` v4.2.2 commit (verified via `GET repos/actions/checkout/git/refs/tags/v4.2.2` → the same SHA; the old example was this SHA missing its final `3`).
- `grep -rn '364c9af68'` across the repo shows the only occurrence was this one line — no eval fixture or workflow references the old value, so nothing else needs updating (acceptance criteria #3).
- Annotated the example with `(v4.2.2)`, which also demonstrates the semantic-version comment the same sentence recommends.
