### PR TITLE
docs(agents): document <PROJECT> vs <project>, and catch spaced variants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,6 +378,8 @@ configuration before executing any command:
 
 | Placeholder | Resolves to | Source |
 |---|---|---|
+| `<PROJECT>` | The project's **display name**, as written in prose, headings, and reporter-facing copy (example: `Apache Foo`). Upper-case throughout. Not interchangeable with `<project>` — see the note below the table. | `<project-config>/project.md` → `project_name` |
+| `<project>` | The project's **infrastructure slug**, as it appears inside mailing-list addresses, roster URLs, and svn / dist paths (example: `foo` in `dev@foo.apache.org`, `svn.apache.org/repos/asf/foo/site`, `dist.apache.org/repos/dist/dev/foo`). Lower-case throughout. Not interchangeable with `<PROJECT>` — see the note below the table. | `<project-config>/project.md` → `short_name`, lowercased — equivalently the name half of `upstream_repo` |
 | `<project-config>` | The adopting project's config directory in its tracker repo (alongside the gitignored `.apache-magpie/` snapshot, not inside it). Bootstrapped from `projects/_template/`. | Filesystem convention. |
 | `<framework>` | The framework root — `.apache-magpie/` (the gitignored snapshot) in adopting projects, `.` in framework standalone. Used in `uv run` and other invocations that address the framework's `tools/<name>/` subtrees. | Filesystem convention. |
 | `<tracker>` | GitHub slug of the (security) tracker repo (example: `airflow-s/airflow-s`). | `<project-config>/project.md` → `tracker_repo` |
@@ -392,6 +394,19 @@ configuration before executing any command:
 | `<project-stage>` | The project's lifecycle stage, if its organization has one (example: `incubating`). | `project.md` → organization → `governance_vocabulary.project_stage_vocab` |
 | `<N>` | An issue or PR number. | The user's input to the skill |
 | `<CVE-ID>` | A CVE identifier of the form `CVE-YYYY-NNNNN`. | Per-tracker |
+
+**`<PROJECT>` and `<project>` are two different placeholders holding two
+different values, not a casing preference for one.** `<PROJECT>` is the
+display name (`Apache Foo`); `<project>` is the infrastructure slug (`foo`).
+The rule of thumb: if the substitution sits inside a hostname, an email
+address, or a URL path, it is `<project>`; if a human reads it as the
+project's name, it is `<PROJECT>`. Substituting one where the other belongs
+produces a value that is wrong rather than merely mis-cased — `Apache
+Foo.apache.org` is not a hostname, and *"the foo security team"* is not how
+the project is named to a reporter. Because the two differ only by case, a
+fixed-string linter pattern written for one will not catch the other; keep
+both spellings in mind when adding checks to
+[`tools/dev/check-placeholders.sh`](tools/dev/check-placeholders.sh).
 
 Do not invent new placeholders; thread a needed value in via the project
 manifest or the user config rather than reaching for a fresh convention.

--- a/tools/dev/check-placeholders.sh
+++ b/tools/dev/check-placeholders.sh
@@ -21,7 +21,9 @@
 # Verifies that framework-level skill / tool docs refer to
 # adopting-project specifics through placeholders only:
 #
-#   <PROJECT>   — adopting project's display name
+#   <PROJECT>   — adopting project's display name ("Apache Foo")
+#   <project>   — adopting project's infrastructure slug ("foo"), as
+#                 used in list addresses, roster URLs and svn paths
 #   <tracker>   — adopting project's private tracker repo slug
 #   <upstream>  — adopting project's public source repo slug
 #
@@ -51,11 +53,21 @@ FORBIDDEN_PATTERNS=(
   "airflow-s/airflow-s"
   "Apache Airflow"
   "apache.org/airflow"
-  # Lowercase forms that slip past the four above: a GraphQL
-  # `repository(owner:"apache",name:"airflow")` argument and a
+  # Lowercase form that slips past the four above: a
   # `closer.lua?path=airflow/` dist path.
-  'name:"airflow"'
   "path=airflow"
+)
+
+# Same purpose, but matched as extended regexes (grep -E) rather than
+# fixed strings. Reserved for references whose surrounding syntax
+# admits optional whitespace, where a fixed string would only catch
+# one spelling: GraphQL / YAML / JSON all accept `name:"airflow"` and
+# `name: "airflow"` interchangeably, so pinning the no-space form lets
+# the spaced one through. Keep entries here to the cases that actually
+# need it — a fixed string in FORBIDDEN_PATTERNS is easier to read and
+# cannot misfire on regex metacharacters.
+FORBIDDEN_REGEXES=(
+  'name:[[:space:]]*"airflow"'
 )
 
 # Files / directories where Airflow references are intentional:
@@ -137,12 +149,34 @@ main() {
 
   echo "check-placeholders: scanning ${SCAN_PATHS[*]} for hardcoded project references..."
 
-  for pattern in "${FORBIDDEN_PATTERNS[@]}"; do
+  # Tag each pattern with the grep mode it needs, so the two arrays
+  # share one match-reporting path below. The tag is split on the
+  # first colon only, which leaves regexes containing `:` intact.
+  local -a scan_specs=()
+  local entry
+  for entry in "${FORBIDDEN_PATTERNS[@]}"; do
+    scan_specs+=( "F:$entry" )
+  done
+  for entry in "${FORBIDDEN_REGEXES[@]}"; do
+    scan_specs+=( "E:$entry" )
+  done
+
+  local spec
+  for spec in "${scan_specs[@]}"; do
+    local mode="${spec%%:*}"
+    local pattern="${spec#*:}"
     local matches
-    matches=$(grep -rFn \
-      --include='*.md' \
-      "$pattern" \
-      "${SCAN_PATHS[@]}" 2>/dev/null || true)
+    if [[ "$mode" == "F" ]]; then
+      matches=$(grep -rFn \
+        --include='*.md' \
+        "$pattern" \
+        "${SCAN_PATHS[@]}" 2>/dev/null || true)
+    else
+      matches=$(grep -rEn \
+        --include='*.md' \
+        "$pattern" \
+        "${SCAN_PATHS[@]}" 2>/dev/null || true)
+    fi
 
     if [[ -z "$matches" ]]; then
       continue


### PR DESCRIPTION
## Summary

- `<PROJECT>` (display name, 84 uses) and `<project>` (infrastructure slug, 313 uses) are both load-bearing — across skills, tool docs, `organizations/ASF/organization.md` and `PRINCIPLES.md` — yet neither had a row in the placeholder table in `AGENTS.md`, which closes with *"do not invent new placeholders"*. Answering *"is `<project>` an invented placeholder?"* needed a repo-wide grep instead of a table lookup. Both now have a row, plus a note stating the difference explicitly: **two placeholders holding two different values, not one value in two casings.** Substituting one where the other belongs produces something wrong rather than mis-cased — `Apache Foo.apache.org` is not a hostname.
- The same case-only difference is a linter hazard. `FORBIDDEN_PATTERNS` is matched with `grep -F`, so the `name:"airflow"` entry added in #1144 only caught the no-space spelling — GraphQL, YAML and JSON all accept `name: "airflow"` equally, and that form passed **every** pattern in the list. Patterns whose surrounding syntax admits optional whitespace now live in a new `FORBIDDEN_REGEXES` array matched with `grep -E`; the two arrays share one match-reporting path. Fixed strings stay the default — easier to read, and they cannot misfire on regex metacharacters.

Both gaps surfaced while reviewing #1144; this is the follow-up that PR's review nit pointed at.

## Type of change

- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] `prek run` passes on both changed files — including `lychee` (the new link to `tools/dev/check-placeholders.sh` resolves) and `doctoc` (no headings changed, so the TOC is untouched).
- [x] **Linter is clean on the current tree:** `tools/dev/check-placeholders.sh` exits 0.
- [x] **Regression, new behaviour:** planting `repository(owner: "apache", name: "airflow")` in `skills/` is now caught — it was **not** caught before this change.
- [x] **Regression, existing behaviour:** planting `repository(owner:"apache",name:"airflow")` is still caught, so the `grep -F` → `grep -E` move loses no coverage.
- [x] `bash -n tools/dev/check-placeholders.sh` clean.
- No eval suites affected — no `SKILL.md` or step prompt material changes, so per `AGENTS.md` § *When the rule fires* this is the prose/tooling row that needs no fixture rerun.

## RFC-AI-0004 compliance

- [x] **Vendor neutrality** — this PR strengthens the mechanical gate that enforces placeholder discipline, and documents the two placeholders it protects.

## Linked issues

Follow-up to #1144.
