### PR TITLE
fix(docs): update RFC-AI-0004 status from Draft to Accepted

### DIFF
--- a/docs/rfcs/RFC-AI-0004.md
+++ b/docs/rfcs/RFC-AI-0004.md
@@ -71,7 +71,7 @@
 |---|---|
 | **RFC** | AI-0004 |
 | **Title** | Principles of agentic interaction for open-source maintainers |
-| **Status** | Draft |
+| **Status** | Accepted |
 | **Authors** | The Apache Magpie project (see [`MISSION.md`](https://github.com/apache/magpie/blob/main/MISSION.md) for roster) |
 | **Initial draft** | 2026-05-07 |
 | **Supersedes** | None |
@@ -93,10 +93,10 @@ It is **not** a specification of any particular implementation detail (LLM cho
 
 ## Status of this document
 
-This is a **Draft**. The Apache Magpie project's reference implementation operationalises every principle in this RFC, but the RFC itself is the project's first attempt to extract the principles from the implementation and frame them as a portable contract. The next two milestones are:
+This is an **Accepted** RFC. The Apache Magpie project's reference implementation operationalises every principle in this RFC. The RFC was the project's first attempt to extract the principles from the implementation and frame them as a portable contract. Further milestones toward promotion to `Stable`:
 
 1. **Public review** — comments solicited from ASF Members, non-ASF maintainers running similar agentic frameworks, and the ASF Responsible AI Initiative working group.
-2. **Pilot validation** — the four principles tested against the Apache Magpie pilot cohort (one ASF PMC running the full security-issue flow, one ASF PMC running just triage + mentoring, at least one non-ASF project) before promotion from `Draft` to `Stable`.
+2. **Pilot validation** — the six principles tested against the Apache Magpie pilot cohort (one ASF PMC running the full security-issue flow, one ASF PMC running just triage + mentoring, at least one non-ASF project).
 
 ---
 


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

Two fixes in `docs/rfcs/RFC-AI-0004.md`:

1. **Status**: `Draft` → `Accepted` — the reference implementation already operationalises every principle.
2. **"four principles" → "six principles"** — the Motivation section's pilot-validation milestone said "four principles" but there are six.

Closes #888