### PR TITLE
fix(pr-management-triage): filter action_required runs server-side

### DIFF
--- a/skills/pr-management-triage/actions.md
+++ b/skills/pr-management-triage/actions.md
@@ -359,13 +359,15 @@ executed.
 ```bash
 # Pre-check: index action_required runs at the head SHA.
 # Note: runs awaiting approval are returned as `status: "completed"`
-# with `conclusion: "action_required"`. The query parameter
-# `?status=action_required` matches no runs and would silently
-# return an empty result — post-filter on `conclusion` instead.
+# with `conclusion: "action_required"`. This lookup is already scoped
+# to one head SHA, so the `conclusion` post-filter is sufficient and
+# needs no `status=` narrowing. (For the repo-wide index in
+# fetch-and-batch.md the opposite holds: filter with
+# `status=action_required` server-side, because an unfiltered listing
+# truncates long before the backlog ends.)
 # One fetch covers both guards.
 read -r head_sha merge_state <<<"$(gh api "repos/<owner>/<repo>/pulls/<N>" \
   --jq '"\(.head.sha) \(.mergeable_state)"')"
-
 pending=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=${head_sha}&per_page=20" \
   --jq '[.workflow_runs[] | select(.conclusion == "action_required")] | length')
 if [ "$pending" -gt 0 ]; then
@@ -703,8 +705,8 @@ without burning a useless mutation):
 ```bash
 # Re-list pending workflow runs for this PR at action time.
 # Runs awaiting approval are returned as `status: "completed"` with
-# `conclusion: "action_required"` — `?status=action_required` matches
-# none of them. Post-filter on `conclusion` to enumerate the real set.
+# `conclusion: "action_required"`. Scoped to one head SHA, so the
+# `conclusion` post-filter enumerates the real set on its own.
 ids=$(gh api "repos/<owner>/<repo>/actions/runs?head_sha=<head_sha>&per_page=20" \
         --jq '.workflow_runs[] | select(.conclusion == "action_required") | .id')
 

--- a/skills/pr-management-triage/fetch-and-batch.md
+++ b/skills/pr-management-triage/fetch-and-batch.md
@@ -433,11 +433,15 @@ is the anti-pattern this file exists to prevent.
 
 ## Mandatory: `action_required` run index per page
 
-Before classification runs, fetch one REST call per page:
+Before classification runs, build the index with a **filtered,
+fully-paginated** query:
 
 ```bash
-gh api "repos/<owner>/<repo>/actions/runs?event=pull_request&per_page=100" \
-  --jq '.workflow_runs[] | select(.conclusion == "action_required")'
+# Primary: filter server-side, and walk every page.
+for page in $(seq 1 10); do
+  gh api "repos/<owner>/<repo>/actions/runs?event=pull_request&status=action_required&per_page=100&page=${page}" \
+    --jq '.workflow_runs[] | {head_sha, name, id}'
+done
 ```
 
 This lists **every** workflow run across the repo that is
@@ -446,15 +450,29 @@ any PR on the current page whose head SHA appears in the index
 is `pending_workflow_approval` (see
 [`classify-and-act.md#decision-table`](classify-and-act.md), row 1).
 
-**Why the post-filter, not `?status=action_required`.** The
-GitHub Actions API returns runs awaiting approval as
-`status: "completed"` with `conclusion: "action_required"` (the
-run has *finished* the queueing phase and is now blocked
-pending approval). The query parameter `?status=action_required`
-matches no runs in this state and silently returns an empty
-result, which lets `pending_workflow_approval` PRs slip through
-classification as `passing`. The post-filter on `conclusion`
-is the only correct way to enumerate them.
+**Filter server-side; do not rely on a post-filter over recent
+runs.** `?status=action_required` **does** match these runs —
+`status` accepts the terminal `action_required` state as well as
+the lifecycle states, and it is what
+[`SKILL.md` Golden rule 1b](SKILL.md) already uses. The
+unfiltered `event=pull_request` listing returns runs
+newest-first regardless of state, so on a high-volume repository
+the pending ones are buried far beyond the first few pages.
+
+Measured on a large `<upstream>` (2026-08): `?status=action_required`
+reported **1109** matching runs, while post-filtering the first
+3 pages of `?event=pull_request` (300 most-recent runs, reaching
+back only ~12 hours) surfaced **9** distinct head SHAs against
+**322** actually pending. Every PR in the ~313-SHA gap whose
+rollup was green from bot checks alone classified as `passing`
+and became a `mark-ready` candidate — precisely the
+false-positive class this index exists to prevent.
+
+A `conclusion == "action_required"` post-filter over the
+**filtered** result set is still a harmless belt-and-braces
+check, and remains correct for hosts whose API build ignores the
+`status` value. What is *not* safe is using the post-filter as
+the primary mechanism over an unfiltered, truncated listing.
 
 Why this is mandatory, not "fallback":
 
@@ -472,10 +490,16 @@ Why this is mandatory, not "fallback":
   rate-limit budget and closes the whole class of false-
   positives.
 
-Walk all pages of `actions/runs` (or at least the first 3, which
-covers any reasonable repo-level backlog) and keep the union as
-a per-page index. Invalidate the index before fetching the next
-PR page — approval state changes fast.
+Walk **every** page of the filtered query and keep the union as
+the index. Do not cap the walk at the first few pages: the
+approval backlog on a busy repository is unbounded and ordered
+newest-first, so a truncated walk silently under-reports the
+oldest pending PRs — the ones most likely to be sitting in the
+queue waiting for exactly this. GitHub caps a listing at 1000
+results; if the run count reaches that cap, narrow with a
+`created:` window and union the slices rather than accepting the
+truncation. Invalidate the index before fetching the next PR
+page — approval state changes fast.
 
 The REST call is the primary signal. The rollup + "real CI
 pattern" guard from


### PR DESCRIPTION
`fetch-and-batch.md` builds the repo-wide `action_required` index from an
unfiltered `event=pull_request` listing, post-filtered on `conclusion` and
capped at the first three pages, justified by the claim that
`?status=action_required` *"matches no runs in this state and silently returns
an empty result"*.

The claim is incorrect, and the framework already contradicts itself —
`SKILL.md` Golden rule 1b uses `?status=action_required&head_sha=<SHA>`.

## Measured impact

Full triage sweep against a large adopter repo (2026-08):

| approach | pending head SHAs found |
|---|---|
| `?status=action_required`, paginated | **322** |
| documented 3-page `event=pull_request` post-filter | **9** |

`?status=action_required` reported 1109 matching runs. The 3-page window
reached back only ~12 hours, because that repo produces ~300 `pull_request`
runs in that time. Every PR in the ~313-SHA gap whose rollup was green from bot
checks alone (`Mergeable`, `WIP`, `DCO`) classified as `passing` and became a
`mark-ready` candidate — the precise false-positive class this index exists to
prevent, and the one Golden rule 1b is written to stop.

## Changes

- `fetch-and-batch.md`: filter server-side, walk every page, and note the
  1000-result listing cap with the `created:`-window workaround. The incorrect
  rationale is replaced with the measured one.
- `actions.md`: the two per-PR lookups are scoped to a single head SHA and were
  never affected by the truncation. Their code is unchanged; only the
  inaccurate claim in the comments is corrected, with a pointer to why the
  repo-wide case differs.

A `conclusion` post-filter over the *filtered* set is kept as belt-and-braces,
and stays correct for a host whose API build ignores `status`.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes — Claude Code (Opus 5)

Generated-by: Claude Code (Opus 5)
