### PR TITLE
docs(spec-loop): align reviewer-routing coverage claim

### DIFF
--- a/tools/spec-loop/specs/reviewer-routing.md
+++ b/tools/spec-loop/specs/reviewer-routing.md
@@ -120,7 +120,8 @@ uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/reviewer-r
 - **Non-ASF roster shape is now exercised.** `projects/non-asf-example/reviewer-roster.md`
   provides a Velox Stream roster with no ASF-specific fields; the
   `non-asf-profile-smoke/step-reviewer-routing/` eval suite asserts that
-  area-match routing and load-aware fallback both work under the
+  area-match routing selects a primary reviewer and that a no-area-match case
+  returns `NO ELIGIBLE REVIEWER` without proposing a fallback under the
   `organization: independent` profile. Gap cleared.
 - **`experimental` — no adopter pilot has run.** The skill ships but no
   end-to-end routing workflow has been exercised in a live maintainer


### PR DESCRIPTION
## Summary

- Correct the non-ASF reviewer-routing coverage statement in `tools/spec-loop/specs/reviewer-routing.md`.
- Describe the behavior actually asserted by the fixtures: area-match routing selects a primary reviewer, while no-area-match returns `NO ELIGIBLE REVIEWER` without proposing a fallback.
- Leave the skill implementation and all eval fixtures unchanged.

## Validation

- `uv run --project tools/spec-validator spec-validate tools/spec-loop/specs/`
- `uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/non-asf-profile-smoke/step-reviewer-routing/fixtures/`
- `uv run prek run --all-files`
- `git diff --check`

All checks passed, including spec validation, the focused reviewer-routing eval, lychee, markdownlint, skill-and-tool validation, and the repository test suite.

## Known limitations

- Documentation-only change; it does not add or change load-aware fallback behavior.
- The upstream Issue could not be assigned to this contributor because the account has fork/pull permissions but not issue-assignment permissions.

## Generative AI disclosure

This PR was prepared with AI assistance and reviewed against the repository source-of-truth fixture and validation commands. The commit carries the required `Generated-by: Codex (GPT-5)` trailer.

Closes #999
