### PR TITLE
infra(.asf.yaml): free the andreahlert collaborator slot

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -53,7 +53,6 @@ github:
   collaborators:
     # Non-ASF-members named in MISSION.md → "involved as
     # collaborators on the project from day one":
-    - andreahlert        # André Ahlert Junior
     - johnslavik         # Bartosz Sławecki
     # The four below are listed in MISSION.md's non-ASF-members
     # section but are already Apache Airflow committers, so they


### PR DESCRIPTION
## Summary

André Ahlert was voted in as a Magpie committer in August 2026 and has
accepted. Once he is in the `magpie` LDAP group he reaches `apache/magpie`
with write access through the apache GitHub org, which makes his
`collaborators:` entry redundant — that list only exists to grant triage
rights to people *outside* the org.

The list was at the ASF Infra cap of 10 entries, so dropping the redundant
one buys headroom for a genuine external triager later.

## Do not merge yet

This must not merge until `ahlert` actually appears in the `magpie` LDAP
group. Merging first would strip his triage rights with nothing replacing
them. As of opening this PR the group still shows 22 PMC members plus
`arnav`.

## Note for a follow-up

Eight further entries — `ppkarwasz`, `zeroshade`, `andrewmusselman`,
`justinmclean`, `jbonofre`, `paulk-asert`, `rusackas`, `russellspitzer` —
are PMC members who are all in the `magpie` LDAP group today, so their slots
look redundant on the same reasoning. Left alone here deliberately: it
depends on each of them having linked their GitHub ID at gitbox, which I
have not verified. Worth a separate check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
