### PR TITLE
fix(sandbox): drop deny rules that file permission checks never match

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -119,8 +119,6 @@
       "Read(//**/.env.*.local)",
       "Edit(.claude/settings.json)",
       "Edit(.claude/settings.local.json)",
-      "Write(.claude/settings.json)",
-      "Write(.claude/settings.local.json)",
       "Bash(curl *)",
       "Bash(wget *)",
       "Bash(aws *)",

--- a/tools/sandbox-lint/expected.json
+++ b/tools/sandbox-lint/expected.json
@@ -119,8 +119,6 @@
       "Read(//**/.env.*.local)",
       "Edit(.claude/settings.json)",
       "Edit(.claude/settings.local.json)",
-      "Write(.claude/settings.json)",
-      "Write(.claude/settings.local.json)",
       "Bash(curl *)",
       "Bash(wget *)",
       "Bash(aws *)",


### PR DESCRIPTION
## Summary

- `Write(.claude/settings.json)` and `Write(.claude/settings.local.json)` looked like they
  guarded those two files, but file permission checks only match `Edit(path)` rules — a
  `Write(...)` deny rule is inert. Both paths are already covered by the `Edit(...)` deny rules
  immediately above, which apply to every file-editing tool, so removing the dead pair loses no
  protection and stops the settings block from implying a guard that was not there.
- Mirrors the removal into `tools/sandbox-lint/expected.json`, as every change to the live
  sandbox must be (docs/security/threat-model.md mitigation M.29).

## Type of change

- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)

## Test plan

- [x] `prek run --all-files` passes
- [x] `uv run pytest` passes in `tools/sandbox-lint` — the baseline-vs-live drift check is the
      gate that catches an unmirrored settings change, and it fails without the `expected.json`
      half of this commit.

## RFC-AI-0004 compliance

- [x] **Sandbox** — strictly removes inert rules; no path gains write access that did not
      already have it.

## Notes for reviewers

- Worth confirming the premise rather than the diff: if `Write(path)` deny rules *are* honoured
  somewhere I have not found, these two should stay and the `Edit(...)` pair is the redundant
  one. The behaviour I relied on is that file permission checks match only `Edit(path)`, which
  covers all file-editing tools including Write.
