### PR TITLE
docs(adapters): reclassify Fossil, add Gmail to mail-source registry

### DIFF
--- a/docs/adapters/registry.md
+++ b/docs/adapters/registry.md
@@ -50,10 +50,10 @@ extension point = a documented, labelled slot with a tracking issue.
 |---|---|---|
 | [`tools/cve-tool`](../../tools/cve-tool/) | [`cve-tool-vulnogram`](../../tools/cve-tool-vulnogram/) (ASF) | MITRE form, CVE.org direct, GHSA |
 | [`tools/mail-archive`](../../tools/mail-archive/) | [`ponymail`](../../tools/ponymail/) (ASF) | Hyperkitty, Discourse, Google Groups, GitHub Discussions |
-| [`tools/mail-source`](../../tools/mail-source/) | mbox, IMAP | Mailman 3 ([#306](https://github.com/apache/magpie/issues/306)) |
+| [`tools/mail-source`](../../tools/mail-source/) | mbox, IMAP, [`gmail`](../../tools/gmail/) | Mailman 3 ([#306](https://github.com/apache/magpie/issues/306)) |
 | [`tools/forwarder-relay`](../../tools/forwarder-relay/) | ASF-security ([`tools/gmail/asf-relay.md`](../../tools/gmail/asf-relay.md)) | huntr.com, HackerOne, GHSA relay |
 | [`tools/scan-format`](../../tools/scan-format/) | ASVS | other scanner formats |
-| [`tools/vcs`](../../tools/vcs/) | Git, Mercurial, Fossil | Subversion [\#602](https://github.com/apache/magpie/issues/602), Jujutsu [\#603](https://github.com/apache/magpie/issues/603), Perforce [\#605](https://github.com/apache/magpie/issues/605) |
+| [`tools/vcs`](../../tools/vcs/) | Git, Mercurial | Subversion [\#602](https://github.com/apache/magpie/issues/602), Jujutsu [\#603](https://github.com/apache/magpie/issues/603), Perforce [\#605](https://github.com/apache/magpie/issues/605) |
 | Forge / tracker | [`github`](../../tools/github/), [`jira`](../../tools/jira/), [`bitbucket`](../../tools/bitbucket/) `partial-read-only` foundation, [`sourcehut`](../../tools/sourcehut/), [`fossil`](../../tools/fossil/) | GitLab [\#305](https://github.com/apache/magpie/issues/305), Forgejo/Gitea [\#310](https://github.com/apache/magpie/issues/310), Pagure [\#312](https://github.com/apache/magpie/issues/312), deeper Bitbucket/Jira coverage [\#606](https://github.com/apache/magpie/issues/606), Bugzilla [\#302](https://github.com/apache/magpie/issues/302) |
 | Agentic runtime | Claude Code, [Codex](codex.md) `experimental` ([#313](https://github.com/apache/magpie/issues/313)) | Gemini CLI [#314](https://github.com/apache/magpie/issues/314)–OpenHands [#322](https://github.com/apache/magpie/issues/322) |
 | Security cross-ref | — | OSV.dev [#311](https://github.com/apache/magpie/issues/311) |


### PR DESCRIPTION
## Summary

- **Reclassify Fossil:** Removed Fossil from the `tools/vcs` (VCS adapter) shipping list in `docs/adapters/registry.md`. Fossil is implemented as a forge bridge under `tools/fossil/` (alongside Bitbucket and SourceHut) and is already correctly listed in the Forge/tracker row.
- **Add Gmail to mail-source:** Added `tools/gmail/` (`[`gmail`](../../tools/gmail/)`) to the `tools/mail-source` shipping adapters list in `docs/adapters/registry.md`, as it implements `contract:mail-source`.
- **Why:** The adapter registry is the reference for contributors deciding where to add new adapter support; misclassifications direct contributors to the wrong implementation patterns.

## Test plan

- Inspected `docs/adapters/registry.md` to ensure relative markdown links (`../../tools/gmail/`) are valid and formatted consistently with adjacent rows.
- Verified that Fossil remains listed under the `Forge / tracker` row and is removed from the `tools/vcs` row.
- Confirmed minimal diff scope (`1 file changed, 2 insertions(+), 2 deletions(-)`).