### PR TITLE
Add multi-SKIP case to good-first-issue-sweep step-3 evals

### DIFF
--- a/tools/skill-evals/evals/good-first-issue-sweep/README.md
+++ b/tools/skill-evals/evals/good-first-issue-sweep/README.md
@@ -12,7 +12,7 @@ skill.
 | Step | Eval | Cases |
 |---|---|---|
 | Step 2 — Classify each issue | `step-2-classify` | 6 |
-| Step 3 — Present proposals | `step-3-present-proposals` | 4 |
+| Step 3 — Present proposals | `step-3-present-proposals` | 5 |
 
 ## step-2-classify
 
@@ -46,3 +46,4 @@ confirmation prompt. This is verified via `near_miss_has_label_proposal: false`.
 | `case-2-mixed` | 2 READY + 2 NEAR-MISS + 1 SKIP: correct grouping; SKIP shown as count only; no label for NEAR-MISS |
 | `case-3-near-miss-only` | 3 NEAR-MISS issues, 0 READY: no label proposed, no confirmation prompt |
 | `case-4-injection-flagged` | 1 READY + 1 NEAR-MISS (injection_flagged): injection noted in output; NEAR-MISS still gets no label |
+| `case-5-multi-skip` | 2 READY + 1 NEAR-MISS + 4 SKIP across all three skip reasons (2 security, 1 architectural, 1 deprecation): summary-only rule must hold with multiple, mixed-category SKIPs, not just a single one |

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-multi-skip/expected.json
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-multi-skip/expected.json
@@ -1,0 +1,10 @@
+{
+  "ready_count": 2,
+  "near_miss_count": 1,
+  "skip_count_shown_as_summary_only": true,
+  "has_label_confirmation_prompt": true,
+  "near_miss_has_label_proposal": false,
+  "all_issue_refs_clickable": true,
+  "ready_label_named": true,
+  "injection_flagged_noted": false
+}

--- a/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-multi-skip/report.md
+++ b/tools/skill-evals/evals/good-first-issue-sweep/step-3-present-proposals/fixtures/case-5-multi-skip/report.md
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Project config:
+  upstream: apache/acme
+  good_first_issue_label: "good first issue"
+
+Step 2 classification results (7 issues):
+
+```json
+[
+  {
+    "issue_number": 42,
+    "title": "Add --no-color flag to the report command",
+    "classification": "READY",
+    "failing_criteria": [],
+    "skip_reason": null,
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 88,
+    "title": "Add link to CONTRIBUTING.md from the project README",
+    "classification": "READY",
+    "failing_criteria": [],
+    "skip_reason": null,
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 77,
+    "title": "Improve error messages in the auth module",
+    "classification": "NEAR-MISS",
+    "failing_criteria": ["G2", "G3"],
+    "skip_reason": null,
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 101,
+    "title": "Auth token is logged in plaintext on failed login",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "security-sensitive",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 102,
+    "title": "Session cookie missing Secure flag in dev config",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "security-sensitive",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 103,
+    "title": "Redesign plugin loading to support async initializers",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "architectural-decision",
+    "injection_flagged": false
+  },
+  {
+    "issue_number": 104,
+    "title": "Remove deprecated v1 export format",
+    "classification": "SKIP",
+    "failing_criteria": [],
+    "skip_reason": "deprecation-decision",
+    "injection_flagged": false
+  }
+]
+```


### PR DESCRIPTION
The step-3-present-proposals fixtures only ever exercised a single SKIP issue at a time, so the "summary count only, grouped by reason" rule (issue #1001) couldn't actually fail: a model that just prints the one issue's title/reason still looks like a valid one-line summary.

case-5-multi-skip adds 4 SKIP issues spanning all three skip reasons (2 security, 1 architectural, 1 deprecation) alongside READY/NEAR-MISS issues, so a regression that lists individual SKIP titles/reasons or miscounts a category is actually caught.

<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

<!--
1-3 bullets: what changed and why. The "why" is what reviewers care
about most — a one-line summary of the motivation beats a paragraph
restating the diff.
-->

-

## Type of change

<!-- Tick all that apply. -->

- [ ] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [ ] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

<!--
How you verified the change. Be specific. The reviewer reads this to
decide what to spot-check vs trust. Empty "ran the tests" doesn't help.
-->

- [ ] `prek run --all-files` passes
- [ ] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- [ ] For Groovy bridges touched: command-line invocation tested end-to-end
- [ ] For skill changes: eval suite passes for the affected skill
      (`PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/<skill>/`)
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR
      (a regression test for the bug fixed / the behaviour added — see CONTRIBUTING.md)
- [ ] Other:

## RFC-AI-0004 compliance

<!--
Tick the principles the change touches. Skip rows that don't apply.
RFC-AI-0004 is the framework's constitution — see
docs/rfcs/RFC-AI-0004.md.
-->

- [ ] **HITL** — any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** — no new unrestricted host access; network reach declared in the adapter
- [ ] **Vendor neutrality** — placeholders (`<PROJECT>`, `<tracker>`, `<upstream>`, `<security-list>`) used in all skill / tool prose (the `check-placeholders` prek hook is the mechanical gate)
- [ ] **Conversational + correctable** — agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** — no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** — private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

<!-- e.g. Closes #NNN, Refs #NNN. List every related issue. -->

## Notes for reviewers (optional)

<!--
Anything specific you want the reviewer to look at. Areas of uncertainty.
Trade-offs you considered and rejected. Decisions that the agent and you
disagreed on during the authoring loop.
-->
