### PR TITLE
docs(contributing): require Groovy 4.x for the JIRA bridge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -456,7 +456,7 @@ invocation, after which HTTP and JSON are fast and stdlib-only.
 | [`tools/jira/bridge.groovy`](tools/jira/bridge.groovy) | Read-only JIRA REST bridge — `search <JQL>`, `issue <KEY>`, `projects`. Uses `@Grab` for HTTP deps, no separate install step. |
 | [`tools/dashboard-generator/reference.groovy`](tools/dashboard-generator/reference.groovy) | Reference impl of the issue-reassess-stats HTML dashboard. Reads `verdict.json` artefacts from a campaign directory and emits HTML. |
 
-Install Groovy 3.x or newer on `PATH` — `sdk install groovy` via
+Install Groovy 4.x or newer on `PATH` — `sdk install groovy` via
 [SDKMAN!](https://sdkman.io/) or your package manager. Then:
 
 ```bash


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` told contributors to install **Groovy 3.x or newer**, but the JIRA bridge cannot run on 3.x — it requires **Groovy 4.x**. This bumps the stated minimum to 4.x.
- Motivation: [`tools/jira/bridge.groovy`](../blob/main/tools/jira/bridge.groovy) line 4 uses `@Grab('org.apache.groovy:groovy-json:4.0.21')`. The `org.apache.groovy` group ID only exists from Groovy 4 onward (Groovy 3 published under `org.codehaus.groovy`), so the dependency does not resolve on a 3.x runtime.
- This aligns `CONTRIBUTING.md` with [`tools/jira/README.md`](../blob/main/tools/jira/README.md) (lines 56, 81–83), which already states the 4.x requirement and the reason. The dashboard generator runs on 3.0+, but since both tools share the same install line, 4.x is the correct minimum to state.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- [x] `prek run --all-files` passes (markdownlint, lychee link check, typos, SPDX — all green on the commit)
- Doc-only change; no code paths affected.

## RFC-AI-0004 compliance

- No principles touched (documentation-only change).

## Linked issues

Closes #1096

## Notes for reviewers (optional)

Scoped intentionally to the version bump only. A separate, unrelated Groovy scoping bug in `bridge.groovy` (top-level `def` config vars — `TRACKER_URL`, `API_TOKEN`, `AUTH_SCHEME` — are invisible to the `cmd_*` methods and raise `MissingPropertyException`) was noticed nearby and will be handled in its own issue/PR.
