### PR TITLE
docs: reflect shipped release audit schema

### DIFF
--- a/tools/spec-loop/specs/release-management-lifecycle.md
+++ b/tools/spec-loop/specs/release-management-lifecycle.md
@@ -179,7 +179,7 @@ uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/release-an
   cut a full release through the family yet, so the RM/binding-voter
   evidence window that would justify default-on or a state-changing lane
   has no data behind it.
-- **Release audit record schema is prose-only.** The audit-report skill
-  exists, but there is no structured schema/template that downstream
-  review can validate. The plan tracks a schema and eval fixtures for
-  incomplete records.
+- **Release audit record schema has shipped.** The canonical structured
+  schema lives at `skills/release-audit-report/audit-record-schema.md`.
+  The `tools/skill-evals/evals/release-audit-report/` suite validates
+  incomplete records, including the `case-4-all-required-missing` fixture.


### PR DESCRIPTION
## Summary

- Replace the stale claim that the release audit record schema is prose-only.
- Point the spec loop at the shipped canonical schema and the incomplete-record eval fixture so it does not plan already-completed work.

## Type of change

- [x] Other: spec documentation

## Test plan

- [x] `uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/`
- [x] Applicable `prek` hooks for `tools/spec-loop/specs/release-management-lifecycle.md` (including markdownlint, typos, lychee, placeholder checks, and spec validation)
- [ ] `prek run --all-files` — Windows path separators and materialized symlinks trigger unrelated repository-wide archive/workspace checks; the checks applicable to this one-file change pass.

## RFC-AI-0004 compliance

No runtime behaviour or state-changing workflow is changed.

## Linked issues

Closes #936

## Generative AI disclosure

This change was prepared with Codex (GPT-5). The commit records this with a `Generated-by:` trailer and does not use an AI `Co-Authored-By:` trailer.