### PR TITLE
refactor(bitbucket): centralize Data Center pagination guard

### DIFF
--- a/tools/bitbucket/src/magpie_bitbucket/datacenter.py
+++ b/tools/bitbucket/src/magpie_bitbucket/datacenter.py
@@ -30,6 +30,26 @@ def _api_base(config: BitbucketConfig) -> str:
     return f"{base_url}/rest/api/1.0"
 
 
+def _next_page_start(page: dict[str, Any], start: int) -> int | None:
+    """Return the validated next page offset, or None when pagination must stop.
+
+    A server that reports a missing, malformed, or non-advancing
+    ``nextPageStart`` would otherwise keep the caller requesting the same
+    page forever; every Data Center paginator routes through this guard.
+    """
+    if page.get("isLastPage") is True:
+        return None
+
+    next_start = page.get("nextPageStart")
+    if not isinstance(next_start, int):
+        return None
+
+    if next_start <= start:
+        return None
+
+    return next_start
+
+
 def get_repository(config: BitbucketConfig) -> dict[str, Any]:
     """Fetch repository metadata from Bitbucket Data Center."""
     project_key = quote_path(require(config.project_key, "BITBUCKET_PROJECT_KEY"))
@@ -64,14 +84,8 @@ def get_repository_restrictions(config: BitbucketConfig) -> dict[str, Any]:
         if isinstance(values, list):
             combined["values"].extend(item for item in values if isinstance(item, dict))
 
-        if page.get("isLastPage") is True:
-            break
-
-        next_start = page.get("nextPageStart")
-        if not isinstance(next_start, int):
-            break
-
-        if next_start <= start:
+        next_start = _next_page_start(page, start)
+        if next_start is None:
             break
 
         start = next_start
@@ -144,14 +158,8 @@ def list_open_pull_requests(config: BitbucketConfig) -> dict[str, Any]:
         if isinstance(values, list):
             combined["values"].extend(item for item in values if isinstance(item, dict))
 
-        if page.get("isLastPage") is True:
-            break
-
-        next_start = page.get("nextPageStart")
-        if not isinstance(next_start, int):
-            break
-
-        if next_start <= start:
+        next_start = _next_page_start(page, start)
+        if next_start is None:
             break
 
         start = next_start
@@ -191,14 +199,8 @@ def get_pull_request_commits(config: BitbucketConfig, pull_request_id: str) -> d
         if isinstance(values, list):
             combined["values"].extend(item for item in values if isinstance(item, dict))
 
-        if page.get("isLastPage") is True:
-            break
-
-        next_start = page.get("nextPageStart")
-        if not isinstance(next_start, int):
-            break
-
-        if next_start <= start:
+        next_start = _next_page_start(page, start)
+        if next_start is None:
             break
 
         start = next_start
@@ -298,14 +300,8 @@ def get_pull_request_status(config: BitbucketConfig, pull_request_id: str) -> di
         if isinstance(values, list):
             combined["values"].extend(item for item in values if isinstance(item, dict))
 
-        if page.get("isLastPage") is True:
-            break
-
-        next_start = page.get("nextPageStart")
-        if not isinstance(next_start, int):
-            break
-
-        if next_start <= start:
+        next_start = _next_page_start(page, start)
+        if next_start is None:
             break
 
         start = next_start
@@ -341,14 +337,8 @@ def get_pull_request_reviews(config: BitbucketConfig, pull_request_id: str) -> d
         if isinstance(values, list):
             combined["values"].extend(item for item in values if isinstance(item, dict))
 
-        if page.get("isLastPage") is True:
-            break
-
-        next_start = page.get("nextPageStart")
-        if not isinstance(next_start, int):
-            break
-
-        if next_start <= start:
+        next_start = _next_page_start(page, start)
+        if next_start is None:
             break
 
         start = next_start
@@ -397,14 +387,8 @@ def get_pull_request_discussion(config: BitbucketConfig, pull_request_id: str) -
         if isinstance(values, list):
             combined["values"].extend(item for item in values if isinstance(item, dict))
 
-        if page.get("isLastPage") is True:
-            break
-
-        next_start = page.get("nextPageStart")
-        if not isinstance(next_start, int):
-            break
-
-        if next_start <= start:
+        next_start = _next_page_start(page, start)
+        if next_start is None:
             break
 
         start = next_start

--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -1000,12 +1000,12 @@ _DATACENTER_PR_PAGE = {"id": 9, "fromRef": {"latestCommit": "def456"}}
     ("paginate", "leading_pages"),
     [
         pytest.param(
-            lambda config: datacenter.get_repository_restrictions(config),
+            datacenter.get_repository_restrictions,
             (),
             id="repository_restrictions",
         ),
         pytest.param(
-            lambda config: datacenter.list_open_pull_requests(config),
+            datacenter.list_open_pull_requests,
             (),
             id="open_pull_requests",
         ),

--- a/tools/bitbucket/tests/test_bitbucket.py
+++ b/tools/bitbucket/tests/test_bitbucket.py
@@ -992,6 +992,78 @@ def test_datacenter_get_pull_request_commits_stops_on_non_advancing_next_page_st
     assert [item["id"] for item in result["values"]] == ["abc123"]
 
 
+_DATACENTER_PR_PAGE = {"id": 9, "fromRef": {"latestCommit": "def456"}}
+
+
+@patch("urllib.request.build_opener")
+@pytest.mark.parametrize(
+    ("paginate", "leading_pages"),
+    [
+        pytest.param(
+            lambda config: datacenter.get_repository_restrictions(config),
+            (),
+            id="repository_restrictions",
+        ),
+        pytest.param(
+            lambda config: datacenter.list_open_pull_requests(config),
+            (),
+            id="open_pull_requests",
+        ),
+        pytest.param(
+            lambda config: datacenter.get_pull_request_commits(config, "9"),
+            (),
+            id="pull_request_commits",
+        ),
+        pytest.param(
+            lambda config: datacenter.get_pull_request_status(config, "9"),
+            (_DATACENTER_PR_PAGE,),
+            id="pull_request_status",
+        ),
+        pytest.param(
+            lambda config: datacenter.get_pull_request_reviews(config, "9"),
+            (_DATACENTER_PR_PAGE,),
+            id="pull_request_reviews",
+        ),
+        pytest.param(
+            lambda config: datacenter.get_pull_request_discussion(config, "9"),
+            (),
+            id="pull_request_discussion",
+        ),
+    ],
+)
+def test_datacenter_paginators_stop_on_non_advancing_next_page_start(
+    mock_build_opener: MagicMock,
+    paginate: Any,
+    leading_pages: tuple[dict[str, Any], ...],
+    datacenter_env: None,
+) -> None:
+    opener = mock_opener(
+        mock_build_opener,
+        *leading_pages,
+        {"values": [{"id": "abc123"}], "isLastPage": False, "nextPageStart": 0},
+    )
+
+    result = paginate(load_config())
+
+    assert len(opener.open.call_args_list) == len(leading_pages) + 1
+    assert [item["id"] for item in result["values"]] == ["abc123"]
+
+
+@pytest.mark.parametrize(
+    ("page", "start", "expected"),
+    [
+        pytest.param({"isLastPage": True, "nextPageStart": 25}, 0, None, id="last_page"),
+        pytest.param({"isLastPage": False}, 0, None, id="missing_next_page_start"),
+        pytest.param({"isLastPage": False, "nextPageStart": "25"}, 0, None, id="non_int_next_page_start"),
+        pytest.param({"isLastPage": False, "nextPageStart": 0}, 0, None, id="repeated_next_page_start"),
+        pytest.param({"isLastPage": False, "nextPageStart": 5}, 10, None, id="backwards_next_page_start"),
+        pytest.param({"isLastPage": False, "nextPageStart": 25}, 0, 25, id="advancing_next_page_start"),
+    ],
+)
+def test_datacenter_next_page_start(page: dict[str, Any], start: int, expected: int | None) -> None:
+    assert datacenter._next_page_start(page, start) == expected
+
+
 def test_normalize_cloud_pull_request_commits() -> None:
     raw = {
         "pull_request_id": "7",


### PR DESCRIPTION
## Summary

- `datacenter.py` repeated the same non-advancing-pagination guard
  (`next_start <= start` plus the `isLastPage` / non-int checks) in six
  paginators, and coverage was uneven: the issue demonstrated that deleting
  the `get_repository_restrictions` copy left the whole suite green.
- Hoist the guard into a single `_next_page_start()` helper, mirroring the
  `_validated_next_url()` single-helper pattern `cloud.py` already uses.
  Behaviour is unchanged — the helper preserves the three stop conditions
  exactly as they were.
- Pin the behaviour twice: unit tests on the helper's stop conditions
  (last page, missing / non-int / repeated / backwards / advancing
  `nextPageStart`), and a parameterized regression test that drives all six
  paginators against a non-advancing server response — so removing the guard
  wiring from any one of them now fails the suite.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)

## Test plan

- [x] New paginator pins run green on the pre-refactor code (they photograph
      existing behaviour), and the helper unit tests go red → green across
      the refactor.
- [x] Full module suite: 127 passed; `ruff check`, `mypy`, and the prek
      workspace hooks (ruff / mypy / pytest) all green.
- [x] Existing regression tests from
      [apache/magpie#1047](https://github.com/apache/magpie/pull/1047) and
      [apache/magpie#766](https://github.com/apache/magpie/pull/766) are
      untouched and still pass.

## RFC-AI-0004 compliance

No new network reach, credentials, or mutations; URL construction,
authentication, and response handling are unchanged.

## Linked issues

Closes [apache/magpie#1052](https://github.com/apache/magpie/issues/1052)

## Notes for reviewers

- The pre-existing quirk that `bool` passes the `isinstance(next_start, int)`
  check is deliberately preserved — this PR changes structure, not
  behaviour.
- @KatalKavya96 had expressed interest in this issue (and authored the
  existing discussion-paginator pin in
  [apache/magpie#766](https://github.com/apache/magpie/pull/766), which this
  change keeps green). Happy to defer or split credit if a PR of theirs is
  in flight — none was visible after 17 days, so this picks the issue up.
