### PR TITLE
fix(tools): scope bridge.groovy config vars with @Field

### DIFF
--- a/tools/jira/bridge.groovy
+++ b/tools/jira/bridge.groovy
@@ -4,6 +4,7 @@
 @Grab('org.apache.groovy:groovy-json:4.0.21')
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
+import groovy.transform.Field
 
 /**
  * JIRA REST bridge for the issue-* skill family.
@@ -37,11 +38,15 @@ import groovy.json.JsonSlurper
  * the calling skill — the bridge only executes confirmed actions.
  */
 
-def ENV = System.getenv()
-def TRACKER_URL  = ENV['ISSUE_TRACKER_URL'] ?: ''
-def PROJECT_KEY  = ENV['ISSUE_TRACKER_PROJECT'] ?: ''
-def API_TOKEN    = ENV['JIRA_API_TOKEN'] ?: ''
-def AUTH_SCHEME  = ENV['JIRA_AUTH_SCHEME'] ?: 'Basic'
+// These are @Field so the cmd_* methods and the httpGet/httpPost helpers
+// can see them. A bare top-level `def` in a Groovy script is a local of the
+// generated run() method and is NOT visible inside methods — referencing it
+// there throws MissingPropertyException.
+@Field Map ENV = System.getenv()
+@Field String TRACKER_URL  = ENV['ISSUE_TRACKER_URL'] ?: ''
+@Field String PROJECT_KEY  = ENV['ISSUE_TRACKER_PROJECT'] ?: ''
+@Field String API_TOKEN    = ENV['JIRA_API_TOKEN'] ?: ''
+@Field String AUTH_SCHEME  = ENV['JIRA_AUTH_SCHEME'] ?: 'Basic'
 
 if (!TRACKER_URL) {
     System.err.println('error: ISSUE_TRACKER_URL not set in the environment (the calling skill resolves it from <project-config>/issue-tracker-config.md and exports it)')


### PR DESCRIPTION
## Summary

- Every `bridge.groovy` subcommand threw `groovy.lang.MissingPropertyException: No such property: TRACKER_URL for class: bridge` before making any HTTP call.
- Root cause: the script-level config vars (`ENV`, `TRACKER_URL`, `API_TOKEN`, `AUTH_SCHEME`) were declared with a bare top-level `def`. In a Groovy script that makes them locals of the generated `run()` method, so the `cmd_*` methods and the `httpGet`/`httpPost` helpers — compiled onto the script class — cannot see them. The `if (!TRACKER_URL)` guard passed because it runs inside `run()`, masking the bug until a method was entered.
- Fix: annotate them with `@groovy.transform.Field` (via `import groovy.transform.Field`) so they become fields visible to every method. Added a short comment explaining the `@Field` requirement.

## Type of change

- [x] Groovy reference impl

## Test plan

- [x] `prek run --all-files` passes — including `pytest (workspace)`, which runs `tools/jira/tests/test_bridge_write.py` (the suite that was failing before this change).
- [x] For Groovy bridges touched: command-line invocation tested end-to-end — `groovy tools/jira/bridge.groovy search 'project = FOO'` now reaches the HTTP layer instead of throwing `MissingPropertyException`; the missing-`ISSUE_TRACKER_URL` guard still exits 2.

Before:

```
Caught: groovy.lang.MissingPropertyException: No such property: TRACKER_URL for class: bridge
	at bridge.cmd_search(bridge.groovy:182)
```

After: 28 passed in `tools/jira/tests/test_bridge_write.py`.

## RFC-AI-0004 compliance

- **Write-access discipline** — unchanged; the bridge still only executes confirmed mutations, this fix only makes existing config resolution work. No other principles touched.

## Linked issues

Closes #1098

## Notes for reviewers (optional)

- `PROJECT_KEY` is promoted to `@Field` too for consistency, though it is currently dead code (defined, never read) — no runtime impact either way.
- The other Groovy tool, `tools/dashboard-generator/reference.groovy`, is not affected: it defines no methods (linear script + closures, which capture the script scope) and reads no environment variables.
