### PR TITLE
fix(_template): drop Apache Airflow residue from the templates

### DIFF
--- a/projects/_template/pr-management-quick-merge-config.md
+++ b/projects/_template/pr-management-quick-merge-config.md
@@ -48,7 +48,7 @@ skill. This is the **`_template` default**; new adopters copy it into their own
 `<project-config>/pr-management-quick-merge-config.md` and tune the thresholds
 and path globs for their repository layout.
 
-The default globs below are shaped for an Apache-Airflow-like monorepo; an
+The default globs below are shaped for a Python monorepo; an
 adopter with a different layout replaces them wholesale. When a field is absent,
 the skill falls back to the default noted in its row.
 
@@ -95,7 +95,8 @@ spelling_wordlist.txt
 **/tests/**
 **/test_*.py
 **/*_test.py
-**/example_dags/**
+**/examples/**
+**/example_*/**
 ```
 
 ### `deny_globs` — absolute disqualifiers (consequential areas; one match drops the PR even at one line)

--- a/projects/_template/reviewer-roster.md
+++ b/projects/_template/reviewer-roster.md
@@ -30,7 +30,7 @@ Shape per entry:
   - handle: github-login        # GitHub @handle (required)
     areas:                      # list of areas / path prefixes / labels
       - component:scheduler
-      - airflow/jobs/
+      - src/scheduler/
     max_reviews: 5              # optional; default 5
 -->
 
@@ -48,7 +48,7 @@ Shape per entry:
 ## Notes
 
 - `areas` entries may be component labels (e.g. `component:scheduler`),
-  path prefixes (e.g. `airflow/jobs/`), or free-form area names that
+  path prefixes (e.g. `src/scheduler/`), or free-form area names that
   match the labels used in this project's issue tracker.
 - `max_reviews` is the maximum number of open review requests this
   reviewer is comfortable holding simultaneously. When their current

--- a/projects/_template/security-intake-config.md
+++ b/projects/_template/security-intake-config.md
@@ -42,7 +42,7 @@ authoritative home for those values.  This file does two things:
 
 New adopters: copy this file into your own
 `<project-config>/security-intake-config.md` and replace every `TODO`.
-The ASF defaults reproduce the Apache Airflow security-team workflow
+The ASF defaults reproduce the standard ASF security-team workflow
 unchanged; override only the fields that differ for your project.
 
 Related scaffolds in the same adopter directory:

--- a/skills/pr-management-quick-merge/candidate-rules.md
+++ b/skills/pr-management-quick-merge/candidate-rules.md
@@ -190,7 +190,8 @@ tier_b_allow_globs:
   - "**/tests/**"
   - "**/test_*.py"
   - "**/*_test.py"
-  - "**/example_dags/**"
+  - "**/examples/**"
+  - "**/example_*/**"
 
 deny_globs:                 # absolute disqualifiers, even at one line
   - "**/migrations/**"


### PR DESCRIPTION
`/magpie-setup upgrade`'s Step 6d template-genericity audit flagged these on an adopter repo. The `_template` scaffolds are meant to be project-agnostic — an adopter copies them and fills in placeholders — but four spots carried the framework's original adopter's specifics as if they were generic:

| File | Was | Now |
|---|---|---|
| `reviewer-roster.md` | `airflow/jobs/` as the unmarked path-prefix sample (shape comment + Notes) | `src/scheduler/` — reads as a shape, not one project's tree |
| `security-intake-config.md` | "The ASF defaults reproduce the **Apache Airflow** security-team workflow" | "…the **standard ASF** security-team workflow" |
| `pr-management-quick-merge-config.md` | `tier_b_allow_globs` shipped `**/example_dags/**`, meaningful only in an Airflow tree; prose called the defaults Airflow-shaped | `**/examples/**` + `**/example_*/**`, and prose says "a Python monorepo" |
| `candidate-rules.md` | the skill's built-in default list carried the same glob | updated in lock-step so template and skill don't drift |

The glob replacement is a **superset** of the old one — `**/example_*/**` still matches `example_dags/`, so an Airflow adopter's example-DAG PRs stay in tier B.

Deliberately left alone: everything that already marks itself as an example — the `release-management-config.md` "filled example" section, the `mentoring-welcome-config.md` filled-in block, and the `Example: apache/airflow-…` cells. Those are calibration aids, not residue.
