### PR TITLE
docs(mode-economics): refresh stale token table

### DIFF
--- a/docs/mode-economics.md
+++ b/docs/mode-economics.md
@@ -131,6 +131,10 @@ cost depends on contributor volume.
 | `pr-management-mentor` | Single threaded reply | 6K–20K | Estimated; skill experimental |
 | `good-first-issue-author` | One candidate → one issue draft | 6K–18K | Estimated; reads one candidate + named source files, no full-thread history; skill experimental |
 | `newcomer-issue-explainer` | One issue → one beginner explanation draft | 4K–12K | Estimated; reads one issue body + a small set of named source files; read-only; skill experimental |
+| `mentoring-welcome` | One first-time contributor → one welcome draft | 4K–12K | Estimated; reads the triggering thread + contributing-guide pointers, no full-thread history; skill experimental |
+| `onboarding-concierge` | One newcomer question → one grounded answer draft | 4K–12K | Estimated; reads `CONTRIBUTING.md` + the relevant doc excerpt; read-only; skill experimental |
+| `contributor-to-committer` | Single contributor readiness brief | 15K–50K | Estimated; reads the contributor's activity history against the adopter's thresholds; read-only; skill experimental |
+| `good-first-issue-sweep` | Backlog sweep (10 issues) | 20K–80K | Estimated; scales linearly with the number of issues scored; skill experimental |
 
 **Rule of thumb for Agentic Mentoring:** budget 10K–20K tokens per
 contributor interaction. A project with 20 active contributors each
@@ -163,7 +167,8 @@ multiply the per-pass cost by the number of review agents.
 | Skill | Typical invocation | Token range | Notes |
 |---|---|---|---|
 | `pairing-self-review` | Pre-flight review of a local diff | 10K–50K | Estimated; skill experimental. Scales with diff size and conventions doc length. |
-| Multi-agent review pipeline | Full three-pass review | 30K–200K | Estimated; future skill. 3–4 × single-pass cost. Parallelism reduces latency, not billing. |
+| `pairing-multi-agent-review` | Full three-pass review | 30K–200K | Estimated; skill experimental. 3–4 × single-pass cost. Parallelism reduces latency, not billing. |
+| `pre-first-pr-check` | Newcomer pre-flight checklist on a local branch | 5K–20K | Estimated; skill experimental. Read-only; scales with diff size and convention docs read. |
 
 **Rule of thumb for Agentic Pairing:** a typical pre-flight self-review of a
 medium PR uses 15K–30K tokens. A three-agent review pipeline on


### PR DESCRIPTION
## Summary

- `docs/mode-economics.md` is the reference adopters use to estimate token
  costs, but its tables had drifted behind the shipped skill set: the Pairing
  table still listed the multi-agent review pipeline as a "future skill", and
  five shipped skills were missing rows entirely.
- Rename the "Multi-agent review pipeline" row to `pairing-multi-agent-review`
  (shipped, experimental — range unchanged) and add the missing rows:
  `pre-first-pr-check` (Pairing) plus the four Mentoring-family skills the
  table omitted (`mentoring-welcome`, `onboarding-concierge`,
  `contributor-to-committer`, `good-first-issue-sweep`).
- New ranges are marked *Estimated*, following the table's existing
  convention for experimental skills.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- [x] `prek run --files docs/mode-economics.md` passes (markdownlint, typos,
      lychee link check all green)
- Docs-only change; no behaviour to test. Skill inventory cross-checked
  against `docs/modes.md` (Mentoring: 7 shipped, table had 3; Pairing: 3
  shipped, table had 1 + a "future" placeholder).

## RFC-AI-0004 compliance

Docs-only; no principles touched.

## Linked issues

Closes [apache/magpie#881](https://github.com/apache/magpie/issues/881)

## Notes for reviewers

The four new Mentoring rows and `pre-first-pr-check` carry estimated ranges
anchored on analogous existing rows (`newcomer-issue-explainer` for the
single-thread drafters, `issue-reassess` for the backlog sweep). The two
worth sanity-checking are `contributor-to-committer` (15K–50K — activity
history read) and `good-first-issue-sweep` (20K–80K per 10-issue sweep).

