### PR TITLE
docs: clear stale reviewer routing gaps

### DIFF
--- a/tools/spec-loop/specs/issue-management-family.md
+++ b/tools/spec-loop/specs/issue-management-family.md
@@ -206,7 +206,7 @@ uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-valid
   fixes exceed the skill's scope and must be handed back to a human-led
   workflow. This boundary is intentional, not a tooling gap, but adopters
   should be aware of it.
-- **`reviewer-routing` row missing from `docs/modes.md` Triage table.**
-  `issue-backlog-stats` and `issue-deduplicate` now appear in the Agentic
-  Triage table; however, `reviewer-routing` (mode: Triage) still lacks a
-  row — tracked as a separate work item (`modes-doc-reviewer-routing-row`).
+- **`reviewer-routing` is listed in the `docs/modes.md` Triage table.**
+  The row describes its roster-based suggestions and confirmation boundary;
+  the Privacy-LLM gate is enforced by Step 0 before issue or PR content is
+  processed. The former missing-row gap is closed.

--- a/tools/spec-loop/specs/reviewer-routing.md
+++ b/tools/spec-loop/specs/reviewer-routing.md
@@ -125,8 +125,6 @@ uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/reviewer-r
 - **`experimental` — no adopter pilot has run.** The skill ships but no
   end-to-end routing workflow has been exercised in a live maintainer
   session; signal weights and roster-match heuristics may change.
-- **Temporarily absent from `docs/modes.md` Triage table.** The skill is
-  under active development (Privacy-LLM gate preflight being added to
-  Step 0); it was removed from the Triage table pending that work landing.
-  The skill itself remains at `mode: Triage` and `experimental`; it will
-  re-enter the modes table once the preflight addition is complete.
+- **Listed in `docs/modes.md` Triage table.** The skill is marked
+  `experimental`, and Step 0 now includes the Privacy-LLM gate before any
+  issue or PR body is fetched. The former documentation gap is closed.


### PR DESCRIPTION
Closes #937

## Summary
- replace both stale Known gaps bullets that claim reviewer-routing is absent from the Triage table
- record that the row is present and that Step 0 carries the Privacy-LLM gate before issue or PR bodies are processed

## Validation
- git diff --check
- verified the live `docs/modes.md` row and `reviewer-routing/SKILL.md` Step 0 gate
- the repository validator command could not run because `uv` is unavailable in this Windows checkout