### PR TITLE
fix(sandbox-lint): normalise every trailing slash, not just one

### DIFF
--- a/tools/sandbox-lint/src/sandbox_lint/__init__.py
+++ b/tools/sandbox-lint/src/sandbox_lint/__init__.py
@@ -121,15 +121,13 @@ REQUIRED_DENY_READ = {"~/"}
 
 
 def _normalise(path: str) -> str:
-    """Strip a single trailing slash so '~/.aws' and '~/.aws/' compare equal.
+    """Strip all trailing slashes so '~/.aws' and '~/.aws//' compare equal.
 
-    The sandbox treats both forms as the same directory; the validator
-    must too, otherwise the forbidden-list could be bypassed by a
-    trailing-slash variant.
+    The sandbox treats every trailing-slash count as the same directory;
+    the validator must too, otherwise the forbidden-list could be bypassed
+    by a multi-slash variant.
     """
-    if path.endswith("/") and len(path) > 1:
-        return path[:-1]
-    return path
+    return path.rstrip("/") or "/"
 
 
 def _normalised_set(paths: list[str]) -> set[str]:

--- a/tools/sandbox-lint/tests/test_validator.py
+++ b/tools/sandbox-lint/tests/test_validator.py
@@ -163,6 +163,7 @@ def test_invariant_missing_deny_read_root(baseline: dict[str, Any]) -> None:
         "~/.config/gcloud",
         "/",
         "~/",
+        "~/.ssh//",
     ],
 )
 def test_invariant_allow_read_rejects_credential_paths(baseline: dict[str, Any], forbidden: str) -> None:
@@ -181,6 +182,7 @@ def test_invariant_allow_read_rejects_credential_paths(baseline: dict[str, Any],
         "~/.gnupg",
         "~/.ssh",
         "~/.aws/",
+        "~/.aws//",
     ],
 )
 def test_invariant_allow_write_rejects_credential_paths(baseline: dict[str, Any], forbidden: str) -> None:


### PR DESCRIPTION
## Summary

- `_normalise()` only stripped one trailing slash, so `~/.ssh//` (two slashes) never matched the normalised `~/.ssh` forbidden entry and `check_invariants()` passed a config it should have rejected.
- Fixes #1148.

## Type of change

- [x] Python package (`tools/*/` with `pyproject.toml`)

## Test plan

- Added a double-trailing-slash case to the existing `allowRead`/`allowWrite` parametrized tests; both are red on main, green on this branch.
- `ruff check`, `ruff format --check` and `mypy` on `tools/sandbox-lint` are clean (mypy needs `pytest` installed to resolve the test-file imports; not a change this PR introduces).
- Full `tools/sandbox-lint` suite: 55 passed, in a clean `python:3.11-slim` container. Did not run `prek` itself (not available in this sandbox), ran the underlying ruff/mypy/pytest commands by hand instead.

## RFC-AI-0004 compliance

- [x] **Sandbox**: no new host access, this only makes the existing credential-path check stricter.

## Linked issues

Fixes #1148.
