### PR TITLE
ci(ai-tutors): add prek hook enforcing inject-knowledge-base.py --check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -204,6 +204,23 @@ repos:
         entry: uv run --project tools/vendor-neutrality-score vendor-neutrality-score --in-place
         files: ^(tools/[^/]+/README\.md|tools/privacy-llm/models\.md|tools/vendor-neutrality-score/.*|skills/[^/]+/SKILL\.md|docs/vendor-neutrality\.md)$
         pass_filenames: false
+  # AI-tutor knowledge-base sync — fail when a `docs/education/` source
+  # page (or a training lesson) changes without regenerating the tutor
+  # prompts in `ai-tutors/`. `--check` prints the stale prompts and exits
+  # non-zero; the contributor reruns `python3
+  # ai-tutors/inject-knowledge-base.py` (no flag) to regenerate and
+  # re-stages. `pass_filenames: false`: the script always scans every
+  # lesson; the `files:` filter only gates *whether* the check fires (and
+  # it always runs on `prek run --all-files` in CI). Deterministic and
+  # offline. Script + pytest suite live in ai-tutors/.
+  - repo: local
+    hooks:
+      - id: ai-tutors-kb-check
+        name: Check ai-tutors prompts are in sync with docs/education
+        language: system
+        entry: python3 ai-tutors/inject-knowledge-base.py --check
+        files: ^(ai-tutors/|docs/education/)
+        pass_filenames: false
   # Self-adoption symlink hygiene: reject cyclic symlinks and misdirected
   # skill relays. `types: [symlink]` fires it on any staged symlink (always
   # on `prek run --all-files`). Rules, rationale, and the pytest suite live


### PR DESCRIPTION
## Summary

- Nothing ran `python3 ai-tutors/inject-knowledge-base.py --check`, so a
  `docs/education/` source-page edit could leave the generated tutor prompts
  in `ai-tutors/` silently stale — both shipped prompts had already drifted
  this way before being noticed (see the issue for the history).
- Wire `--check` as a local prek hook scoped to
  `^(ai-tutors/|docs/education/)`, mirroring the `vendor-neutrality-score`
  hook's generated-content pattern (own `repo: local` block,
  `pass_filenames: false`, explanatory comment). The script itself is
  untouched — `--check` already prints the drifting prompts and exits
  non-zero.
- CI already runs `prek run --all-files`, so the one config change gates both
  commit time and CI.

## Type of change

- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] Red case: with the drift currently live on `main`
      (`ai-tutors/lesson-08-eval-driven-development.md`), the hook fails and
      names the stale file.
- [x] Green case: after regenerating lesson-08 locally, the hook passes.
      (The regeneration itself is not part of this PR — see the ordering note
      below.)
- [x] `prek run --files .pre-commit-config.yaml` passes, including the
      "Check if all hooks apply to the repository" gate that validates the
      new `files:` pattern.

## RFC-AI-0004 compliance

CI-only; no principles touched.

## Linked issues

Closes [apache/magpie#1051](https://github.com/apache/magpie/issues/1051)

## Notes for reviewers

**Ordering: blocked by [apache/magpie#1050](https://github.com/apache/magpie/pull/1050).**
`main` currently has a live lesson-08 drift, which #1050 fixes. Until that
merges, this PR's own CI will fail on exactly the new hook — a live
demonstration that the gate works, but it means this PR should merge
*after* #1050 (and then rebase/re-run to go green). Regenerating lesson-08
here instead would duplicate #1050, so this PR deliberately stays hook-only.

