### PR TITLE
fix(security): remove ASF address from skills

### DIFF
--- a/skills/security-cve-allocate/SKILL.md
+++ b/skills/security-cve-allocate/SKILL.md
@@ -463,12 +463,12 @@ re-invoke this skill with the CVE ID as an override argument to
 resume from Step 4.
 
 **Fallback when no governance-authorised member is reachable:**
-if every authorised member is unavailable or unresponsive, send
-an email to `security@apache.org` with subject
-`CVE request for <one-line description>`. The ASF Security Team
-will allocate the CVE and send the ID back. Re-invoke this skill
-with the returned `CVE-YYYY-NNNNN` as an override to resume from
-Step 4.
+if every authorised member is unavailable or unresponsive, follow
+the fallback path documented by the active CVE-tool adapter (for
+the Vulnogram adapter, see
+[`tools/cve-tool-vulnogram/allocation.md` § *PMC-gated access*](../../tools/cve-tool-vulnogram/allocation.md#pmc-gated-access)).
+When the fallback returns a `CVE-YYYY-NNNNN`, re-invoke this skill
+with that ID as an override to resume from Step 4.
 
 **Wait for the user** to report back a `CVE-\d{4}-\d+` token. Do
 not proceed to Step 4 until that token has arrived. If the user

--- a/skills/security-issue-sync/github-advisory.md
+++ b/skills/security-issue-sync/github-advisory.md
@@ -126,7 +126,7 @@ path.
 ### Delivery — an email relay (draft, never auto-sent)
 
 Create a **draft** email to the org's advisory-admin security team
-(`<security-team-list>`; for ASF, `security@apache.org`) with
+(`<security-team-list>`) with
 `oauth-draft-create` — never send directly (SKILL Golden rule 1; and the
 Gmail MCP mangles the `security/advisories/GHSA-…` URLs into redirects, so
 use oauth-draft). **Always CC the project `<security-list>`** so the


### PR DESCRIPTION
## Summary

- Remove the hardcoded ASF security address from `security-cve-allocate` and point fallback guidance at the active CVE-tool adapter instead.
- Remove the remaining literal ASF security address from the GitHub advisory sync hand-off wording, keeping the generic `<security-team-list>` placeholder.

Fixes #998

## Validation

- `grep -rn "security@apache.org" skills/` returns no matches
- `uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate`
- `uv run prek run --all-files`
