### PR TITLE
fix(validator): scan tool-root Python and 'from socket import' for telemetry

### DIFF
--- a/tools/egress-gateway/tool.md
+++ b/tools/egress-gateway/tool.md
@@ -113,11 +113,19 @@ action (PRINCIPLE 10).  This guarantee rests on two pillars:
    all other `substrate:*` tools are network-free by design.
 
 2. **The validator enforces the invariant.**  `tools/skill-and-tool-validator/`
-   check #21 (`no-telemetry-import`) scans the source of every `substrate:*`
-   tool for network-calling imports (`requests`, `httpx`, `aiohttp`,
-   `urllib.request`, `http.client`, `socket`) and flags any hit as a SOFT
-   advisory.  A substrate tool that accidentally grows a network import is
-   caught before it is merged.
+   check #21 (`no-telemetry-import`) scans every Python file owned by a
+   `substrate:*` tool — under `src/` and at the tool root alike, excluding
+   `tests/` — for network-calling imports (`requests`, `httpx`, `aiohttp`,
+   `urllib.request`, `http.client`, `socket`, in both `import x` and
+   `from x import` form) and flags any hit as a SOFT advisory.  A substrate
+   tool that accidentally grows a network import is surfaced in the
+   validator's output before it is merged.
+
+   Two limits worth stating plainly.  The check is **advisory unless
+   `--strict`**, so an accidental import can merge on a run that does not
+   pass the flag — it is a tripwire the reviewer reads, not a gate that
+   stops the merge.  And the library list is deliberately non-exhaustive:
+   it catches the common accidents, not a determined author.
 
 The declared egress surfaces as of this writing:
 

--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -399,6 +399,7 @@ _NETWORK_IMPORT_PATTERNS: list[tuple[re.Pattern[str], str]] = [
     (re.compile(r"^\s*from\s+urllib\s+import\s+(?:\w+\s*,\s*)*request\b"), "urllib.request"),
     (re.compile(r"^\s*(?:import|from)\s+http\.client\b"), "http.client"),
     (re.compile(r"^\s*import\s+socket\b"), "socket"),
+    (re.compile(r"^\s*from\s+socket\s+import\b"), "socket"),
 ]
 
 
@@ -3637,11 +3638,19 @@ def validate_no_telemetry_imports(root: Path | None = None) -> Iterable[Violatio
                 if any(e.startswith(_ADAPTER_CONTRACT_PREFIX) for e in entries):
                     continue  # declared contract:* adapter — network is expected
 
-        src_dir = tool_dir / "src"
-        if not src_dir.is_dir():
-            continue
-
-        for py_path in sorted(src_dir.rglob("*.py")):
+        # Scan every Python file the tool owns, not just ``src/``.  Several
+        # substrate tools keep their Python at the tool root
+        # (``pr-management-stats/dashboard.py``,
+        # ``security-tracker-stats-dashboard/render.py``, …), and a
+        # ``src/``-only scan silently exempted them while
+        # ``tools/egress-gateway/tool.md`` promised that "a substrate tool
+        # that accidentally grows a network import is caught before it is
+        # merged".  ``tests/`` is excluded: a test may legitimately import a
+        # network module to assert it is *not* reachable.
+        for py_path in sorted(tool_dir.rglob("*.py")):
+            rel_parts = py_path.relative_to(tool_dir).parts
+            if "tests" in rel_parts:
+                continue
             if any(part in _LICENSE_SKIP_PATH_PARTS for part in py_path.parts):
                 continue
             try:

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -5199,3 +5199,55 @@ class TestValidateNoTelemetryImports:
         )
         violations = list(validate_no_telemetry_imports(root))
         assert any("PRINCIPLE 10" in v.message for v in violations)
+
+    def test_tool_root_python_outside_src_is_scanned(self, tmp_path: Path) -> None:
+        # Several substrate tools keep Python at the tool root rather than
+        # under src/ (pr-management-stats/dashboard.py and friends). A
+        # src/-only scan exempted every one of them while tool.md promised
+        # the opposite.
+        root = self._make_tool(
+            tmp_path,
+            name="root-script-substrate",
+            readme=self._SUBSTRATE_README,
+            src_files={"root_script_substrate/__init__.py": "# SPDX-License-Identifier: Apache-2.0\n"},
+        )
+        tool_dir = root / "tools" / "root-script-substrate"
+        (tool_dir / "dashboard.py").write_text("# SPDX-License-Identifier: Apache-2.0\nimport requests\n")
+        violations = list(validate_no_telemetry_imports(root))
+        assert len(violations) == 1
+        assert violations[0].path.name == "dashboard.py"
+        assert "requests" in violations[0].message
+
+    def test_from_socket_import_is_flagged(self, tmp_path: Path) -> None:
+        # Every sibling pattern accepts both `import x` and `from x import`;
+        # socket accepted only the former.
+        root = self._make_tool(
+            tmp_path,
+            name="from-socket-substrate",
+            readme=self._SUBSTRATE_README,
+            src_files={
+                "from_socket_substrate/__init__.py": (
+                    "# SPDX-License-Identifier: Apache-2.0\nfrom socket import socket\n"
+                )
+            },
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert len(violations) == 1
+        assert "socket" in violations[0].message
+
+    def test_tests_directory_is_not_scanned(self, tmp_path: Path) -> None:
+        # A test may legitimately import a network module to assert it is
+        # not reachable; broadening the scan must not start flagging those.
+        root = self._make_tool(
+            tmp_path,
+            name="tested-substrate",
+            readme=self._SUBSTRATE_README,
+            src_files={"tested_substrate/__init__.py": "# SPDX-License-Identifier: Apache-2.0\n"},
+        )
+        tool_dir = root / "tools" / "tested-substrate"
+        (tool_dir / "tests").mkdir()
+        (tool_dir / "tests" / "test_net.py").write_text(
+            "# SPDX-License-Identifier: Apache-2.0\nimport requests\nfrom socket import socket\n"
+        )
+        violations = list(validate_no_telemetry_imports(root))
+        assert violations == []


### PR DESCRIPTION
## Summary

Closes #783.

`tools/egress-gateway/tool.md` promised that *"a substrate tool that accidentally grows a network import is caught before it is merged."* For 11 Python files it did not.

- **Scan every `.py` the tool owns**, not just `tools/<name>/src/`. Several substrate tools keep Python at the tool root — `pr-management-stats/{dashboard,reference}.py`, `security-tracker-stats-dashboard/{fetch_roster,fetch_prs,render}.py`, `dashboard-generator/reference.py` — and a `src/`-only scan exempted every one of them. `tests/` stays excluded: a test may legitimately import a network module to assert it is unreachable.
- **Add the `from socket import` companion pattern.** Every sibling pattern already accepted both `import x` and `from x import`; `socket` accepted only the former. Clearly an oversight rather than a decision.
- **Correct the `tool.md` guarantee** so it states the real scope and the two limits it previously implied away.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] `prek run --files` green on all three files (ruff, ruff-format, mypy, pytest, markdownlint, typos, lychee, skill-and-tool-validate)
- [x] `uv run --directory tools/skill-and-tool-validator --group dev pytest` passes
- [x] **Before/after proven by planting the defects.** `import requests` added to `tools/pr-management-stats/dashboard.py` and `from socket import socket` to `reference.py` — both real tool-root files:

  | Validator | Violations found |
  |---|---|
  | original (`main`) | **0** — both missed |
  | this PR | **2** — both caught |

- [x] **Clean tree is 0 violations before and after**, so no existing tool is newly flagged and this does not turn CI red on merge
- [x] Three tests added; the two behavioural ones fail on the previous implementation with `assert 0 == 1`

## RFC-AI-0004 compliance

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [x] **Sandbox** — this is the check backing PRINCIPLE 10's zero-default-egress guarantee; the change widens enforcement to the files that were silently exempt
- [ ] **Vendor neutrality**
- [ ] **Conversational + correctable**
- [ ] **Write-access discipline**
- [x] **Privacy LLM** — the no-telemetry invariant is what stops a substrate tool quietly acquiring an outbound call

## Linked issues

Closes #783. Follow-up from the review of #763.

## Notes for reviewers

**On the `tool.md` rewording.** I first considered only widening the scan and leaving the prose. That would still have overclaimed: the check is SOFT unless `--strict`, so an accidental import can merge on a run without the flag. The doc now says plainly that it is *"a tripwire the reviewer reads, not a gate that stops the merge"*, and that the library list is deliberately non-exhaustive. A guarantee that overstates its own strength is worse than a narrower one stated accurately — someone reads it and stops looking.

**On the `tests/` exclusion.** Deliberate, and the third test pins it. Broadening the scan without it would have started flagging test files that import `requests` precisely to assert it cannot reach anywhere — a check that fires on its own negative controls trains people to ignore it.

**Verification method.** The clean tree reports 0 violations both before and after, so a passing run proves nothing on its own. The planted-defect comparison in the test plan above is what establishes that the broadened scan actually reaches the new files.
