### PR TITLE
docs(contributing): reconcile Agent harnesses with the reference runtimes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -363,18 +363,29 @@ validator + eval cases.
 
 ## Agent harnesses
 
-The framework's reference runtime today is **Claude Code** — skills
-are loaded from `skills/<name>/SKILL.md`, MCP servers from
-the user's Claude Code config, and the sandbox from
-`setup-isolated-setup-install`.
+The framework has two **reference implementations** today —
+[OpenCode](https://opencode.ai/), which is open source and
+model-agnostic (so it can drive every LLM backend), and
+[Claude Code](https://www.anthropic.com/claude-code), powered by
+Anthropic subscriptions. Both load skills from `skills/<name>/SKILL.md`
+(exposed to every harness through the committed `.agents/skills/`
+symlink tree), read MCP servers from the runtime's own config, and
+apply the sandbox from `setup-isolated-setup-install`. A third runtime,
+[OpenAI Codex](https://github.com/openai/codex), reads the
+`.agents/skills/` tree natively and ships an in-tree sandbox profile and
+HITL exec-policy rules; its adapter is **experimental** — see the
+[Codex runtime guide](docs/adapters/codex.md).
 
 RFC-AI-0004 §3 commits the framework to **vendor neutrality across
-LLM backends**. The current state per harness:
+LLM backends** — [`docs/prerequisites.md`](docs/prerequisites.md) and
+[`docs/vendor-neutrality.md`](docs/vendor-neutrality.md) carry the
+authoritative runtime matrix. The current state per harness:
 
 | Harness | State | Tracking |
 |---|---|---|
-| Claude Code | Primary, fully supported | — |
-| Codex CLI | Partial — Claude Code plugin delegates rescue + adversarial-review subtasks to Codex | First-class runtime tracked at [#313](https://github.com/apache/magpie/issues/313) |
+| OpenCode | Reference implementation, fully supported | — |
+| Claude Code | Reference implementation, fully supported | — |
+| Codex CLI | Experimental first-class adapter — reads `.agents/skills/` natively, ships in-tree sandbox + HITL rules | [#313](https://github.com/apache/magpie/issues/313) |
 | Gemini CLI | Not yet ported | [#314](https://github.com/apache/magpie/issues/314) |
 | Local LLM (Ollama / llama.cpp / vLLM) | Not yet ported | [#315](https://github.com/apache/magpie/issues/315) |
 | Cursor (Composer + Agent CLI) | Not yet ported | [#316](https://github.com/apache/magpie/issues/316) |
@@ -385,7 +396,7 @@ LLM backends**. The current state per harness:
 | JetBrains Junie | Not yet ported | [#321](https://github.com/apache/magpie/issues/321) |
 | OpenHands | Not yet ported | [#322](https://github.com/apache/magpie/issues/322) |
 
-MCP servers used by the Claude Code runtime today: Slack, Gmail,
+MCP servers used by the reference runtimes today: Slack, Gmail,
 Google Calendar, Google Drive, plus framework-internal ones for
 the ponymail / incubator-mail / incubator-reports surfaces. MCP-
 compatible harnesses (Gemini CLI, Goose, Copilot CLI) should pick


### PR DESCRIPTION
## Summary

- The `## Agent harnesses` section of `CONTRIBUTING.md` named **Claude Code** as the framework's sole reference runtime and did not mention **OpenCode** at all, contradicting [`docs/prerequisites.md`](../blob/main/docs/prerequisites.md) (OpenCode = reference implementation) and [`docs/vendor-neutrality.md`](../blob/main/docs/vendor-neutrality.md) (Claude Code; OpenCode; Codex experimental).
- The section was last touched 2026-05-26 (#323), predating the vendor-neutrality work — OpenCode as a reference implementation and the first-class Codex adapter both landed later (#902). It was simply left behind.
- Reframed to **two reference implementations** — OpenCode (open source, model-agnostic) and Claude Code (Anthropic-powered) — with **Codex** as an experimental first-class adapter. Deliberately uses the softer, co-reference wording (consistent with the `vendor-neutrality.md` matrix) rather than crowning a single "the reference implementation". Added links to the two authoritative docs so the three don't redivergence.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- [x] `prek run --files CONTRIBUTING.md` passes (markdownlint, typos, lychee link check, SPDX, doctoc — all green). The section anchor is unchanged, so the TOC is unaffected.
- Doc-only change; no code paths affected.

## RFC-AI-0004 compliance

- **Vendor neutrality** — this change *improves* alignment with RFC-AI-0004 §3 by removing the single-vendor "reference runtime" framing and pointing at the authoritative runtime matrix. No other principles touched.

## Linked issues

Closes #1100

## Notes for reviewers (optional)

Governance call to confirm: `prerequisites.md` says OpenCode is *"the"* reference implementation, while `vendor-neutrality.md` lists Claude Code and OpenCode side by side. This PR follows the softer `vendor-neutrality.md` framing (co-reference). If the PMC prefers the stronger "OpenCode is the reference implementation" wording, the opening sentence and the table's two `Reference implementation` rows are the only lines to adjust — happy to change it.

The path phrasing was also corrected: skills are authored under `skills/<name>/SKILL.md` and exposed to every harness through the committed `.agents/skills/` symlink tree (per AGENTS.md) — `CONTRIBUTING.md` previously described only the Claude-Code view.
