### PR TITLE
fix(specs): update three stale Known gaps in meta-and-quality-tooling.md

### DIFF
--- a/tools/spec-loop/specs/meta-and-quality-tooling.md
+++ b/tools/spec-loop/specs/meta-and-quality-tooling.md
@@ -145,15 +145,23 @@ uv run --project tools/spec-inventory --group dev pytest tools/spec-inventory/te
   required fields, but the next pass should make `mode`, `status`,
   `capability`, `organization`, and `source` combinations explicit and
   test-backed.
-- **Capability taxonomy drift is not yet checked.** The validator should
-  catch misspelled or undocumented capability values, and should surface
-  taxonomy rows that no skill/tool implements unless they are marked
-  reserved.
-- **`docs/modes.md` is manually synced.** The plan tracks a generated
-  consistency check so mode tables and shipped counts cannot silently
-  drift from skill frontmatter.
-- **Tool README prerequisites vary.** A prerequisites consistency pass
-  should normalize older tool READMEs before tightening the validator.
+- **Capability taxonomy drift is now checked.**
+  `validate_capability_taxonomy_coverage` parses the Axis 1 / Axis 2
+  vocabulary tables in `docs/labels-and-capabilities.md`, surfaces
+  taxonomy rows that no skill/tool implements (entries marked
+  *(reserved)* / *(future)* are exempt), and cross-checks the
+  `SKILL_CAPABILITIES` / `TOOL_CAPABILITIES` code constants against the
+  doc — all SOFT advisories. Undocumented frontmatter capability values
+  are rejected by skill validation separately.
+- **`docs/modes.md` is no longer manually synced.**
+  `validate_modes_doc_consistency` compares the doc's per-mode tables
+  against live skill frontmatter — missing skills, mode mismatches,
+  skill-count mismatches, and unlisted skills — as SOFT advisories.
+- **Tool README prerequisites are normalized and enforced.** The HARD
+  `tool-prerequisites-fields` check requires the bold sub-field labels
+  (**Runtime:**, **CLIs:**, **Credentials / auth:**, **Network:**) or
+  the pure-contract delegation shorthand in every tool README, so the
+  normalize-then-tighten ordering this bullet used to track is done.
 - **Pilot evidence shape is now defined and validated.** `docs/pilot-report-template.md`
   defines the required frontmatter schema and body sections; `tools/pilot-report-validator/`
   enforces the schema on every `.md` file with a YAML frontmatter block.


### PR DESCRIPTION
## Summary

Three `Known gaps` bullets in `tools/spec-loop/specs/meta-and-quality-tooling.md` described validator checks as missing or pending when all three have shipped. Each bullet is rewritten to name the check that closed it and its enforcement level, so the spec-loop plan beat stops steering at finished work:

- capability taxonomy drift → `validate_capability_taxonomy_coverage` (SOFT advisories; *(reserved)* / *(future)* rows exempt; also cross-checks the `SKILL_CAPABILITIES` / `TOOL_CAPABILITIES` constants)
- `docs/modes.md` sync → `validate_modes_doc_consistency` (four SOFT checks: missing skill, mode mismatch, count mismatch, unlisted skill)
- tool README prerequisites → the HARD `tool-prerequisites-fields` check (bold sub-field labels or the pure-contract delegation shorthand), so the normalize-then-tighten ordering the old bullet tracked is done

## Type of change

- [x] Other: spec documentation (`tools/spec-loop/specs/`)

## Test plan

- [x] `uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/` — OK, no violations
- [x] `prek run --all-files` — all 23 hooks pass
- [x] Each rewritten bullet checked against the validator source (`validate_capability_taxonomy_coverage` at `__init__.py` L2283, `validate_modes_doc_consistency` at L2821, `tool-prerequisites-fields` in `HARD_CATEGORIES`), per the issue's "verify by finding the call site" note

## RFC-AI-0004 compliance

No runtime behaviour or state-changing workflow is changed — spec prose only.

## Linked issues

Closes #938

## Generative AI disclosure

Prepared with Claude Code (Fable 5). The commit carries a `Generated-by:` trailer and no AI `Co-Authored-By:` trailer.
