### PR TITLE
fix(agent-isolation): don't replace the caller's shell when agent-iso.sh is sourced

### DIFF
--- a/tools/agent-isolation/agent-iso.sh
+++ b/tools/agent-isolation/agent-iso.sh
@@ -290,6 +290,18 @@ agent_iso_run() {
     printf '[%s-iso] running in isolated env (%s)\n' "$agent" "$agent_bin" >&2
   fi
 
+  # `exec` replaces the current process with the agent. That is right when
+  # this script was *executed* (one less process, and the agent inherits the
+  # caller's exit-status slot) but wrong when it was *sourced*: there the
+  # current process is the user's own interactive shell, so `exec` would
+  # replace it — quitting the agent would close the terminal — and a failed
+  # exec (lost permission bit, bad interpreter, binary replaced mid-upgrade)
+  # would take the shell down with it. In sourced mode run the agent as a
+  # child and hand its exit status back to the shell instead.
+  if [[ -n "${_AGENT_ISO_SOURCED-}" ]]; then
+    env -i "${env_args[@]}" "$agent_bin" "$@"
+    return $?
+  fi
   exec env -i "${env_args[@]}" "$agent_bin" "$@"
 }
 
@@ -311,6 +323,11 @@ claude_iso_main() { agent_iso_run "${AGENT_ISO_AGENT:-claude}" "$@"; }
 #   `--settings` sandbox allowRead injection is skipped (it is Claude-specific
 #   and already guarded by `if [[ "$agent" == "claude" ]]`).
 if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  # Sourced: every entry point below runs inside the user's interactive
+  # shell, so nothing on this path may `exec` or `exit` — both would take
+  # the shell with them. The flag tells `agent_iso_run` to launch the agent
+  # as a child and `return`; the guards below use `return`, never `exit`.
+  _AGENT_ISO_SOURCED=1
   claude-iso()   { agent_iso_run claude "$@"; }
   opencode-iso() { agent_iso_run opencode "$@"; }
   kiro-iso()     { agent_iso_run kiro "$@"; }
@@ -325,6 +342,9 @@ if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
     agent_iso_run "$@"
   }
 else
+  # Executed directly: this process exists only to become the agent, so the
+  # `exec` in `agent_iso_run` and the `exit`s below are the correct exits.
+  _AGENT_ISO_SOURCED=
   _aig_basename="$(basename "${0}")"
   case "$_aig_basename" in
     opencode-iso*) agent_iso_run opencode "$@" ;;

--- a/tools/agent-isolation/tests/test_generic_iso.py
+++ b/tools/agent-isolation/tests/test_generic_iso.py
@@ -325,3 +325,103 @@ class TestGenericIsoSymlink:
         )
         assert res.returncode != 0
         assert "Usage" in res.stderr
+
+
+class TestSourcedDoesNotReplaceTheShell:
+    """Sourced mode must not `exec` — the current process is the user's shell.
+
+    When the script is sourced from an rc file, ``agent-iso`` / ``claude-iso``
+    are shell functions running *in* the interactive shell. `exec`ing the
+    agent there replaces that shell: quitting the agent closes the terminal,
+    and an exec that fails (lost permission bit, bad interpreter, binary
+    swapped mid-upgrade) takes the shell down with it. Sourced mode runs the
+    agent as a child and returns its status; direct exec still `exec`s.
+    """
+
+    @staticmethod
+    def _env(tmp_path: Path) -> dict:
+        return {
+            "PATH": f"{tmp_path}:{os.environ.get('PATH', '/usr/bin:/bin')}",
+            "HOME": "/tmp/testhome",
+            "USER": "testuser",
+            "SHELL": "/bin/sh",
+            "TERM": "xterm",
+            "LANG": "en_US.UTF-8",
+        }
+
+    @staticmethod
+    def _fake_cli_exiting(tmp_path: Path, name: str, code: int) -> None:
+        fake = tmp_path / name
+        fake.write_text(f'#!/bin/sh\necho "AGENT RAN"\nexit {code}\n')
+        fake.chmod(fake.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    def test_sourced_shell_survives_the_agent(self, tmp_path: Path) -> None:
+        # The line after the launcher must still run: proof the shell was not
+        # replaced by the agent process.
+        self._fake_cli_exiting(tmp_path, _FAKE_CLI, 0)
+        res = subprocess.run(
+            [BASH, "-c", f'source "{SCRIPT}"\nagent-iso {_FAKE_CLI}\necho AFTER_AGENT\n'],
+            env=self._env(tmp_path),
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+        )
+        assert "AGENT RAN" in res.stdout, res.stderr
+        assert "AFTER_AGENT" in res.stdout, "sourced launcher exec'd and replaced the shell"
+
+    def test_sourced_returns_the_agent_exit_status(self, tmp_path: Path) -> None:
+        self._fake_cli_exiting(tmp_path, _FAKE_CLI, 3)
+        res = subprocess.run(
+            [BASH, "-c", f'source "{SCRIPT}"\nagent-iso {_FAKE_CLI}\necho "RC=$?"\n'],
+            env=self._env(tmp_path),
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+        )
+        assert "RC=3" in res.stdout, res.stderr
+
+    def test_sourced_shell_survives_a_failed_launch(self, tmp_path: Path) -> None:
+        # On PATH, exec-bit set, but the shebang names an interpreter that does
+        # not exist — the "binary swapped mid-upgrade" case. `exec` would abort
+        # the shell here; a child process just reports the failure.
+        broken = tmp_path / "broken-cli"
+        broken.write_text("#!/nonexistent/interpreter\n")
+        broken.chmod(broken.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        res = subprocess.run(
+            [BASH, "-c", f'source "{SCRIPT}"\nagent-iso broken-cli\necho "SURVIVED RC=$?"\n'],
+            env=self._env(tmp_path),
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+        )
+        # The shell reaching the next line at all is the assertion. The exact
+        # status is left to the platform: a failed launch is 126 or 127
+        # depending on how the kernel and shell classify the unrunnable file.
+        assert "SURVIVED RC=" in res.stdout, res.stderr
+        rc = int(res.stdout.split("SURVIVED RC=")[1].split()[0])
+        assert rc != 0, f"expected a non-zero status for a failed launch, got {rc}"
+
+    def test_sourced_claude_iso_shell_survives(self, tmp_path: Path) -> None:
+        # Same contract for the named per-agent launchers, not just `agent-iso`.
+        self._fake_cli_exiting(tmp_path, "claude", 0)
+        res = subprocess.run(
+            [BASH, "-c", f'source "{SCRIPT}"\nclaude-iso\necho AFTER_AGENT\n'],
+            env=self._env(tmp_path),
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+        )
+        assert "AFTER_AGENT" in res.stdout, "claude-iso exec'd and replaced the shell"
+
+    def test_direct_exec_still_execs(self, tmp_path: Path) -> None:
+        # The direct-exec path exists only to become the agent, so it must
+        # keep `exec`ing — the agent replaces this process, not a child of it.
+        self._fake_cli_exiting(tmp_path, _FAKE_CLI, 3)
+        res = subprocess.run(
+            [BASH, str(SCRIPT), "agent-iso", _FAKE_CLI],
+            env=self._env(tmp_path),
+            cwd=str(tmp_path),
+            capture_output=True,
+            text=True,
+        )
+        assert res.returncode == 3, res.stderr


### PR DESCRIPTION
## Summary

- `agent_iso_run` in `tools/agent-isolation/agent-iso.sh` ended with an unconditional
  `exec env -i … "$agent_bin"`. That is right for `bash agent-iso.sh …`, where the process
  exists only to become the agent — but wrong on the **sourced** path, the documented rc-file
  setup where `claude-iso` / `agent-iso` are shell functions. There the current process is the
  user's own interactive shell, so `exec` replaced it: quitting the agent closed the terminal,
  and a launch that failed (lost exec bit, bad interpreter, binary swapped mid-upgrade) took
  the shell down with it.
- The sourced/direct branch now records which mode the script loaded in; `agent_iso_run` uses
  that to run the agent as a child and return its exit status when sourced, and to keep
  `exec`ing when executed directly.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)
- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)

## Test plan

- [x] `prek run --all-files` passes
- [x] `uv run pytest` passes in `tools/agent-isolation` (88 passed)
- [x] New `TestSourcedDoesNotReplaceTheShell` covers: the shell surviving the agent, the agent's
      exit status reaching the shell, the shell surviving a *failed* launch (a missing-interpreter
      shebang — previously fatal to the shell), the named `claude-iso` launcher, and a guard that
      direct exec still `exec`s.
      The first four fail against the pre-fix script — verified by restoring it and re-running.

## RFC-AI-0004 compliance

- [x] **Sandbox** — no new host access; the change only affects which process the agent replaces.

## Notes for reviewers

- The direct-exec path deliberately keeps `exec`. That process exists only to become the agent,
  so replacing it is correct and saves a process; only the sourced path changed.
- The `exit 1` calls at the bottom of the script were already confined to the direct-exec
  branch, and the sourced entry points already used `return` — `exec` was the only remaining
  path that could take the parent shell down.
- The other ten scripts under `tools/agent-isolation/` are hooks and shims that are always
  executed, never sourced, so none needed the same treatment.
- Mode detection reuses the existing `[[ "${BASH_SOURCE[0]}" != "${0}" ]]` check. Under zsh
  `BASH_SOURCE` is unset, which lands on the sourced branch — the correct answer there, since
  direct execution always goes through the bash shebang.
