### PR TITLE
docs(mode-economics): add contributor-growth skills to the token tables

### DIFF
--- a/docs/mode-economics.md
+++ b/docs/mode-economics.md
@@ -15,6 +15,7 @@
     - [Drafting](#drafting)
     - [Pairing](#pairing)
     - [Agentic Autonomous](#agentic-autonomous)
+    - [Meta](#meta)
   - [Model class and mode cost shape](#model-class-and-mode-cost-shape)
   - [Local and self-hosted inference](#local-and-self-hosted-inference)
   - [Reducing costs](#reducing-costs)
@@ -114,6 +115,9 @@ to input.
 | `security-issue-invalidate` | Single invalid close | 8K–20K | Report length + reply draft |
 | `security-issue-sync` | Full tracker reconciliation | 20K–100K | Tracker age, mail-thread depth, linked PRs |
 | `security-cve-allocate` | CVE allocation workflow | 5K–12K | Mostly procedural; low variance |
+| `contributor-activity-sweep` | Single-contributor activity card | 10K–40K | Activity volume in the configured window |
+| `contributor-sentiment` | Full sentiment gate report | 20K–80K | Number of threads and signals sampled |
+| `contributor-nomination` | Nomination-readiness brief | 15K–50K | Contributor activity breadth read |
 
 **Rule of thumb for Agentic Triage:** budget 10K–30K tokens per
 PR / issue / report on average. A project processing 50 inbound items
@@ -178,6 +182,19 @@ the same PR: 45K–90K tokens.
 
 **Status: off.** Agentic Autonomous is not implemented; it has no token cost.
 See [`docs/modes.md` § Agentic Autonomous](modes.md#agentic-autonomous).
+
+### Meta
+
+The **Meta** mode is mostly framework machinery — setup, utilities,
+dashboards — whose cost is per machine or per repo rather than per
+maintainership item, so it is not budgeted per invocation here (see
+[`docs/modes.md` § Meta](modes.md#meta)). The exception with a
+recurring per-item shape is `committer-onboarding`, which runs once
+per new committer or PMC member:
+
+| Skill | Typical invocation | Token range | Primary cost driver |
+|---|---|---|---|
+| `committer-onboarding` | One post-vote onboarding walkthrough | 10K–30K | Mostly procedural; podling vs TLP path length |
 
 ---
 


### PR DESCRIPTION
## Summary

- Follow-up to the review on
  [apache/magpie#1079](https://github.com/apache/magpie/pull/1079), which
  recorded that four shipped `family: contributor-growth` skills appeared
  nowhere in `docs/mode-economics.md`.
- Add `contributor-activity-sweep`, `contributor-sentiment`, and
  `contributor-nomination` to the Triage table — Triage is their mode per
  `docs/modes.md` (heeding that review's note: the page's sections are modes,
  not families).
- Add a short **Meta** subsection for `committer-onboarding` (`mode: Meta`),
  since the page had no section for Meta-mode skills. The subsection states
  why the rest of Meta (setup, utilities, dashboards) is not budgeted
  per-invocation: their cost is per machine or per repo, not per
  maintainership item.
- Ranges follow the page's existing indicative convention, anchored on
  analogous rows and each skill's own SKILL.md size.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- [x] `prek run --files docs/mode-economics.md` passes (doctoc TOC
      regenerated for the new Meta heading; markdownlint, typos, lychee all
      green)
- Docs-only change. Mode placement cross-checked against `docs/modes.md`
  (three skills listed under § Triage, `committer-onboarding` under § Meta).

## RFC-AI-0004 compliance

Docs-only; no principles touched.

## Linked issues

Refs [apache/magpie#1079](https://github.com/apache/magpie/pull/1079)
(review follow-up; no tracking issue exists).

## Notes for reviewers

`contributor-sentiment` (20K–80K) is the widest new range: the gate report
samples a configurable set of threads, so the upper end assumes a
two-quarter advancement review. Happy to tighten if there is measured data.
