### PR TITLE
docs: align MISSION.md cross-reference with established-TLP framing

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ files are reproduced in [`NOTICE`](NOTICE).
 
 ## Cross-references
 
-- [`MISSION.md`](MISSION.md) — **draft** project-establishment proposal: motivation, scope, design commitments, initial PMC composition target.
+- [`MISSION.md`](MISSION.md) — the founding mission of the Apache Magpie TLP: the original establishment proposal kept as a historical record — motivation, scope, design commitments, initial PMC composition target.
 - [`docs/setup/agentic-overrides.md`](docs/setup/agentic-overrides.md) — the contract between adopters who write overrides and framework skills that read them.
 - [`docs/prerequisites.md`](docs/prerequisites.md) — what a maintainer needs installed before invoking any framework skill (Claude Code, Gmail MCP, GitHub auth, browser, `uv`, etc.).
 - [`docs/source-release-contents.md`](docs/source-release-contents.md) — what ships in the signed `apache-magpie-<version>-source.zip` (and what is excluded), with the rationale for the repository-root metadata/config files it keeps.


### PR DESCRIPTION
Fixes #1006.

The Cross-references entry still called `MISSION.md` a **draft** project-establishment proposal, contradicting line 48 ("the founding mission of the established TLP") and the status banner in `MISSION.md` itself (established by ASF Board resolution on 17 June 2026; the original proposal kept as a historical record).

One-line change: the entry now matches both, and still tells the reader what is inside (motivation, scope, design commitments, initial PMC composition target).

Docs-only single-line edit; relying on PR CI for the prek pass.