### PR TITLE
fix(security-issue-import): require a positive GHSA query on every scan

### DIFF
--- a/skills/security-issue-import/SKILL.md
+++ b/skills/security-issue-import/SKILL.md
@@ -454,6 +454,32 @@ The canonical query template in
 omits the blanket exclusion; project-specific `<project-config>/project.md`
 declarations enumerate dedicated mirror noreply senders only.
 
+**Mandatory second pass — run a positive GHSA query.** The rule above
+is a *negative* one, and negative rules are not self-enforcing: an
+exclusion added anywhere for noise reduction removes the whole GHSA
+intake channel, and the miss is invisible — nothing reports that a
+report was filtered out. So every import scan **also** runs the
+[GHSA-advisory query](../../tools/gmail/search-queries.md#security-issue-import--ghsa-advisory-query-mandatory-second-pass),
+which checks the channel by construction and cannot be filtered away
+by an exclusion elsewhere. Union its hits with the candidate-listing
+query's before Step 2.
+
+For each hit whose subject carries `[<upstream>] ... (GHSA-...)`:
+
+- Treat it as a **`Report`** candidate, not tracker-mirror noise.
+- The advisory **body is confidential** — it lands in the private
+  tracker only, per the confidentiality golden rule; never echo it to
+  a public surface.
+- Prefer the advisory **record API**
+  (`gh api repos/<upstream>/security-advisories/<GHSA>`). **If it
+  404s, the operator is not yet a collaborator on that specific
+  advisory** — this is an access state, not a missing advisory.
+  Extract the report from the notification email body and flag the
+  **admin hand-off**: someone with advisory-admin rights must add the
+  operator as a collaborator before the record API and the
+  reporter-reply path become usable. See the GHSA contract in
+  [`security-issue-sync`'s `github-advisory.md`](../security-issue-sync/github-advisory.md).
+
 Adjust the time window per the user's selector (`since:` → `newer_than:`
 or `after:`; `import all` → `newer_than:90d`).
 

--- a/tools/gmail/search-queries.md
+++ b/tools/gmail/search-queries.md
@@ -10,6 +10,7 @@
   - [GitHub-notification exclusions](#github-notification-exclusions)
   - [Query templates by skill](#query-templates-by-skill)
     - [`security-issue-import` — candidate-listing query](#security-issue-import--candidate-listing-query)
+    - [`security-issue-import` — GHSA-advisory query (mandatory second pass)](#security-issue-import--ghsa-advisory-query-mandatory-second-pass)
     - [`security-issue-import` — prior-rejection search](#security-issue-import--prior-rejection-search)
     - [`security-issue-sync` — reporter-thread lookup by distinctive phrase](#security-issue-sync--reporter-thread-lookup-by-distinctive-phrase)
     - [`security-issue-sync` — CVE-review-comment search](#security-issue-sync--cve-review-comment-search)
@@ -113,6 +114,33 @@ instead.
 
 Adjust the time window per the user's selector (`since:` →
 `newer_than:` or `after:`; `import all` → `newer_than:90d`).
+
+### `security-issue-import` — GHSA-advisory query (mandatory second pass)
+
+Run **in addition to** the candidate-listing query above, on every
+import scan:
+
+```text
+from:notifications@github.com
+  newer_than:<window>
+  (GHSA OR "Report a vulnerability" OR "security advisory")
+```
+
+The rule above says not to exclude `notifications@github.com`. This
+query is the positive counterpart, and it exists because the negative
+rule is not self-enforcing: an exclusion added anywhere for noise
+reduction — in the candidate query, a project override, a hand-edited
+one-off — silently removes the entire GHSA intake channel, and the
+resulting miss is invisible. Nothing reports *"a report was filtered
+out"*.
+
+Running a dedicated positive query makes the GHSA channel checked **by
+construction**. It cannot be filtered away by an exclusion elsewhere,
+because it does not depend on the other query's filter list. The cost
+is one extra search per scan; the failure it prevents is a
+silently-missed, often high-severity report.
+
+Adjust the window to match the candidate-listing query's.
 
 ### `security-issue-import` — prior-rejection search
 


### PR DESCRIPTION
## Summary

The skill already says not to exclude `notifications@github.com` wholesale, because that sender carries both tracker-mirror chatter and GHSA-relayed inbound reports. That rule is correct, but it is **negative** — and negative rules are not self-enforcing.

Adds a positive counterpart that every import scan runs alongside the candidate-listing query:

```text
from:notifications@github.com newer_than:<window>
  (GHSA OR "Report a vulnerability" OR "security advisory")
```

## Motivation

An exclusion added anywhere for noise reduction — in the candidate query, a project override, a hand-edited one-off — removes the entire GHSA intake channel. **The resulting miss is invisible**: nothing reports that a report was filtered out, so the scan looks clean and the advisory is simply never seen.

A downstream adopter lost an incomplete-fix follow-up advisory to exactly this, and caught it only because the operator independently knew the report existed. That is not a control — it is luck.

Because the new query does not depend on the other query's filter list, the GHSA channel is checked **by construction** and cannot be filtered away by an exclusion elsewhere. Cost is one extra search per scan.

## Also

Documents the 404 case on the advisory record API. A 404 there means the operator **is not yet a collaborator on that specific advisory** — an access state, not a missing advisory — and the fix is an admin hand-off (someone with advisory-admin rights adds the operator) before the record API and the reporter-reply path work. That distinction is easy to misread as "no such advisory" and abandon.

## Test plan

`prek run --files` passes on both files. The in-hook lychee confirms the new cross-reference anchor (`#security-issue-import--ghsa-advisory-query-mandatory-second-pass`) resolves against the doctoc-generated TOC, and `check-placeholders` confirms the added text uses only `<upstream>` / `<GHSA>` / `<window>` placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
