### PR TITLE
ci(asf.yaml): stop blocking merge on unresolved review threads

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -185,10 +185,19 @@ github:
       # above — squash is the only enabled merge mode, so every
       # merge results in a single commit on top of main.
       required_linear_history: true
-      # Block merge while review threads remain unresolved. This
-      # bites even without an approval requirement: any reviewer
-      # who opens a thread blocks merge until it is resolved.
-      required_conversation_resolution: true
+      # Do NOT block merge on unresolved review threads. With the
+      # approval requirement lifted above, this was the one merge gate
+      # a reviewer could trip by accident: *any* open thread held the
+      # PR, including a nit the reviewer explicitly marked as
+      # non-blocking. The observed effect is reviewers resolving their
+      # own advisory comments purely to unblock the merge, which
+      # defeats the point of leaving the comment where the author can
+      # still see it. Unresolved threads remain visible in the PR UI;
+      # they are simply no longer a hard gate.
+      #
+      # Restore alongside `required_pull_request_reviews` above if the
+      # project later wants threads to gate merge again.
+      required_conversation_resolution: false
       # Do NOT require signed commits. External contributors
       # without configured GPG/SSH signing would be unable to
       # contribute. Re-enable if/when the project adopts a


### PR DESCRIPTION
## Summary

- `required_conversation_resolution: true` made **any** open review thread a hard merge gate. With the approval requirement currently lifted, it was the one gate a reviewer could trip by accident.
- The failure mode is specific and was hit repeatedly during a review pass over #1141–#1145: a reviewer leaves a nit they explicitly mark *non-blocking*, the PR becomes unmergeable, and the reviewer resolves their own advisory comment purely to unblock the merge. That destroys the signal — an unresolved thread should mean "the author hasn't looked at this yet", not "the merge button is stuck".
- Unresolved threads stay visible in the PR UI; they are simply no longer a hard gate. `zizmor` / `prek` / `tests-ok` and `required_linear_history` are untouched, so nothing merges without green CI.

## Not included: Actions workflow approval

The other half of the request — stop requiring maintainer approval for contributors' workflow runs — **cannot be expressed in `.asf.yaml`.** I checked the asfyaml implementation rather than guessing: [`asfyaml/feature/github/`](https://github.com/apache/infrastructure-asfyaml/tree/main/asfyaml/feature/github) has modules for branch protection, rulesets, merge buttons, collaborators, pull requests, protected tags, pages, environments and Copilot review — but **no Actions module**, and no `actions` / `fork` / `approval` keys anywhere in the feature set.

That setting lives in GitHub's *Settings → Actions → General → Fork pull request workflows from outside collaborators*. It needs either a repo admin or an ASF Infra (JIRA) request. Worth noting `potiuk` currently has `push`/`triage` but not `admin` or `maintain` on this repo, so it needs Infra.

Empirically the repo is on **"Require approval for all outside collaborators"** rather than the first-time-contributor default: `AmirF194` is a returning `CONTRIBUTOR` with three open PRs and every run is still gated. Moving it to *"Require approval for first-time contributors"* would unblock the recurring contributors while keeping the guard for brand-new accounts.

## Type of change

- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] YAML parses; no other key touched (single-key diff plus its comment block).
- [x] `prek` passes on the changed file.
- [x] Verified against the asfyaml source that `required_conversation_resolution` is a supported `protected_branches` key (`asfyaml/feature/github/branch_protection.py:140`), so this lands rather than being silently ignored.
- ASF Infra reconciles `protected_branches` within a few minutes of merge to `main`.

## Linked issues

Follow-up to the review pass on #1141, #1144, #1145, #1143, #1142.
