### PR TITLE
fix(validator): tokenize gh-list-no-limit's flag check instead of substring match

### DIFF
--- a/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
+++ b/tools/skill-and-tool-validator/src/skill_and_tool_validator/__init__.py
@@ -151,6 +151,7 @@ from __future__ import annotations
 import argparse
 import contextlib
 import re
+import shlex
 import subprocess
 import sys
 from collections.abc import Iterable
@@ -2726,7 +2727,11 @@ def validate_gh_list_limit(path: Path, text: str) -> Iterable[Violation]:
             if line_end == -1:
                 line_end = len(joined)
             logical_line = joined[line_start:line_end]
-            if "--limit" in logical_line:
+            try:
+                tokens = shlex.split(logical_line, comments=True)
+            except ValueError:
+                tokens = []  # unbalanced quoting, can't tell, so flag it
+            if any(tok == "--limit" or tok.startswith("--limit=") for tok in tokens):
                 continue
             line_no = text[: block_match.start()].count("\n") + joined[: cmd_match.start()].count("\n") + 1
             yield Violation(

--- a/tools/skill-and-tool-validator/tests/test_validator.py
+++ b/tools/skill-and-tool-validator/tests/test_validator.py
@@ -1800,6 +1800,23 @@ class TestGhListLimit:
         violations = list(validate_gh_list_limit(path, text))
         assert not any("gh-list-no-limit" in v.message for v in violations)
 
+    def test_fires_when_limit_only_appears_in_a_trailing_comment(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = _fenced("gh issue list --repo <repo> --state open  # add --limit later if slow")
+        violations = list(validate_gh_list_limit(path, text))
+        assert any("gh-list-no-limit" in v.message for v in violations)
+
+    def test_fires_when_limit_only_appears_inside_a_quoted_argument(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        text = _fenced('gh issue list --repo <repo> --search "mentions --limit"')
+        violations = list(validate_gh_list_limit(path, text))
+        assert any("gh-list-no-limit" in v.message for v in violations)
+
+    def test_silent_when_limit_uses_equals_form(self, tmp_path: Path) -> None:
+        path = tmp_path / "SKILL.md"
+        violations = list(validate_gh_list_limit(path, _fenced("gh issue list --repo <repo> --limit=100")))
+        assert not any("gh-list-no-limit" in v.message for v in violations)
+
 
 # ---------------------------------------------------------------------------
 # Pattern 6 — Privacy-LLM gate-check


### PR DESCRIPTION
<!-- SPDX-License-Identifier: Apache-2.0
     https://www.apache.org/licenses/LICENSE-2.0 -->

## Summary

- `validate_gh_list_limit` decides whether a `gh issue list` / `gh pr list` call is missing
  `--limit` by testing whether the literal substring `--limit` occurs anywhere on the
  logical line, so a trailing shell comment or a quoted argument that merely mentions
  `--limit` silently suppresses the warning even when the command has no such flag.
- Fixes it by tokenizing the line with `shlex.split(..., comments=True)` and checking for an
  actual `--limit` (or `--limit=N`) token instead of a bare substring match.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)

## Test plan

- [x] `prek run --all-files` passes
- [x] For Python packages touched: `uv run pytest` / `ruff check` / `mypy` passes
- Added three cases to `TestGhListLimit`: a trailing comment containing `--limit`, a quoted
  argument containing `--limit`, and the `--limit=100` equals-form (control, must stay
  silent). The first two fail on `main` and pass on this branch, verified both ways on
  Python 3.12. Full `tests/test_validator.py` (466 cases) still passes.
- I have not checked every `--limit` spelling `gh` itself accepts, only `--limit N` and
  `--limit=N`.

## RFC-AI-0004 compliance

- [x] **Sandbox**: no new host access, pure text processing like the code it replaces

## Linked issues

Self-discovered while reading the validator surface; no existing issue.

## Notes for reviewers (optional)

`_GH_LIST_RE` matching and the fenced-block boundary are unchanged. The only touched
function is `validate_gh_list_limit`, single call site.
