### PR TITLE
fix(marketplace): sync magpie-utilities plugin with report-framework-issue skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -70,7 +70,7 @@
       "name": "magpie-utilities",
       "source": "./plugins/magpie-utilities",
       "version": "0.2.0.dev0",
-      "description": "Apache Magpie utilities family (4 skills)."
+      "description": "Apache Magpie utilities family (5 skills)."
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ means and which modes are still proposed vs. shipping today.
 | Family | Type | Modes | Purpose | Detail |
 |---|---|---|---|---|
 | [**setup**](docs/setup/README.md) | always-on | (infra) | Isolated agent setup, framework install + maintenance, shared-config sync. The prerequisite — at minimum the `setup` skill itself runs out of this family. | 9 skills, [`docs/setup/`](docs/setup/) |
-| **utilities** | always-on | (meta) | Framework meta-skills: author skills (`write-skill`), restructure them (`optimize-skill`), reconcile skill state (`skill-reconciler`), and print a live index (`list-skills`). | 4 skills |
+| **utilities** | always-on | (meta) | Framework meta-skills: author skills (`write-skill`), restructure them (`optimize-skill`), reconcile skill state (`skill-reconciler`), report framework issues (`report-framework-issue`), and print a live index (`list-skills`). | 5 skills |
 | [**security**](docs/security/README.md) | opt-in | Triage, Drafting | 16-step security-issue handling lifecycle — from `security@` import through CVE publication, including state sync. Maintainer-only. | 12 skills, [`docs/security/`](docs/security/) |
 | [**pr-management**](docs/pr-management/README.md) | opt-in | Triage | Maintainer-facing PR-queue management — triage, stats, deep code review, express-lane merge, stale-sweep, reviewer routing, and pre-first-PR checks. | 8 skills, [`docs/pr-management/`](docs/pr-management/README.md) |
 | [**issue**](docs/issue-management/README.md) | opt-in | Triage, Drafting | General-issue lifecycle: triage, reproduction, fix drafting, reassess, stale-sweep, deduplication, and backlog reporting. | 8 skills, [`docs/issue-management/`](docs/issue-management/README.md) |

--- a/docs/setup/marketplaces.md
+++ b/docs/setup/marketplaces.md
@@ -34,7 +34,7 @@ through the plugin/extension mechanisms of the major AI coding agents,
 
 > [!IMPORTANT]
 > The marketplace path is a **discovery and trial** channel: it drops the
-> 70 skills into your agent so you can use them immediately. It does **not**
+> 71 skills into your agent so you can use them immediately. It does **not**
 > set up the full adoption machinery (the committed pin, the gitignored
 > snapshot, drift detection, agentic overrides, or the secure-agent setup).
 > For a project that adopts Magpie for real, use `/magpie-setup` — the
@@ -114,7 +114,7 @@ the model on **every** turn — see ["always-on" cost](#versioning) below).
 
 **All-in-one — `magpie`**
 
-- ✅ One install; all 70 skills; nothing to decide. Uses the real `skills/`
+- ✅ One install; all 71 skills; nothing to decide. Uses the real `skills/`
   directory, so **no symlinks** — works on Windows out of the box.
 - ⚠️ Adds **~21.7k always-on tokens to every session**, including families you
   may never use — that context (and cost) is spent whether or not you invoke a
@@ -324,7 +324,7 @@ as an AP1 package. Two ways in:
    the coding-agent settings) and install `magpie` from it. That path reads the
    root [`marketplace.json`](../../marketplace.json).
 
-Either way the 70 skills become available to the agent under the plugin. As
+Either way the 71 skills become available to the agent under the plugin. As
 with Codex, only the **all-in-one** `magpie` plugin is offered — the per-family
 plugins are Claude Code-only, for the reason recorded
 [above](#choosing-a-plugin-all-in-one-vs-per-family).

--- a/plugins/magpie-utilities/skills/report-framework-issue
+++ b/plugins/magpie-utilities/skills/report-framework-issue
@@ -1,0 +1,1 @@
+../../../skills/report-framework-issue


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- `main` is red: the `check-family-plugins` prek hook fails with
  `magpie-utilities: missing symlink for 'report-framework-issue'
  (family=utilities)`, and every PR built against `main` inherits the
  failure (e.g. the [prek run on main](https://github.com/apache/magpie/actions/runs/32178573003)).
- Cause is a semantic conflict between two PRs that were each green on
  their own: [apache/magpie#922](https://github.com/apache/magpie/pull/922)
  added the `report-framework-issue` skill with `family: utilities`
  *before* the hook existed, while
  [apache/magpie#907](https://github.com/apache/magpie/pull/907)
  generated the family plugins (and introduced the hook) from a branch
  that predated #922's merge — so the generated `magpie-utilities`
  plugin never picked up the new skill.
- Fix is the checker's own remediation: `python3
  tools/dev/check-family-plugins.py --fix`. Output is exactly two
  changes — the `plugins/magpie-utilities/skills/report-framework-issue`
  symlink and the marketplace entry bumped from "4 skills" to
  "5 skills". No hand-written changes.

## Type of change

- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] `prek run --all-files` passes
- [x] `python3 tools/dev/check-family-plugins.py` exits 1 on `main`
      before the change and 0 after regeneration
- [x] `symlink-lint` and `check-family-plugins` hooks both green on the
      regenerated tree; the new symlink resolves
      (`plugins/magpie-utilities/skills/report-framework-issue →
      ../../../skills/report-framework-issue`, same relative shape as
      its siblings)

## RFC-AI-0004 compliance

Generated-artefact sync only; no new mutations, network reach, or
skill/tool prose. No principles touched.

## Linked issues

Follow-up to [apache/magpie#922](https://github.com/apache/magpie/pull/922)
and [apache/magpie#907](https://github.com/apache/magpie/pull/907).

## Notes for reviewers

- Deliberately **not** included (stale but non-blocking, happy to do a
  follow-up or fold in here if preferred): the README utilities row
  still says "4 skills" and lists only the four original meta-skills,
  and `docs/setup/marketplaces.md` says "70 skills" in three places
  while `skills/` now holds 71. `docs/rfcs/RFC-AI-0007.md` also says
  "~3 MB across 70 skills" but reads as a historical snapshot, so I
  left it alone.
