### PR TITLE
feat(pr-management-code-review): always report the branch's conflict state

### DIFF
--- a/skills/pr-management-code-review/SKILL.md
+++ b/skills/pr-management-code-review/SKILL.md
@@ -476,7 +476,8 @@ For each PR on the list, capture only the headline data needed
 to **decide whether to start the review**:
 
 - PR number, title, author, author association
-- head SHA, base ref, draft flag, mergeable state
+- head SHA, base ref, draft flag
+- merge/conflict state (`mergeable` **and** `mergeStateStatus`; `UNKNOWN` means not yet computed, not clean)
 - check-rollup state (PASSING / FAILING / PENDING)
 - count of unresolved review threads
 - labels

--- a/skills/pr-management-code-review/posting.md
+++ b/skills/pr-management-code-review/posting.md
@@ -67,6 +67,33 @@ Golden rule 7 (`SKILL.md`) downgrades any auto-`APPROVE` if
 unresolved threads / pending other-maintainer reviews exist.
 Golden rule 8 downgrades any auto-`APPROVE` if CI is failing.
 
+### Conflicts are always stated in the body
+
+A PR whose `mergeStateStatus` is `DIRTY` (or whose `mergeable` is
+`CONFLICTING`) **must say so in the review body**, whatever the
+disposition. One sentence naming the state and asking for a rebase
+onto the base branch is enough:
+
+> The branch currently conflicts with `main` and needs a rebase
+> before this can merge.
+
+Conflicts do **not** by themselves force `REQUEST_CHANGES`. A PR can
+be entirely correct and still trail its base, and gating an otherwise
+finished review behind a mechanical rebase wastes a round trip. But
+saying nothing is worse: the author sees an approving review, assumes
+the PR is done, and only discovers the conflict when a maintainer
+reaches the merge button — by which point the reviewer has moved on.
+Approving a branch that cannot merge, without mentioning it, is the
+failure this rule exists to prevent.
+
+Where the conflict state is `UNKNOWN` after a re-read (see
+[`review-flow.md` § Step 2](review-flow.md)), say that instead of
+claiming the branch is clean.
+
+Rebasing the branch is a triage action, not a review action — point
+the maintainer at `/magpie-pr-management-triage pr:<N>` rather than
+doing it here (Golden rule 9).
+
 ---
 
 ## `gh pr review` invocation

--- a/skills/pr-management-code-review/review-flow.md
+++ b/skills/pr-management-code-review/review-flow.md
@@ -34,6 +34,7 @@ PR #65934 — Fix scheduler N+1 on serialized Dag load
   Author: alice (CONTRIBUTOR, [external])
   Base:   main  •  Head: 4f8a09b1
   CI:     ✅ SUCCESS  •  Threads: 0 unresolved  •  Reviews: 0
+  Merge:  ✅ clean
   Files:  3 changed  +47 −12
   Labels: area:scheduler
   Match:  [review-requested 2 days ago] [touches: src/core/jobs/scheduler.py]
@@ -105,7 +106,18 @@ wanted to skip.
 
 **Read**:
 
-- `gh pr view <N> --repo <repo> --json body,changedFiles,files,statusCheckRollup,commits,reviews,reviewRequests,reviewDecision,comments,authorAssociation,labels,headRefOid,baseRefName,additions,deletions,isDraft,mergeable`
+- `gh pr view <N> --repo <repo> --json body,changedFiles,files,statusCheckRollup,commits,reviews,reviewRequests,reviewDecision,comments,authorAssociation,labels,headRefOid,baseRefName,additions,deletions,isDraft,mergeable,mergeStateStatus`
+
+  **`mergeable` alone is not enough.** GitHub computes it lazily: the
+  first read of a PR that has not been tested against its base since
+  the last push returns `UNKNOWN`, and it stays `UNKNOWN` for the whole
+  session if nothing asks again. Treat `UNKNOWN` as "not yet known",
+  not as "fine" — re-read `mergeable,mergeStateStatus` once after a
+  short pause, and if it is still `UNKNOWN` say so in the headline
+  rather than implying the branch is clean. `mergeStateStatus` is the
+  more useful of the two: `DIRTY` means real conflicts, `BEHIND` means
+  the branch merely trails the base, `BLOCKED` means a required check
+  or review is missing.
 - `gh pr diff <N> --repo <repo>` — the unified diff
 - For every touched directory, locate any nearby `AGENTS.md`:
 


### PR DESCRIPTION
## Summary

- Fetch `mergeStateStatus` alongside `mergeable`, and treat `UNKNOWN` as "not yet computed" rather than "clean" — re-read once, and say so if it stays unknown.
- Add a `Merge:` field to the per-PR headline.
- New rule in `posting.md`: a conflicting branch is **always** stated in the review body, whatever the disposition.

## Motivation

The skill already asked for `mergeable`, but GitHub computes it lazily — a PR that has not been tested against its base since the last push answers `UNKNOWN`, and keeps answering `UNKNOWN` unless something asks again. Across a full review session every PR came back `UNKNOWN`, so the headline's "mergeable state" carried no information and a conflicting branch never reached the author.

The failure that produces is an approving review on a branch that cannot merge. The author reads the approval as "done"; the conflict surfaces weeks later at the merge button, when the reviewer has moved on.

Found while reviewing apache/airflow#68359, which was `DIRTY` against `main` throughout a review that would otherwise have approved it without mentioning the conflict.

## Design note

Conflicts deliberately do **not** feed the disposition rules. A PR can be entirely correct and merely trail its base; gating a finished review behind a mechanical rebase wastes a round trip. Stating it is enough. Rebasing stays a triage action per Golden rule 9.

## Migration path for existing adopters

No config knob and no opt-out — a doc-contract change to an existing step. Adopters get the extra headline field and the body sentence on their next `/magpie-setup upgrade`.

## Test plan

- `prek run --files` over all three changed files — all hooks pass (markdownlint, lychee, check-placeholders, skill-and-tool-validate, vendor-neutrality).

---
Drafted-by: Claude Code (Claude Opus 5); reviewed by @potiuk before posting
