### PR TITLE
test(bitbucket): add test coverage for defensive pagination and redirect guards

### DIFF
--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -919,6 +919,28 @@ def test_cloud_get_pull_request_commits_follows_next(
 
 
 @patch("urllib.request.build_opener")
+def test_cloud_get_pull_request_commits_rejects_repeated_next_url(
+    mock_build_opener: MagicMock,
+    cloud_env: None,
+) -> None:
+    repeated_url = "https://api.bitbucket.org/2.0/repositories/apache/magpie/pullrequests/7/commits?page=2"
+    mock_opener(
+        mock_build_opener,
+        {
+            "values": [],
+            "next": repeated_url,
+        },
+        {
+            "values": [],
+            "next": repeated_url,
+        },
+    )
+
+    with pytest.raises(BitbucketError, match="pagination returned a repeated URL"):
+        cloud.get_pull_request_commits(load_config(), "7")
+
+
+@patch("urllib.request.build_opener")
 def test_datacenter_get_pull_request_commits_follows_next_page_start(
     mock_build_opener: MagicMock,
     datacenter_env: None,

--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -149,6 +149,21 @@ def test_same_host_redirect_handler_rejects_different_port() -> None:
         )
 
 
+def test_same_host_redirect_handler_rejects_scheme_downgrade() -> None:
+    handler = SameHostRedirectHandler()
+    request = urllib_request("https://bitbucket.example.test/rest/api/1.0/foo")
+
+    with pytest.raises(BitbucketError, match="refusing to forward credentials"):
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            {},
+            "http://bitbucket.example.test/rest/api/1.0/bar",
+        )
+
+
 def test_load_config_defaults_to_cloud(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("BITBUCKET_KIND", raising=False)
     config = load_config()

--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -945,6 +945,27 @@ def test_datacenter_get_pull_request_commits_follows_next_page_start(
     assert [item["id"] for item in result["values"]] == ["abc123", "def456"]
 
 
+@patch("urllib.request.build_opener")
+def test_datacenter_get_pull_request_commits_stops_on_non_advancing_next_page_start(
+    mock_build_opener: MagicMock,
+    datacenter_env: None,
+) -> None:
+    opener = mock_opener(
+        mock_build_opener,
+        {
+            "values": [{"id": "abc123", "message": "First commit"}],
+            "isLastPage": False,
+            "nextPageStart": 0,
+        },
+    )
+
+    result = datacenter.get_pull_request_commits(load_config(), "9")
+
+    assert len(opener.open.call_args_list) == 1
+    assert result["pull_request_id"] == "9"
+    assert [item["id"] for item in result["values"]] == ["abc123"]
+
+
 def test_normalize_cloud_pull_request_commits() -> None:
     raw = {
         "pull_request_id": "7",


### PR DESCRIPTION
### Summary
Adds unit test cases in `tools/bitbucket/tests/test_bitbucket.py` for three defensive guards in the Bitbucket bridge to prevent regressions or accidental removal during future refactoring:

1. **Redirect Scheme Downgrade Guard**:
   - `test_same_host_redirect_handler_rejects_scheme_downgrade`: Asserts `SameHostRedirectHandler` refuses `https → http` redirects on the same host and raises `BitbucketError` ("refusing to forward credentials").
2. **Data Center Non-advancing Cursor Guard**:
   - `test_datacenter_get_pull_request_commits_stops_on_non_advancing_next_page_start`: Asserts `datacenter.get_pull_request_commits` terminates its pagination loop when `nextPageStart` is non-advancing (`<= start`), preventing infinite loops.
3. **Cloud Repeated Pagination URL Guard**:
   - `test_cloud_get_pull_request_commits_rejects_repeated_next_url`: Asserts `cloud.get_pull_request_commits` rejects repeated next URLs and raises `BitbucketError` ("pagination returned a repeated URL").

### Negative Control Verification
Each test was verified by temporarily disabling its guard in source code:
- Disabling scheme validation in `_origin()` caused `test_same_host_redirect_handler_rejects_scheme_downgrade` to fail (`DID NOT RAISE BitbucketError`).
- Removing `if next_start <= start: break` from `datacenter.py` caused `test_datacenter_get_pull_request_commits_stops_on_non_advancing_next_page_start` to fail (`StopIteration`).
- Removing `if next_url in seen_urls:` from `cloud.py` caused `test_cloud_get_pull_request_commits_rejects_repeated_next_url` to fail (`StopIteration`).

### Test Suite Status
All 101 unit tests in `tools/bitbucket` pass cleanly (`uv run --directory tools/bitbucket pytest`).

## fixes: #1007 

Generated using Claude Code