### PR TITLE
fix(pr-management-triage): one violation bullet per category, not per check

### DIFF
--- a/skills/pr-management-triage/comment-templates.md
+++ b/skills/pr-management-triage/comment-templates.md
@@ -887,25 +887,42 @@ bad-faith actor a footnote to argue with.
 ## Violations rendering
 
 `<violations>` in the templates above expands to a bullet list,
-one bullet per violation returned by the classifier. Each
+**one bullet per category** — not one per failing check. Each
 bullet has the form:
 
 ```markdown
-- :x: **<category>** — <explanation>. See [docs](<doc_link>).
+- :x: **<category>**. See [docs](<doc_link>).
+```
+
+or, when a short payload carries signal the contributor cannot
+see at a glance:
+
+```markdown
+- :x: **<category>**: <short payload>. See [docs](<doc_link>).
 ```
 
 - `:x:` for severity `error`, `:warning:` for severity `warning`.
 - `<category>` — short category name, e.g.
   `Merge conflicts`, `mypy (type checking)`,
   `Unresolved review comments`.
-- `<explanation>` — one short clause stating what's wrong
-  (e.g. *"Failing: mypy-core, mypy-providers"*).
+- `<short payload>` — **optional**, one short clause carrying a
+  number or fact the category name does not already convey
+  (e.g. *"3 thread(s)"*, *"behind by 42 commits"*). Omit it
+  whenever the category alone says everything.
 - `<doc_link>` — link to the canonical doc that explains how to
-  fix this category. Do **not** inline project-specific
-  commands or step-by-step remediation prose in the bullet —
-  the linked doc has them. Keep the bullet to one line.
+  fix this category.
 
-The category / explanation / doc-link triples come from
+**Never enumerate individual failing check names**, and never
+inline project-specific commands or step-by-step remediation
+prose — GitHub's Checks tab already lists the failing jobs and
+the linked doc already has the steps. Repeating them costs more
+in comment length than it adds in signal, and a comment that
+runs long is a comment contributors stop reading. Several
+failing checks in the same category still produce exactly one
+bullet; violations in different categories produce one bullet
+each. Keep every bullet to one line.
+
+The category / payload / doc-link triples come from
 `assess_pr_checks` / `assess_pr_conflicts` /
 `assess_pr_unresolved_comments`-equivalent logic — this skill
 reproduces those deterministic assessments without the LLM


### PR DESCRIPTION
## Summary

- `<violations>` rendering now emits **one bullet per category** instead of one per failing check, and the mandatory `<explanation>` clause becomes an optional `<short payload>`.
- The "no inline commands or remediation prose" rule, previously buried inside the `<doc_link>` bullet, is promoted to its own paragraph next to the new "never enumerate check names" rule.

## Motivation

The contract's model example was `- :x: **<category>** — Failing: mypy-core, mypy-providers.`, which invites the skill to name every failing job. On a PR failing a dozen jobs in one category, that yields a bullet listing all of them.

GitHub's Checks tab already shows the failing jobs and their re-run controls, so the enumeration adds comment length without adding signal — and a triage comment that runs long is one contributors stop reading, which is exactly the outcome the skill exists to prevent.

Apache Airflow has run this rule as a local override since adoption (`.apache-magpie-overrides/pr-management-triage-comment-templates.md` § "Violations bullet format"). Nothing in it is Airflow-specific, so it belongs in the framework default.

The optional payload keeps the cases where a number *is* the point — unresolved thread count, commits behind — and cannot be read off the PR at a glance.

## Migration path for existing adopters

No new config knob and no opt-out: this is a refactor of an existing step's contract. Adopters get shorter triage bullets on their next `/magpie-setup upgrade`. An adopter who genuinely wants job names enumerated can still add a body override in `<project-config>/pr-management-triage-comment-templates.md`.

## Test plan

- `prek run --files skills/pr-management-triage/comment-templates.md` — all hooks pass (markdownlint, lychee, check-placeholders, skill-and-tool-validate).
- Confirmed no other file under `skills/`, `projects/` or `docs/` references the removed `<explanation>` placeholder.

---
Drafted-by: Claude Code (Claude Opus 5); reviewed by @potiuk before posting
