### PR TITLE
docs(adapters): fix add-a-harness recipe

### DIFF
--- a/docs/adapters/add-a-harness.md
+++ b/docs/adapters/add-a-harness.md
@@ -77,7 +77,7 @@ relay symlinks automatically. The rules are:
 verify after any manual link creation:
 
 ```bash
-uv run --project tools/symlink-lint python3 -m symlink_lint
+uv run --project tools/symlink-lint symlink-lint
 ```
 
 ## Step 2 — wire the action guard
@@ -93,20 +93,24 @@ existing OpenCode example.
 
 ```text
 tools/agent-guard/
-  src/agent_guard/__init__.py    ← dispatch() core (harness-agnostic)
-  src/agent_guard/__main__.py    ← CLI entry point (stdin JSON → stdout JSON)
-  src/agent_guard/guards.d/     ← individual guard scripts
+  src/agent_guard/__init__.py    ← dispatch() core + thin CLI adapters
+  src/agent_guard/guards.d/      ← individual guard scripts
   opencode/plugin.js             ← OpenCode adapter (JS plugin)
-  tests/                         ← test suite incl. per-harness tests
+  tests/                         ← test suite including per-harness cases
 ```
 
-The core (`__init__.py`) exposes a `dispatch()` function. Per-harness
-adapters translate the runtime's hook format into a `dispatch()` call.
-Your adapter must:
+The core (`__init__.py`) exposes `dispatch()` plus one thin `*_main()`
+function per hook-shaped harness (`opencode_main()`, `kiro_main()`,
+…). The `cli()` router near the end of the file selects those adapters
+from flags such as `--opencode` and `--kiro`. To add another hook-shaped
+harness, follow that pattern:
+
 1. Parse the harness's pre-tool hook payload (stdin JSON, env vars,
    CLI args, or a native plugin format — check the runtime docs).
 2. Call `dispatch(command_string)` from the core module.
 3. Return the harness's expected "allow" or "block" response.
+4. Add a `--<runtime>` branch in `cli()` that routes to the new
+   `*_main()` function.
 
 Run the guard's test suite to verify the adapter:
 
@@ -232,7 +236,7 @@ in its comment header.
 
 ```bash
 # 1. Symlink topology (no cycles, correct relay direction)
-uv run --project tools/symlink-lint python3 -m symlink_lint
+uv run --project tools/symlink-lint symlink-lint
 
 # 2. Skill + tool metadata (capability, prerequisites, organization lines)
 uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate


### PR DESCRIPTION
## Summary

- Replace the broken `python3 -m symlink_lint` examples with the shipped `symlink-lint` console script.
- Update the action-guard file tree to match the current `tools/agent-guard/src/agent_guard/__init__.py` layout.
- Describe adding a hook-shaped harness as a `*_main()` adapter plus a `cli()` routing branch, matching the existing OpenCode and Kiro paths.

Fixes #997

## Validation

- `uv run --project tools/symlink-lint symlink-lint`
- `uv run --directory tools/agent-guard --project . --group dev pytest`
- `uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-validate`
- `bash -n tools/spec-loop/loop.sh && bash -n tools/spec-loop/lib.sh`
- `uv run prek run --all-files`
