### PR TITLE
fix(specs): correct repo-health family count in triage-mode.md

### DIFF
--- a/tools/spec-loop/specs/triage-mode.md
+++ b/tools/spec-loop/specs/triage-mode.md
@@ -111,8 +111,8 @@ uv run --project tools/skill-and-tool-validator --group dev skill-and-tool-valid
   committer), emeritus / inactive-committer handling, and contributor
   offboarding. Worth deciding whether this becomes a named family with
   its own spec.
-- **Repo-health audits are now a five-skill family — feature-complete.**
+- **Repo-health audits are now a six-skill family — feature-complete.**
   `ci-runner-audit`, `workflow-security-audit` (zizmor-backed),
-  `dependency-audit`, `license-compliance-audit`, and `flaky-test-triage`
-  have all shipped (read-only, `experimental`); see
+  `dependency-audit`, `license-compliance-audit`, `flaky-test-triage`, and
+  `dependency-license-audit` have all shipped (read-only, `experimental`); see
   [repo-health-family.md](repo-health-family.md). No candidates remain.


### PR DESCRIPTION
## Summary

`triage-mode.md` called repo-health a "five-skill family" while `repo-health-family.md` says six. The sixth skill, `dependency-license-audit`, shipped without this spec being updated. Per the maintainer's direction on the issue (Option 1: six read-only audits is the correct count), this PR updates the count to six and adds the missing skill to the list.

## Type of change

- [x] Other: spec documentation (`tools/spec-loop/specs/`)

## Test plan

- [x] `uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/` — OK, no violations
- [x] `prek run --all-files` — all 23 hooks pass

## RFC-AI-0004 compliance

No runtime behaviour or state-changing workflow is changed — spec prose only.

## Linked issues

Closes #931

## Notes for reviewers (optional)

Scoped to the prose fix only. The other half of Option 1 — re-keying `audit-finding-fix` off `family: repo-health` — is left for a follow-up once the target key is decided (it also feeds the three-way-discrepancy example in `spec-gap-staleness.md`, which a re-key would invalidate).

## Generative AI disclosure

Prepared with Claude Code (Fable 5). The commit carries a `Generated-by:` trailer and no AI `Co-Authored-By:` trailer.
