### PR TITLE
fix(setup): ignore the snapshot symlink that worktree-init creates

### DIFF
--- a/docs/setup/install-recipes.md
+++ b/docs/setup/install-recipes.md
@@ -109,8 +109,10 @@ ln -sf ../../.agents/skills/magpie-setup .github/skills/magpie-setup
 cat >> .gitignore <<'GITIGNORE'
 
 # Magpie — gitignored snapshot of the framework, refreshed
-# by /magpie-setup upgrade. Build artefact, not source.
-/.apache-magpie/
+# by /magpie-setup upgrade. Build artefact, not source. No trailing
+# slash: worktree-init makes this a symlink to the main checkout's
+# snapshot, and a directory-only pattern would not match it.
+/.apache-magpie
 
 # Per-machine local-pin file. Records what THIS machine fetched and
 # when. Compared against the committed .apache-magpie.lock to

--- a/skills/setup/adopt.md
+++ b/skills/setup/adopt.md
@@ -580,10 +580,10 @@ idempotent — re-add them if they're missing.
 **Base entries — always needed**:
 
 ```text
-/.apache-magpie/
+/.apache-magpie
 /.apache-magpie.local.lock
 /.apache-magpie-local/
-/.apache-magpie-sources/
+/.apache-magpie-sources
 /.apache-magpie.sources.local.lock
 /.claude/settings.local.json
 /.claude/hooks/agent-guard.py
@@ -591,6 +591,17 @@ idempotent — re-add them if they're missing.
 __pycache__/
 *.pyc
 ```
+
+`/.apache-magpie` and `/.apache-magpie-sources` carry **no trailing
+slash** on purpose. In the main checkout both are directories, but
+[`worktree-init`](worktree-init.md#step-1--create-the-snapshot-symlink)
+replaces each with a **symlink** to the main checkout's copy so every
+worktree shares one framework state. A `dir/`-style pattern matches
+only directories, so a trailing slash would leave both entries
+untracked-but-not-ignored in every worktree — `git status` noise, and
+one `git add -A` away from committing a machine-local absolute-path
+symlink. Without the slash the pattern matches the directory, its
+contents, and the symlink alike, so the main checkout is unaffected.
 
 The `/.apache-magpie-sources/` and
 `/.apache-magpie.sources.local.lock` lines keep the gitignored

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -150,7 +150,9 @@ Check that the entries from
 [`adopt.md` Step 7](adopt.md) are present in
 `<repo-root>/.gitignore`. Required:
 
-- `/.apache-magpie/` (snapshot path)
+- `/.apache-magpie` (snapshot path — **no trailing slash**, so the
+  pattern also matches the symlink `worktree-init` puts there; a
+  `/.apache-magpie/` entry is a finding, not a pass)
 - `/.apache-magpie.local.lock` (per-machine state)
 - `/.claude/settings.local.json` (per-machine project-scope
   settings — written to by
@@ -177,8 +179,12 @@ variation):
   `.goose/skills/`, …) — the same two-line block keyed on its own
   dir.
 
-- ✗ if `/.apache-magpie/` is not gitignored — the snapshot
-  is at risk of being accidentally committed.
+- ✗ if `/.apache-magpie` is not gitignored — the snapshot
+  is at risk of being accidentally committed. Check this from a
+  **worktree** as well as the main checkout: a legacy
+  `/.apache-magpie/` entry passes in the main checkout (directory)
+  and fails in every worktree (symlink). Remediation is dropping the
+  trailing slash, not adding a second entry.
 - ✗ if `/.apache-magpie.local.lock` is not gitignored —
   per-machine state would leak into the repo.
 - ✗ if `/.claude/settings.local.json` is not gitignored —


### PR DESCRIPTION
## Summary

- `adopt` writes `/.apache-magpie/` and `/.apache-magpie-sources/` into the adopter's `.gitignore`. A `dir/`-style pattern matches only directories — but only the **main checkout** has directories there. `worktree-init` deliberately replaces both with **symlinks** to the main checkout's copies so every worktree shares one framework state and picks up `/magpie-setup upgrade` automatically.
- Net effect: both entries show as untracked in **every worktree of every adopter**. That is `git status` noise on its own, and one careless `git add -A` away from committing a symlink whose target is a machine-local absolute path.
- Dropping the trailing slash matches the directory, its contents, and the symlink alike, so the main checkout is unaffected. `verify` check 4 is updated to expect the unslashed form and to flag a legacy `/.apache-magpie/` entry as a finding.

## Type of change

- [X] Skill change (`.claude/skills/<name>/`) — eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [ ] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [X] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

Verified the pattern semantics directly in a scratch repo, with `/.apache-magpie` as the only ignore line:

```
dir  -> IGNORED      # main checkout
file -> IGNORED      # .apache-magpie/skills/a.md
link -> IGNORED      # worktree symlink
```

and confirmed the old `/.apache-magpie/` pattern reports the symlink as **not** ignored, reproducing the bug.

Also confirmed against a live adopter (`apache/airflow`, worktree off the main checkout): `git status` reported `?? .apache-magpie` before, and is clean after.

- [ ] `prek run --all-files` passes — **not run**; the pre-commit hooks ran on the changed files at commit time and passed, including `symlink-lint` and `skill-and-tool-validate`
- [ ] For Python packages touched: n/a — no Python changed
- [ ] For Groovy bridges touched: n/a
- [ ] For skill changes: eval suite passes for the affected skill — **n/a**, see below
- [ ] For skill *behaviour* changes: a new or updated eval fixture is included in this PR — **n/a**, see below
- [X] Other: no eval asserts the `.gitignore` entry list. `grep -rn '^/\.apache-magpie/$' tools/skill-evals/evals/` returns nothing, and `tools/skill-evals/evals/setup/` has no fixture mentioning `gitignore`, so there is no fixture to update and no existing eval this can regress. Happy to add a `setup` eval case pinning the entry list if you'd like the behaviour locked down.

## RFC-AI-0004 compliance

- [ ] **HITL** — no new mutation
- [ ] **Sandbox** — no change to host access
- [X] **Vendor neutrality** — the changed prose keeps the existing placeholders; no adopter-specific names introduced
- [ ] **Conversational + correctable** — no adopter-tunable behaviour added
- [ ] **Write-access discipline** — no outbound messages
- [ ] **Privacy LLM** — no content routed to an LLM

## Linked issues

None filed — found while adopting the framework in `apache/airflow`. The adopter-side `.gitignore` entry there is being fixed separately; this PR fixes the source that generates it for every adopter.

## Notes for reviewers (optional)

Two judgement calls worth a look:

1. **`/.claude/hooks/guards.d/` keeps its trailing slash.** `worktree-init` *copies* the guards rather than symlinking them, so it is a real directory in every worktree and the slash is correct there. Only the two entries `worktree-init` symlinks are changed.
2. **`verify` wording.** I made the legacy slashed form an explicit ✗ rather than silently accepting both, and noted that the check has to run from a worktree to see the failure at all — in the main checkout the old pattern passes, which is exactly why this went unnoticed.
