### PR TITLE
fix(docs): collapse three org-level security placeholder names into one

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -383,6 +383,7 @@ configuration before executing any command:
 | `<tracker>` | GitHub slug of the (security) tracker repo (example: `airflow-s/airflow-s`). | `<project-config>/project.md` → `tracker_repo` |
 | `<upstream>` | GitHub slug of the upstream codebase the fixes land in (example: `apache/airflow`). | `<project-config>/project.md` → `upstream_repo` |
 | `<security-list>` | The project's security mailing list (example: `security@airflow.apache.org`). | `<project-config>/project.md` → `security_list` (under **Mailing lists**) |
+| `<foundation-security-list>` | The org-level advisory-admin security address, distinct from the project's own `<security-list>` (example: `security@apache.org`). Inherited, not declared per-project. | organization manifest → `security_inbox.foundation_security_address` |
 | `<issue-tracker>` | URL of the project's general-issue tracker, distinct from the security tracker. | `<project-config>/issue-tracker-config.md` → `url` |
 | `<issue-tracker-project>` | Project key within the issue tracker (JIRA key or `owner/repo`). | `<project-config>/issue-tracker-config.md` → `project_key` |
 | `<runtime>` | Recipe for invoking the project's runtime on a single source file. | `<project-config>/runtime-invocation.md` |
@@ -663,7 +664,7 @@ While triaging a report, you may learn about vulnerabilities in
 **other ASF projects** through the same channels that surface our
 own reports: the reporter's mail thread mentions that they filed a
 similar issue against Superset or Allura; a cross-project digest on
-`<asf-security-list>` summarises active reports across several
+`<foundation-security-list>` summarises active reports across several
 projects; a Gmail search for a CVE ID or a vulnerability pattern
 returns hits on threads belonging to unrelated projects; your own
 deduction from a reporter's résumé or prior disclosures correlates
@@ -722,7 +723,7 @@ channel they arrived on:
   against Superset and Allura"* is not. *"A sibling ASF project
   landed a comparable fix"* is allowed; *"Tomcat landed the
   equivalent fix in 11.0.3"* is not.
-- Cross-project triage belongs on `<asf-security-list>` or in a
+- Cross-project triage belongs on `<foundation-security-list>` or in a
   direct mail to that project's security team, not in our tracker.
 
 **Self-check before posting, committing, or drafting.** Grep the

--- a/skills/security-issue-sync/github-advisory.md
+++ b/skills/security-issue-sync/github-advisory.md
@@ -126,7 +126,7 @@ path.
 ### Delivery — an email relay (draft, never auto-sent)
 
 Create a **draft** email to the org's advisory-admin security team
-(`<security-team-list>`) with
+(`<foundation-security-list>`) with
 `oauth-draft-create` — never send directly (SKILL Golden rule 1; and the
 Gmail MCP mangles the `security/advisories/GHSA-…` URLs into redirects, so
 use oauth-draft). **Always CC the project `<security-list>`** so the


### PR DESCRIPTION
## Summary

- The org-level advisory-admin security address had three names in the tree (`<security-team-list>`, `<asf-security-list>`, and the bare `security_inbox.foundation_security_address` config path) and none was registered in the placeholder table.
- `<asf-security-list>` also bakes an ASF-specific name into a framework whose placeholder mechanism exists to keep adopting projects vendor-neutral.
- Registers one org-neutral placeholder, `<foundation-security-list>`, and uses it at all three call sites. The distinct project-level `<security-list>` is untouched, since `github-advisory.md`'s own delivery instructions deliberately address the two lists separately.

## Type of change

- [ ] Skill change (`.claude/skills/<name>/`) - eval fixtures updated below
- [ ] Tool / bridge contract (`tools/<system>/*.md`)
- [ ] Python package (`tools/*/` with `pyproject.toml`)
- [ ] Groovy reference impl
- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [ ] Project template (`projects/_template/`)
- [ ] CI / dev loop (`prek`, workflows, validators)
- [ ] Other:

## Test plan

- [x] `prek run --all-files` not available in this environment (no `uv`/`prek`); ran the individual hooks by hand instead: `tools/dev/check-placeholders.sh`, `npx markdownlint-cli2` and `typos` on both changed files, and the `doctoc` check (no TOC change needed; `skills/**` is excluded from the doctoc hook and `AGENTS.md`'s TOC is unaffected by a text-only edit). All clean.
- [x] `PYTHONPATH=tools/skill-and-tool-validator/src python3 -c "from skill_and_tool_validator import main; main()"` (the same entry point `uv run skill-and-tool-validate` calls) reports the same 29 pre-existing soft warnings before and after this change, none on the touched files.
- [ ] Other: did not run the Python test matrix; this PR touches no `tools/*/` package.

## RFC-AI-0004 compliance

- [ ] **HITL** - any new mutation is gated on explicit user confirmation
- [ ] **Sandbox** - no new unrestricted host access; network reach declared in the adapter
- [x] **Vendor neutrality** - replaces an ASF-branded placeholder (`<asf-security-list>`) with an org-neutral one, matching `<governance-body>` and `<project-stage>`
- [ ] **Conversational + correctable** - agentic-override path documented if behaviour is adopter-tunable
- [ ] **Write-access discipline** - no autonomous outbound messages; drafts only, sent on confirmation
- [ ] **Privacy LLM** - private content does not reach a non-approved LLM; redactor invoked where needed

## Linked issues

Fixes #1057

## Notes for reviewers (optional)

Followed the naming this issue itself suggests, matching the config key: `<foundation-security-list>` rather than `<org-security-list>`. `projects/_template/project.md` already documents `security_inbox.foundation_security_address` as org-level and inherited ("Do not declare it here"), so no change was needed there.
