### PR TITLE
fix(agent-guard): scope Segment.raw to its own tokens, not the whole command

### DIFF
--- a/tools/agent-guard/src/agent_guard/__init__.py
+++ b/tools/agent-guard/src/agent_guard/__init__.py
@@ -113,8 +113,8 @@ class Segment:
     """One simple command from a (possibly compound) shell line.
 
     ``argv`` has leading ``NAME=value`` env assignments stripped into ``env``;
-    ``raw`` is the original text of the segment (used for substring scans that
-    survive heredocs, e.g. the Co-Authored-By trailer).
+    ``raw`` is a reconstruction of this segment's own tokens only (used for
+    substring scans that survive heredocs, e.g. the Co-Authored-By trailer).
     """
 
     def __init__(self, tokens: list[str], raw: str) -> None:
@@ -164,12 +164,12 @@ def split_segments(command: str) -> list[Segment]:
     for tok in tokens:
         if tok in SHELL_OPERATORS:
             if current:
-                segments.append(Segment(current, command))
+                segments.append(Segment(current, shlex.join(current)))
                 current = []
         else:
             current.append(tok)
     if current:
-        segments.append(Segment(current, command))
+        segments.append(Segment(current, shlex.join(current)))
     return segments
 
 

--- a/tools/agent-guard/tests/test_guards.py
+++ b/tools/agent-guard/tests/test_guards.py
@@ -218,6 +218,13 @@ def test_compound_command_guarded():
     assert dispatch('cd /tmp && git commit -m "x\nCo-Authored-By: a"') is not None
 
 
+def test_compound_command_other_segment_not_denied():
+    # The phrase lives in an unrelated earlier segment, not in the commit's
+    # own message, so the commit segment must not inherit it.
+    command = 'echo "note: never add a Co-Authored-By: trailer" && git commit -m "clean fix"'
+    assert dispatch(command) is None
+
+
 def test_malformed_command_allows():
     assert dispatch('gh pr comment 5 --body "oops') is None
 


### PR DESCRIPTION
`split_segments()` builds every `Segment` in a compound command as `Segment(current, command)`, passing the whole input string as `raw` regardless of which segment it is. `guard_commit_trailer` searches `seg.raw` for `co-authored-by:`, so it was really searching the entire line, not the commit's own message. A `git commit` with a clean message gets denied if an unrelated earlier segment (a comment, a grep, an echo) happens to contain that phrase.

Fixed by giving each segment `raw = shlex.join(current)`, a reconstruction of that segment's own tokens only. It still supports the heredoc-survival case the docstring describes: `shlex.split` doesn't parse `<<` specially, so a heredoc's delimiter and body just become ordinary tokens attached to the segment they trail, and `shlex.join` puts them back as one searchable string. Checked the field's only other reader, `GuardContext.raw`: none of the four `guards.d`/skill-contributed guards use it, so the fix's blast radius is exactly the one guard this issue is about.

Added `test_compound_command_other_segment_not_denied`, the new test breaks without the change and passes with it. Full `tools/agent-guard` suite (92 tests), ruff, ruff format and mypy all come back clean in a `python:3.11-slim` container.

Fixes #1150
