### PR TITLE
docs(skill-evals): add --cli to workflow-security-audit and license-compliance-audit READMEs

### DIFF
--- a/tools/skill-evals/evals/license-compliance-audit/README.md
+++ b/tools/skill-evals/evals/license-compliance-audit/README.md
@@ -16,13 +16,16 @@ Behavioral evals for the `license-compliance-audit` skill.
 
 ```bash
 # All cases
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/license-compliance-audit/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/license-compliance-audit/
 
 # Single suite
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/license-compliance-audit/step-scope-selection/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/license-compliance-audit/step-scope-selection/
 
 # Single case
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-1-explicit-repo/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/license-compliance-audit/step-scope-selection/fixtures/case-1-explicit-repo/
 ```
 
 ## What the suites cover

--- a/tools/skill-evals/evals/workflow-security-audit/README.md
+++ b/tools/skill-evals/evals/workflow-security-audit/README.md
@@ -16,14 +16,15 @@ Behavioral evals for the `workflow-security-audit` skill.
 
 ```bash
 # All cases
-uv run --project tools/skill-evals skill-eval tools/skill-evals/evals/workflow-security-audit/
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
+    tools/skill-evals/evals/workflow-security-audit/
 
 # Single suite
-uv run --project tools/skill-evals skill-eval \
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
     tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/
 
 # Single case
-uv run --project tools/skill-evals skill-eval \
+uv run --project tools/skill-evals skill-eval --cli "claude -p" \
     tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-1-explicit-repo
 ```
 


### PR DESCRIPTION
## Summary

- Add `--cli "claude -p"` to the documented run commands in the
  `workflow-security-audit` and `license-compliance-audit` eval READMEs.
- Without it the runner has no model to drive, so both suites' prose and
  structured cases report `MANUAL` instead of `PASS`/`FAIL` when the README
  is followed as written.

## Type of change

- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)

## Test plan

- `PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner tools/skill-evals/evals/workflow-security-audit/step-scope-selection/fixtures/case-3-injection-in-scope-input` (the pre-fix, documented command): prints the prompt and expected JSON, no PASS/FAIL/MANUAL grading at all, since print mode has no model to compare against.
- Same case with `--cli` pointed at a stub script that echoes the exact `expected.json`: `PASS step-scope-selection/case-3-injection-in-scope-input`, confirming the `--cli` flag is what drives grading. I don't have a `claude` CLI or API credentials in this environment, so I could not run it against the real model; the stub proves the harness wiring, not a live grade.
- `prek run --all-files` (`add-license-headers`, `check-placeholders`, `markdownlint-cli2`, `typos`) passes on both files. `lychee` is unaffected: the diff adds no links.
- Both suites already use exact-match `expected.json` (enums/booleans only), the same shape `onboarding-concierge`'s README documents as gradable via `--cli` with no `MANUAL` fallback.

## RFC-AI-0004 compliance

Not applicable: doc-only change to eval instructions, no skill/tool behavior changed.

## Linked issues

Fixes #943
