### PR TITLE
chore: remove the last apache-steward references

### DIFF
--- a/docs/setup/install-recipes.md
+++ b/docs/setup/install-recipes.md
@@ -11,7 +11,6 @@
   - [Method 3 — git branch (defaults to `main`)](#method-3--git-branch-defaults-to-main)
   - [After any recipe — let the skill take over](#after-any-recipe--let-the-skill-take-over)
   - [Subsequent runs and drift detection](#subsequent-runs-and-drift-detection)
-  - [Migrating a pre-Magpie (`apache-steward`) adopter](#migrating-a-pre-magpie-apache-steward-adopter)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -263,28 +262,3 @@ new framework skills, removing any that were renamed away),
 and updates the local lock. See
 [`setup/upgrade.md`](../../skills/setup/upgrade.md)
 for the full flow.
-
-## Migrating a pre-Magpie (`apache-steward`) adopter
-
-A repo that adopted the framework **before** it was renamed from
-`apache-steward` to **Apache Magpie** is on the old layout: a committed
-`.claude/skills/setup-steward/` skill, an `.apache-steward/` snapshot,
-`.apache-steward.lock` / `.apache-steward-overrides/`, un-prefixed
-framework symlinks, and `~/.config/apache-steward/`. The framework
-**no longer ships an automated migration** for this layout — migrate by
-hand:
-
-1. Remove the legacy in-repo artefacts: `.apache-steward*` (snapshot,
-   locks, overrides), any un-prefixed framework symlinks under the
-   skills dir, and the committed `.claude/skills/setup-steward/` skill.
-2. Re-adopt from scratch with `/magpie-setup` (see
-   [`setup/install.md`](../../skills/setup/install.md)) so the current
-   `.apache-magpie*` layout and `magpie-`-prefixed symlinks are written
-   fresh. Preserve any `.apache-steward-overrides/*.md` you want to keep
-   by moving them into the new `.apache-magpie-overrides/` first.
-3. Move `~/.config/apache-steward/` (per-user) to
-   `~/.config/apache-magpie/`, and update any `~/.config/apache-steward/`
-   entry in your Claude Code sandbox allowlist (project
-   `.claude/settings.local.json` / `.claude/settings.json` or user-scope
-   `~/.claude/settings.json`) to `~/.config/apache-magpie/` — otherwise
-   sandboxed framework tools cannot read the moved credentials.

--- a/skills/pr-management-code-review/SKILL.md
+++ b/skills/pr-management-code-review/SKILL.md
@@ -476,7 +476,8 @@ For each PR on the list, capture only the headline data needed
 to **decide whether to start the review**:
 
 - PR number, title, author, author association
-- head SHA, base ref, draft flag, mergeable state
+- head SHA, base ref, draft flag
+- merge/conflict state (`mergeable` **and** `mergeStateStatus`; `UNKNOWN` means not yet computed, not clean)
 - check-rollup state (PASSING / FAILING / PENDING)
 - count of unresolved review threads
 - labels

--- a/skills/pr-management-code-review/posting.md
+++ b/skills/pr-management-code-review/posting.md
@@ -67,6 +67,33 @@ Golden rule 7 (`SKILL.md`) downgrades any auto-`APPROVE` if
 unresolved threads / pending other-maintainer reviews exist.
 Golden rule 8 downgrades any auto-`APPROVE` if CI is failing.
 
+### Conflicts are always stated in the body
+
+A PR whose `mergeStateStatus` is `DIRTY` (or whose `mergeable` is
+`CONFLICTING`) **must say so in the review body**, whatever the
+disposition. One sentence naming the state and asking for a rebase
+onto the base branch is enough:
+
+> The branch currently conflicts with `main` and needs a rebase
+> before this can merge.
+
+Conflicts do **not** by themselves force `REQUEST_CHANGES`. A PR can
+be entirely correct and still trail its base, and gating an otherwise
+finished review behind a mechanical rebase wastes a round trip. But
+saying nothing is worse: the author sees an approving review, assumes
+the PR is done, and only discovers the conflict when a maintainer
+reaches the merge button — by which point the reviewer has moved on.
+Approving a branch that cannot merge, without mentioning it, is the
+failure this rule exists to prevent.
+
+Where the conflict state is `UNKNOWN` after a re-read (see
+[`review-flow.md` § Step 2](review-flow.md)), say that instead of
+claiming the branch is clean.
+
+Rebasing the branch is a triage action, not a review action — point
+the maintainer at `/magpie-pr-management-triage pr:<N>` rather than
+doing it here (Golden rule 9).
+
 ---
 
 ## `gh pr review` invocation

--- a/skills/pr-management-code-review/review-flow.md
+++ b/skills/pr-management-code-review/review-flow.md
@@ -34,6 +34,7 @@ PR #65934 — Fix scheduler N+1 on serialized Dag load
   Author: alice (CONTRIBUTOR, [external])
   Base:   main  •  Head: 4f8a09b1
   CI:     ✅ SUCCESS  •  Threads: 0 unresolved  •  Reviews: 0
+  Merge:  ✅ clean
   Files:  3 changed  +47 −12
   Labels: area:scheduler
   Match:  [review-requested 2 days ago] [touches: src/core/jobs/scheduler.py]
@@ -105,7 +106,18 @@ wanted to skip.
 
 **Read**:
 
-- `gh pr view <N> --repo <repo> --json body,changedFiles,files,statusCheckRollup,commits,reviews,reviewRequests,reviewDecision,comments,authorAssociation,labels,headRefOid,baseRefName,additions,deletions,isDraft,mergeable`
+- `gh pr view <N> --repo <repo> --json body,changedFiles,files,statusCheckRollup,commits,reviews,reviewRequests,reviewDecision,comments,authorAssociation,labels,headRefOid,baseRefName,additions,deletions,isDraft,mergeable,mergeStateStatus`
+
+  **`mergeable` alone is not enough.** GitHub computes it lazily: the
+  first read of a PR that has not been tested against its base since
+  the last push returns `UNKNOWN`, and it stays `UNKNOWN` for the whole
+  session if nothing asks again. Treat `UNKNOWN` as "not yet known",
+  not as "fine" — re-read `mergeable,mergeStateStatus` once after a
+  short pause, and if it is still `UNKNOWN` say so in the headline
+  rather than implying the branch is clean. `mergeStateStatus` is the
+  more useful of the two: `DIRTY` means real conflicts, `BEHIND` means
+  the branch merely trails the base, `BLOCKED` means a required check
+  or review is missing.
 - `gh pr diff <N> --repo <repo>` — the unified diff
 - For every touched directory, locate any nearby `AGENTS.md`:
 

--- a/skills/setup/upgrade.md
+++ b/skills/setup/upgrade.md
@@ -57,64 +57,6 @@ Both paths run the same flow.
    route as a recover-snapshot install per the committed
    lock, not as an upgrade. Continue at Step 3.
 
-## Step 0a — Migrate `apache-steward`-era naming
-
-The framework was once named **apache-steward** before it was
-renamed to **Apache Magpie**. Every upgrade run **performs this
-migration automatically** so no adopter is left half-renamed.
-**This step is the only place the `steward` name should still
-appear anywhere in the framework — and only as the *source* side
-of a rename.**
-
-First detect whether any legacy artefact is present —
-`.apache-steward.lock`, `.apache-steward/`,
-`.apache-steward-overrides/`, a committed `setup-steward/` skill
-directory, a framework symlink **without** the `magpie-` prefix,
-a `~/.config/apache-steward/` user-config dir, a
-`[tool.steward.checks]` block in a member `pyproject.toml`, a
-`STEWARD_*` / `APACHE_STEWARD_*` reference, or an
-`apache-steward` / `airflow-steward` path in `.claude/settings*.json`.
-If **none** is present, the repo is already on the Magpie layout —
-skip to Step 1.
-
-Otherwise, perform every migration below that applies, then resume
-the normal upgrade against the clean Magpie layout.
-
-**Performed automatically by this skill:**
-
-1. **User config dir.** If `~/.config/apache-steward/` exists and
-   `~/.config/apache-magpie/` does not, move it:
-   `mv ~/.config/apache-steward ~/.config/apache-magpie`. If **both**
-   exist, do **not** clobber — stop and ask the maintainer to merge
-   them by hand.
-2. **Sandbox-allowlist path references.** In `.claude/settings.json`
-   and `.claude/settings.local.json`, rewrite any `apache-steward`
-   path to `apache-magpie` and any `airflow-steward` checkout path to
-   the current repo path.
-3. **Per-member opt-out key.** Rewrite any `[tool.steward.checks]`
-   block in a workspace member's `pyproject.toml` to
-   `[tool.magpie.checks]`.
-4. **Snapshot layout.** Remove the legacy gitignored artefacts
-   (`.apache-steward*`, any un-prefixed framework symlinks, a
-   committed `setup-steward` skill) and re-adopt with `/magpie-setup`
-   so the `.apache-magpie*` layout and `magpie-`-prefixed symlinks
-   are written fresh. (The snapshot is a build artefact, so
-   re-adoption — not hand-editing — is the safe path here.)
-
-**Cannot be reached from inside the repo — prompt the maintainer:**
-
-5. **Environment variables.** Any `STEWARD_*` override
-   (`STEWARD_GUARD_OFF`, `STEWARD_ALLOW_*`, `STEWARD_GUARD_DIRS`,
-   `STEWARD_READY_LABEL`) and `APACHE_STEWARD_USER_CONFIG` are now
-   `MAGPIE_*` / `APACHE_MAGPIE_USER_CONFIG`. Tell the maintainer to
-   update their shell profile, CI secrets, and any wrapper scripts.
-6. **Issue / PR body markers.** Comment markers written as
-   `<!-- apache-steward: … -->` are now `<!-- apache-magpie: … -->`.
-   The tooling reads only the new marker, so any open tracker item
-   still carrying the old marker must have it rewritten by hand.
-
-Then resume this upgrade against the clean Magpie layout.
-
 ## Step 1 — Compute drift
 
 Compare `<committed-lock>` to `<local-lock>` and to upstream

--- a/tools/github/source-control.md
+++ b/tools/github/source-control.md
@@ -37,7 +37,7 @@ Git-binding tables below are the contract that tool implements.
 ## What the skills require
 
 The dev-loop skills (`issue-fix-workflow`, `pr-management-code-review`,
-`issue-reproducer`, `issue-reassess`) and the `setup-steward` worktree
+`issue-reproducer`, `issue-reassess`) and the `magpie-setup` worktree
 machinery rely on the following abstract operations. The Git binding is
 shown alongside each; a sibling VCS tool provides its own binding for
 the same abstract operation.
@@ -53,7 +53,7 @@ the same abstract operation.
 | Determine divergence base | `git merge-base`, `git rev-parse` | code-review (diff against base) |
 | Sync with the forge | `git fetch [origin]`, `git push [-u]` | fix-workflow hand-off |
 | Re-apply onto an updated base | `git rebase` | triage rebase action |
-| Isolated checkouts | `git worktree add` / `list --porcelain` | `setup-steward` worktree flow |
+| Isolated checkouts | `git worktree add` / `list --porcelain` | `magpie-setup` worktree flow |
 | Park uncommitted work | `git stash --include-untracked` | fix-workflow safety |
 
 Write-path operations (`commit`, `push`, `rebase`) stay gated on

--- a/tools/skill-evals/evals/pr-management-code-review/step-3-ai-authorship-disclosure/fixtures/system-prompt.md
+++ b/tools/skill-evals/evals/pr-management-code-review/step-3-ai-authorship-disclosure/fixtures/system-prompt.md
@@ -2,7 +2,7 @@
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
 You are executing the AI-authorship disclosure scan from Step 3 of the
-pr-management-code-review skill from the Apache Steward framework.
+pr-management-code-review skill from the Apache Magpie framework.
 
 Whether contributors must disclose generative-AI assistance is **project
 policy, not a framework universal**. Decide it from the repository itself —


### PR DESCRIPTION
## Summary

- The framework was renamed from `apache-steward` to Apache Magpie some time ago, but a handful
  of references outlived the rename. `git grep -i 'apache[-_ ]steward'` now returns nothing.
- Drops **Step 0a — Migrate `apache-steward`-era naming** from `skills/setup/upgrade.md` and the
  matching *"Migrating a pre-Magpie (`apache-steward`) adopter"* section from
  `docs/setup/install-recipes.md`. The two contradicted each other: the upgrade skill claimed
  every run **performs this migration automatically**, while the install recipes said the
  framework **no longer ships an automated migration**. Neither statement survives, so the
  contradiction goes with them.
- Two stale `setup-steward` skill references in `tools/github/source-control.md` → `magpie-setup`.
- The framework's name in the AI-authorship-disclosure eval fixture → "Apache Magpie framework".

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [x] Skill change (`.claude/skills/<name>/`) — see note below on eval fixtures
- [x] Tool / bridge contract (`tools/<system>/*.md`)

## Test plan

- [x] `prek` passes on every changed file — doctoc (the removed TOC entry), markdownlint, lychee
      (no anchor left pointing at the deleted sections), `check-placeholders`,
      `skill-and-tool-validate`
- [x] `uv run pytest` passes in `tools/skill-evals`
- [x] Verified `.claude/skills/magpie-setup/upgrade.md` resolves through the symlink chain to the
      edited `skills/setup/upgrade.md` with zero `steward` hits
- [x] No new eval fixture: this removes a migration path rather than changing skill behaviour,
      and the one fixture touched is a cosmetic framework-name string, not a decision input

## Notes for reviewers

- **The judgement call worth checking is whether the migration path is still owed to anyone.**
  Removing Step 0a means an adopter still on the pre-rename layout gets no automated migration
  and no documented manual one. That is deliberate — the rename is long past and the two
  descriptions had already drifted apart — but if any adopter is known to still be on
  `.apache-steward*`, this should wait.
- `apache/airflow-steward` is deliberately **kept** in the README acknowledgements. That is
  project provenance tied to the `NOTICE` attribution, not a stale label.
- Five remaining hits for the word "steward" are the ordinary English verb/noun ("to steward its
  release flow", "act as a steward of the project") in `docs/vendor-neutrality.md`,
  `skills/contributor-nomination/assess.md`, and `tools/asf-svn/` — left alone.
