### PR TITLE
docs: document assertions.json requirement in Pattern 8

### DIFF
--- a/docs/education/pattern-catalogue.md
+++ b/docs/education/pattern-catalogue.md
@@ -361,6 +361,7 @@ tools/skill-evals/evals/<skill-name>/
         ├── step-config.json          # { "skill_md": "...", "step_heading": "..." }
         ├── output-spec.md            # JSON schema the step must return
         ├── user-prompt-template.md   # user-facing prompt with {variable} slots
+        ├── assertions.json           # checks for any has_*/mention_* keys below
         ├── case-1-normal/
         │   ├── report.md             # realistic example input
         │   └── expected.json         # expected structured output
@@ -400,6 +401,16 @@ booleans, IDs) are compared exactly; prose fields are scored by a judge model.
    with a "nothing to do" message, not an error.
 4. **Confirm gate.** Check that the skill stops and asks before any step that
    changes something. It must not assume it already has permission.
+
+**If `expected.json` uses `has_*` or `mention_*` keys, add `assertions.json`.**
+The runner treats keys starting with `has_` or `mention_` as structural flags
+and looks for a matching predicate in `assertions.json` (see
+[`docs/education/eval-driven-development.md`](eval-driven-development.md) for
+the format). Without it, those cases fall back to `MANUAL` instead of
+`PASS`/`FAIL` — easy to miss since the suite still runs, it just never grades
+itself. The injection case is the one most likely to need this, since
+"injection flagged, not followed" is usually checked with a `has_*` flag on
+the rationale rather than an exact string match.
 
 **Why the injection case matters:** it is the easiest one to forget and the
 most important one to have. Without it, a reviewer cannot check the skill's


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

Closes #1004

## Summary

- Add `assertions.json` to the fixtures directory-layout block in Pattern 8,
  right after `user-prompt-template.md`.
- Add a paragraph after the four-case list explaining that `expected.json`
  keys starting with `has_` or `mention_` are structural flags that need a
  matching predicate in `assertions.json` — without it the case falls back
  to `MANUAL` grading instead of `PASS`/`FAIL` — and linking to
  `eval-driven-development.md` for the format.

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [x] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Closes #1004

## Notes for reviewers (optional)

None.
