### PR TITLE
ci(ruff): reformat Python snippets in three skill markdown files

### DIFF
--- a/skills/contributor-nomination/fetch.md
+++ b/skills/contributor-nomination/fetch.md
@@ -199,7 +199,7 @@ calendar month to feed the activity timeline in
 ```python
 # Pseudocode — implement via jq or Python as convenient
 for event in all_events:
-    month = event["createdAt"][:7]   # "YYYY-MM"
+    month = event["createdAt"][:7]  # "YYYY-MM"
     buckets[month] += 1
 ```
 

--- a/skills/contributor-sentiment/SKILL.md
+++ b/skills/contributor-sentiment/SKILL.md
@@ -214,7 +214,7 @@ Aggregate counts per login. Compute Gini as:
 ```python
 sorted = sorted(counts)
 n = len(sorted)
-gini = (2 * sum((i+1)*v for i,v in enumerate(sorted)) / (n * sum(sorted))) - (n+1)/n
+gini = (2 * sum((i + 1) * v for i, v in enumerate(sorted)) / (n * sum(sorted))) - (n + 1) / n
 ```
 
 Clamp to [0, 1]. If reviewer_count < 2, set `reviewer_load_gini: null`

--- a/skills/issue-reproducer/verification.md
+++ b/skills/issue-reproducer/verification.md
@@ -57,7 +57,7 @@ substring matching near common prefixes.
 **Bad:**
 
 ```python
-if "xs" in output:                       # matches xsi too
+if "xs" in output:  # matches xsi too
     classified = "still-fails-same"
 ```
 
@@ -73,7 +73,8 @@ if (output.contains("foo")) {            // matches foo-bar, foobar
 
 ```python
 import re
-if re.search(r'\bxs="[^"]*"', output):   # match only xs= attribute
+
+if re.search(r'\bxs="[^"]*"', output):  # match only xs= attribute
     classified = "still-fails-same"
 ```
 


### PR DESCRIPTION
## Summary

- `ruff format --check` currently fails on `main`, which breaks the required
  `prek` status on every open PR — including unrelated ones (spotted on #1116,
  an `.asf.yaml`-only change).
- Three fenced `` ```python `` blocks inside skill docs predate the ruff 0.16.1
  bump in 5b504d85 and no longer match the formatter:
  `skills/contributor-nomination/fetch.md:202`,
  `skills/contributor-sentiment/SKILL.md:217`,
  `skills/issue-reproducer/verification.md:60`.
- This applies exactly what `ruff format` produces and nothing else: comment
  gaps normalised to two spaces, binary operators spaced, and a blank line
  after an `import re`. No snippet changes behaviour or meaning.

## Type of change

- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] `uv run ruff format --check skills/` → `143 files already formatted`
- [x] `prek run --files <the three files>` passes every applicable hook
      (markdownlint, lychee, check-placeholders, skill-and-tool-validate included)
- Diff is formatter output only; no skill behaviour is touched, so no eval
  fixture changes apply.

## RFC-AI-0004 compliance

Not applicable — whitespace-only changes to documentation snippets.

## Linked issues

Refs #1116 (blocked by this failure).

## Notes for reviewers

In `issue-reproducer/verification.md` the reformatted "Bad" Python block now
sits next to an unchanged Java block that still uses wide comment alignment —
ruff doesn't touch Java. The visual asymmetry is cosmetic; aligning the Java
snippet by hand seemed worse than leaving the formatter as the single source
of truth.
