### PR TITLE
Correct AGENTS.md's stale 7-day cooldown claim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -428,8 +428,11 @@ with default-permissive access to `~/`, env vars, and arbitrary network
 egress is a real exfiltration risk. See
 [`docs/setup/secure-agent-setup.md`](docs/setup/secure-agent-setup.md)
 for the layered defence the framework dogfoods (sandbox + tool
-permissions + clean-env wrapper, system tools pinned with a 7-day
-upstream cooldown).
+permissions + clean-env wrapper, sandbox primitives pinned with a 7-day
+upstream cooldown). The agent runtime itself is deliberately unpinned —
+it installs at `@latest` with a `min_version` floor and no cooldown, so
+it always carries the newest permission-rule, sandbox, and
+prompt-injection fixes.
 
 **Tool credentials live under `$HOME`, never in the project tree.** Any
 persistent token, API key, OAuth refresh token, or session cookie a


### PR DESCRIPTION
## Summary
- `AGENTS.md` summarised the framework's supply-chain posture as "system tools pinned with a 7-day upstream cooldown" — no longer accurate for the agent runtime since PR #825 moved `claude-code` to an always-latest install with a `min_version` floor and no cooldown.
- Updates the sentence in the *Local setup* section to describe the sandbox primitives (`bubblewrap`, `socat`) as pinned with the 7-day cooldown, and the agent runtime as deliberately unpinned (`@latest` + `min_version` floor, no cooldown), matching the wording already used in `docs/setup/secure-agent-setup.md` and `docs/rfcs/RFC-AI-0002.md`.
- No other file changed, per the issue's acceptance criteria.

Closes #1002

## Test plan
- [x] `prek run --files AGENTS.md --skip lychee` — all applicable hooks pass (markdownlint, typos, SPDX header, trailing-whitespace, EOF, mixed-line-ending, merge-conflict/private-key scans).
- [x] `lychee` (link checker) not run locally — this edit adds no links and touches no existing link syntax, so it's out of scope for what changed; the repo's Rust-based lychee hook env takes long enough to compile from source that it wasn't practical to build locally for this change.