### PR TITLE
fix(security-tracker-stats): recognise the framework's own comment marker

### DIFF
--- a/tools/security-tracker-stats-dashboard/README.md
+++ b/tools/security-tracker-stats-dashboard/README.md
@@ -99,9 +99,11 @@ run is ~5–10 minutes on a 250-issue tracker; incremental re-renders
 1. `default-config.yaml` (in this directory).
 2. `$TRACKER_STATS_CONFIG` overlay YAML, when set (typically
    `<adopter-repo>/.apache-magpie-overrides/security-tracker-stats.yaml`).
-   Deep-merged with the default. **The `milestones` and `categories`
-   lists are REPLACED entirely** (not concatenated) — overlaying a
-   single category requires re-stating the whole list.
+   Deep-merged with the default. **Every list is REPLACED entirely**
+   (not concatenated) — `milestones`, `categories`, `bot_prefixes`,
+   `keywords`, and any other list-valued key. Overlaying a single
+   entry requires re-stating the whole list, otherwise the defaults
+   are silently dropped.
 3. Env-var quick overrides for the most common knobs:
    `TRACKER_STATS_BUCKETS`, `TRACKER_STATS_START`,
    `TRACKER_STATS_UPSTREAM_REPO`.

--- a/tools/security-tracker-stats-dashboard/default-config.yaml
+++ b/tools/security-tracker-stats-dashboard/default-config.yaml
@@ -163,8 +163,15 @@ triage:
     - Security Model
     - cve-worthy
     - CVE-worthy
+  # Skill-authored comments, skipped when measuring human triage
+  # activity. The first entry is the canonical machine marker every
+  # framework skill writes (`<!-- apache-magpie: <kind> vN -->`); the
+  # rest are prose prefixes from older comment shapes.
+  #
+  # NOTE: this list is REPLACED wholesale by an overlay, not merged --
+  # an overlay adding one prefix must restate the whole list.
   bot_prefixes:
-    - "<!-- airflow-s status rollup v"
+    - "<!-- apache-magpie: "
     - "**Sync "
     - "**Imported on "
     - "**Status update"


### PR DESCRIPTION
## Summary

The default `bot_prefixes` does not list `<!-- apache-magpie: ` — the canonical machine marker **every framework skill writes** on its status-rollup, hand-off and import comments. Those comments are therefore counted as *human triage activity*, pulling the time-to-triage median toward zero on any tracker the skills touch. The more the skills are used, the more wrong the metric gets.

Meanwhile the default *does* list `<!-- airflow-s status rollup v` — a marker specific to one adopter's tracker repo, meaningless to every other project. This swaps the leaked adopter marker for the framework's own.

## Two things worth a reviewer's attention

**1. Template-genericity residue.** The `airflow-s` prefix is exactly what the upgrade flow's Step 6d audit exists to catch. #1123 removed the last `apache-steward` references; this one survived because it names an adopter, not the old framework.

**2. The README's merge documentation was wrong**, and that is what made this bug hard to notice downstream. It said the `milestones` and `categories` lists are replaced entirely — implying other lists merge. `deep_merge` replaces **every** list; its own docstring says *"Lists are REPLACED, not concatenated."* So an adopter who fixes the marker locally by overlaying one `bot_prefixes` entry silently discards all the defaults. Corrected to say every list replaces.

## Test plan

- The config still parses under the hand-rolled `_minimal_yaml_load` subset parser with the added comments — checked directly, since that parser handles only a YAML subset and comments were a real risk.
- `is_bot_body` now classifies a real `<!-- apache-magpie: status-rollup v3 -->` comment as bot (`True`) while leaving a human triage comment alone (`False`).
- The tool's full suite passes: **114 tests**, `uv run --project . pytest`.
- `prek run --files` passes on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
