### PR TITLE
feat(tracker-stats): project the current bucket to end-of-bucket totals

### DIFF
--- a/projects/_template/security-tracker-stats.md
+++ b/projects/_template/security-tracker-stats.md
@@ -11,6 +11,7 @@
   - [Cache directory](#cache-directory)
   - [Refresh cadence](#refresh-cadence)
   - [Rejected-without-tracker ledger](#rejected-without-tracker-ledger)
+  - [Current-bucket projection](#current-bucket-projection)
   - [Example overlay (`security-tracker-stats.yaml`)](#example-overlay-security-tracker-statsyaml)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -100,6 +101,29 @@ The ASF default is `rejections-ledger`, matching
 `tracker.labels.rejections_ledger` in `project.md`. To turn the stat
 on, create the open ledger issue, label it, and keep this knob
 pointed at the same label.
+
+## Current-bucket projection
+
+```yaml
+projection:
+  enabled: true
+  min_elapsed_fraction: 0.1
+```
+
+Lives in the renderer's YAML overlay. The dashboard's final bucket is
+always cut short by "now", so every count in it reads low against
+complete buckets. When enabled, the renderer extrapolates each
+projectable series to its end-of-bucket value and draws a dotted
+continuation on every chart that carries one — the lifecycle bands,
+opened / untriaged / reported, the cumulative lines, and the
+rejections chart — plus a header banner. Intake counts scale whole;
+cumulative totals and end-of-bucket snapshots scale only their
+movement inside the bucket. The mean-time charts are not projected.
+
+`min_elapsed_fraction` is the floor below which the projection is
+suppressed as noise (default `0.1` — one tenth of the bucket).
+Low-volume trackers, where a single report swings the projection by
+tens, want a higher floor; `enabled: false` turns the stat off.
 
 ## Example overlay (`security-tracker-stats.yaml`)
 

--- a/skills/security-tracker-stats-dashboard/SKILL.md
+++ b/skills/security-tracker-stats-dashboard/SKILL.md
@@ -165,10 +165,21 @@ fetch.
 
 4. **Report the result.** Print the final HTML path and a short
    summary (total trackers, open count, latest-bucket category
-   breakdown, triage-median, PR-merge-median when configured). The
-   pipeline already echoes most of this to stdout — pass it
-   through verbatim and add the clickable
+   breakdown, triage-median, PR-merge-median when configured, and the
+   current-bucket projection). The pipeline already echoes most of
+   this to stdout — pass it through verbatim and add the clickable
    `file://<output-path>` line at the end.
+
+   The final bucket is always partial, so its counts are not
+   comparable with the complete buckets before it. Quote the
+   `Current-bucket projection` block as projections — never present a
+   projected number as an observed count, and keep the elapsed
+   percentage attached. Report the intake lines (`opened`,
+   `reported`) and the untriaged-backlog band; the rest of the block
+   is there for the charts and only needs quoting when the user asks
+   about that series. When the block says *skipped*, say the
+   projection was suppressed and why (too early in the bucket, a
+   single-bucket axis, or disabled) rather than silently omitting it.
 
 The full pipeline:
 
@@ -225,6 +236,16 @@ The most-overridden knobs by adopters tend to be:
 - **`triage.keywords:`** / **`triage.bot_prefixes:`** — the
   time-to-triage signal. Adopters whose security team uses
   different phrasing in triage-proposal comments override these.
+- **`projection:`** — the end-of-bucket projection for the current
+  (partial) bucket, drawn as a dotted continuation on every chart
+  that carries a projectable series (lifecycle bands, opened /
+  untriaged, cumulative, rejections) plus a header banner. Intake
+  series scale whole (`observed / elapsed`); cumulative totals and
+  snapshots scale only their movement inside the bucket; the
+  mean-time charts are not projected. `enabled: false` switches it
+  off; `min_elapsed_fraction:` (default `0.1`) suppresses it early
+  in a bucket, where one report extrapolates to a dozen. Low-volume
+  trackers may want a higher threshold.
 
 ---
 
@@ -262,6 +283,7 @@ overlay is being picked up.
 | `events/<N>.json` missing for some N | gh transient failure during paginate | Re-run; `fetch_events.py` resumes from cache |
 | `prs.json` has `{"error": ...}` entries | False-positive body parse (PR# doesn't exist) | Silently filtered at render; safe to ignore |
 | `c_rel` median jumps after re-fetch | New advisory shipped since last run | Expected — re-render is correct |
+| No projection banner on the dashboard | Current bucket below `projection.min_elapsed_fraction`, or the stat is disabled | Expected — stdout prints the skip reason |
 | Empty `c_prc` / `c_prm` / `c_rel` early buckets | No linked PR in those tracker buckets | Expected — not all early trackers had a fix PR |
 | Three PR charts missing entirely | `upstream_repo: null` in config (or env override) | By design — set `upstream_repo:` if you want them |
 | `ModuleNotFoundError: yaml` | PyYAML missing | Bundled fallback parser handles `default-config.yaml`; install pyyaml for richer overlays |

--- a/tools/security-tracker-stats-dashboard/README.md
+++ b/tools/security-tracker-stats-dashboard/README.md
@@ -13,6 +13,7 @@
     - [Categories (lifecycle bands)](#categories-lifecycle-bands)
     - [Time-to-triage signal](#time-to-triage-signal)
     - [Milestones (vertical annotations)](#milestones-vertical-annotations)
+    - [Current-bucket projection (`projection`)](#current-bucket-projection-projection)
     - [Rejected-without-tracker ledger (`rejections_ledger_label`)](#rejected-without-tracker-ledger-rejections_ledger_label)
     - [When `upstream_repo` is null](#when-upstream_repo-is-null)
   - [Prerequisites](#prerequisites)
@@ -159,6 +160,72 @@ on every time-axis chart. Each entry needs `date: YYYY-MM-DD` (mapped
 onto the bucket axis) and `label`. Set `milestones: []` in an overlay
 to remove them entirely.
 
+### Current-bucket projection (`projection`)
+
+```yaml
+projection:
+  enabled: true
+  min_elapsed_fraction: 0.1
+```
+
+The last bucket on the axis is always cut short by "now", so every
+count in it reads low against complete buckets — regenerate the
+dashboard on the 8th of a month and September looks like a collapse in
+reports rather than a month that is 23 % over. The projection
+extrapolates that final bucket to where it is on course to end.
+
+Two kinds of series need two different extrapolations:
+
+| Kind | Series | Formula |
+|---|---|---|
+| **rate** — accumulates from zero inside the bucket | opened / rejected / reported in bucket | `observed / elapsed` |
+| **level** — carries over from the previous bucket | cumulative opened / closed / rejected / reported, every lifecycle band, the untriaged backlog | `prev + (observed - prev) / elapsed` |
+
+Only the movement *inside* the bucket is scaled for a level series —
+scaling the level itself would multiply years of accumulated history
+by four. A falling level (a backlog being worked down) projects
+further down, floored at zero. A rate projection is never below what
+has already happened.
+
+Projections are drawn on every chart that carries a projectable
+series: the lifecycle bands, *Reported vs. opened vs. untriaged*, the
+cumulative chart, and the rejections chart. Each is a dotted two-point
+segment from the last complete bucket's actual value to the projected
+end-of-bucket value, so a forecast can never be mistaken for a
+measurement. On the stacked lifecycle chart each band's forecast is
+drawn at its projected position *in the stack*, with the band's own
+projected count in the hover (legend entries suppressed — five extra
+rows would double the legend). Since the bands partition every
+tracker, their projected values sum to the projected cumulative
+opened, which makes an easy sanity check.
+
+**The mean-time charts are deliberately not projected.** A mean over
+the items seen so far is already an estimate of the bucket's mean, not
+a partial accumulation — scaling it by elapsed time would be
+meaningless.
+
+An HTML header banner carries the operational headline (reported,
+opened, and the projected untriaged backlog); stdout lists every
+projected series:
+
+```text
+Current-bucket projection (2026-09, 23% elapsed, now -> month-end):
+  opened                      9 -> 38
+  rejected                    3 -> 13
+  reported                   12 -> 51
+  cum_opened                355 -> 384
+  cum_closed                313 -> 323
+  band:open_untriaged        14 -> 7
+  band:open_triaged          16 -> 39
+```
+
+`min_elapsed_fraction` suppresses the projection early in a bucket,
+where the extrapolation is noise: two days into a month a single
+report projects to fifteen. Below the threshold the banner and traces
+are omitted and stdout says why. The projection is also skipped when
+the axis holds a single bucket — the level series have no baseline to
+project from. `enabled: false` switches the whole stat off.
+
 ### Rejected-without-tracker ledger (`rejections_ledger_label`)
 
 ```yaml
@@ -244,5 +311,6 @@ remaining charts still render.
 | `events/<N>.json` missing for some N | gh transient failure during paginate | Re-run `run.sh`; `fetch_events.py` resumes from cache |
 | `prs.json` has `{"error": ...}` entries | False-positive body parse (PR# doesn't exist) | Silently filtered at render; safe to ignore |
 | `c_rel` median jumps after re-fetch | New advisory shipped since last run | Expected — re-render is correct |
+| No projection banner / dotted trace | Bucket below `min_elapsed_fraction`, or `projection.enabled: false` | Expected — stdout prints the skip reason |
 | Empty `c_prc` / `c_prm` / `c_rel` early buckets | No linked PR in those tracker buckets | Expected — not all early trackers had a fix PR |
 | `ModuleNotFoundError: yaml` | PyYAML missing | The bundled fallback parser handles `default-config.yaml`; for richer overlays install pyyaml or use `TRACKER_STATS_PY=uv-yaml` |

--- a/tools/security-tracker-stats-dashboard/default-config.yaml
+++ b/tools/security-tracker-stats-dashboard/default-config.yaml
@@ -43,6 +43,24 @@ upstream_repo: apache/airflow   # null -> skip c_prc/c_prm/c_rel charts and the 
                                 # Mirrors <project-config>/project.md -> `upstream_repo`; ASF default is the airflow-s adopter's
                                 # value. Override in the overlay if the renderer should chart a different repo (or null).
 
+# End-of-bucket projection for the current (partial) bucket. The last
+# bucket on the axis is almost always cut short by "now", so every count
+# in it reads low next to complete buckets. When enabled, the renderer
+# extrapolates each projectable series to bucket end and draws the
+# result as a dotted continuation plus a header banner.
+#
+# Rate series (opened / rejected / reported in bucket) scale whole:
+# observed / elapsed_fraction. Level series (cumulative totals, the
+# lifecycle bands, the untriaged backlog) scale only their movement
+# inside the bucket: prev + (observed - prev) / elapsed_fraction. The
+# mean-time charts are not projected at all — a mean of the items so
+# far is already an estimate of the bucket's mean.
+projection:
+  enabled: true                 # false -> no projection banner, trace, or stdout line
+  min_elapsed_fraction: 0.1     # skip the projection until this much of the bucket has
+                                # elapsed; a couple of days into a month one report
+                                # extrapolates to fifteen, which is noise, not a signal
+
 milestones:
   - date: 2026-04-13
     label: skill adoption

--- a/tools/security-tracker-stats-dashboard/render.py
+++ b/tools/security-tracker-stats-dashboard/render.py
@@ -60,8 +60,10 @@ sys.path.insert(0, os.path.join(_HERE, "src"))
 
 from security_tracker_stats_dashboard.core import (  # noqa: E402
     _minimal_yaml_load,
+    bucket_bounds,
     build_triage_regex,
     deep_merge,
+    elapsed_fraction,
     eval_predicate,
     is_bot_body,
     iter_months,
@@ -75,6 +77,8 @@ from security_tracker_stats_dashboard.core import (  # noqa: E402
     month_label,
     month_of,
     parse_dt,
+    project_bucket_level,
+    project_bucket_total,
     quarter_end,
     quarter_label,
     quarter_of,
@@ -131,6 +135,8 @@ CONFIG = load_config()
 BUCKETS_MODE = CONFIG.get("buckets", "monthly")
 if BUCKETS_MODE not in ("monthly", "quarterly", "weekly"):
     raise SystemExit(f"buckets must be 'monthly', 'quarterly' or 'weekly', got {BUCKETS_MODE!r}")
+# Prose word for one bucket, used in stdout lines and chart titles.
+bucket_word = {"monthly": "month", "weekly": "week"}.get(BUCKETS_MODE, "quarter")
 
 START_OVERRIDE = CONFIG.get("start")
 UPSTREAM_REPO = CONFIG.get("upstream_repo")
@@ -142,6 +148,10 @@ BOT_PREFIXES = tuple(CONFIG.get("triage", {}).get("bot_prefixes") or [])
 # Label identifying the "rejected without tracker" ledger issue. When
 # null (or no such issue exists) the rejection stat is omitted / shows 0.
 REJECTIONS_LEDGER_LABEL = CONFIG.get("rejections_ledger_label")
+# End-of-bucket projection for the current (partial) bucket.
+PROJECTION_CFG = CONFIG.get("projection") or {}
+PROJECTION_ENABLED = PROJECTION_CFG.get("enabled", True)
+PROJECTION_MIN_ELAPSED = float(PROJECTION_CFG.get("min_elapsed_fraction", 0.1) or 0.0)
 
 # Distinct category names in the order they FIRST appear in CATEGORIES_CFG
 # (multiple rules can share a name to express disjoint branches of the
@@ -523,6 +533,69 @@ for i in issues:
 # stat is disabled, so the trace is only drawn when the stat is active.
 reported_in_b = [o + r for o, r in zip(opened_in_b, rejected_series, strict=True)]
 
+# --- current-bucket projection -------------------------------------
+#
+# The last bucket on the axis is cut short by "now", so every count in it
+# reads low against complete buckets and the series appear to fall off a
+# cliff each time the dashboard is regenerated mid-month. Extrapolate the
+# final bucket to what it is on course to be at bucket end.
+#
+# Two kinds of series need two different extrapolations:
+#
+#   RATE  — per-bucket intake that accumulates from zero inside the
+#           bucket (opened / rejected / reported in bucket). The whole
+#           count scales: observed / elapsed_fraction.
+#   LEVEL — cumulative totals and end-of-bucket snapshots (the lifecycle
+#           bands, the untriaged backlog, the cumulative lines). These
+#           carry over from the previous bucket, so only the movement
+#           *inside* the bucket scales: prev + (observed - prev) / f.
+#           Scaling the whole level would multiply three years of
+#           accumulated history by four.
+#
+# The mean-time charts (triage / first response / PR / release) are
+# deliberately NOT projected: a mean over the items seen so far is
+# already an estimate of the bucket's mean, not a partial accumulation,
+# so scaling it by elapsed time would be meaningless.
+#
+# PROJECTIONS is empty whenever there is nothing meaningful to project —
+# the stat is switched off, the final bucket is already complete (a run
+# at or after bucket end), too little of it has elapsed for the
+# extrapolation to mean anything (`min_elapsed_fraction`), or there is
+# no earlier bucket to serve as a baseline for the level series.
+b_start, b_end = bucket_bounds(*buckets[-1], BUCKETS_MODE)
+cur_elapsed = elapsed_fraction(NOW, b_start, b_end)
+PROJECTIONS = {}  # series key -> projected end-of-bucket value
+projection_skip_reason = None
+
+if not PROJECTION_ENABLED:
+    projection_skip_reason = "disabled in config"
+elif cur_elapsed >= 1.0:
+    projection_skip_reason = f"bucket {bucket_labels[-1]} is already complete"
+elif cur_elapsed < PROJECTION_MIN_ELAPSED:
+    projection_skip_reason = (
+        f"only {cur_elapsed:.0%} of {bucket_labels[-1]} elapsed "
+        f"(min_elapsed_fraction={PROJECTION_MIN_ELAPSED:.0%})"
+    )
+elif n_buckets < 2:
+    projection_skip_reason = "only one bucket on the axis — no baseline to project from"
+else:
+
+    def _proj_rate(key, series):
+        PROJECTIONS[key] = project_bucket_total(series[-1], cur_elapsed)
+
+    def _proj_level(key, series):
+        PROJECTIONS[key] = project_bucket_level(series[-2], series[-1], cur_elapsed)
+
+    _proj_rate("opened", opened_in_b)
+    _proj_rate("rejected", rejected_series)
+    _proj_rate("reported", reported_in_b)
+    _proj_level("cum_opened", cum_opened)
+    _proj_level("cum_closed", cum_closed)
+    _proj_level("cum_rejected", cum_rejected)
+    _proj_level("cum_reported", cum_reported)
+    for cat in CATS:
+        _proj_level(f"band:{cat}", counts[cat])
+
 # --- triage / response ---------------------------------------------
 
 TRIAGE_RE = build_triage_regex(TRIAGE_KW)
@@ -711,11 +784,71 @@ print(
     f"opened_in_b={opened_in_b[-1]}, untriaged_at_bend={untriaged_at_bend[-1]}"
 )
 
+if not PROJECTIONS:
+    print(f"Current-bucket projection: skipped ({projection_skip_reason})")
+else:
+    print()
+    print(
+        f"Current-bucket projection ({bucket_labels[-1]}, {cur_elapsed:.0%} elapsed, now -> {bucket_word}-end):"
+    )
+    _proj_now = {
+        "opened": opened_in_b[-1],
+        "rejected": rejected_series[-1],
+        "reported": reported_in_b[-1],
+        "cum_opened": cum_opened[-1],
+        "cum_closed": cum_closed[-1],
+        "cum_rejected": cum_rejected[-1],
+        "cum_reported": cum_reported[-1],
+        **{f"band:{cat}": counts[cat][-1] for cat in CATS},
+    }
+    _rejections_on = bool(REJECTIONS_LEDGER_LABEL and (rejections_total or ledger_issues))
+    for key, projected in PROJECTIONS.items():
+        if not _rejections_on and key in ("rejected", "reported", "cum_rejected", "cum_reported"):
+            continue
+        print(f"  {key:<24} {_proj_now[key]:>4} -> {projected}")
+
 
 # --- Render HTML ---------------------------------------------------
 
-# Title prefix differs between bucket modes for clarity.
-bucket_word = {"monthly": "month", "weekly": "week"}.get(BUCKETS_MODE, "quarter")
+# Projection traces: a dotted segment from the last COMPLETE bucket's
+# actual value to the projected end-of-bucket value. Every point before
+# that is null, and connectgaps stays off (unlike the actual series), so
+# the forecast reads as a forecast and can never be mistaken for a
+# measurement. `_proj_trace` returns "" when the series has no
+# projection, so every call site degrades to the un-projected chart.
+
+
+def _proj_trace(name, color, projected, actuals=None, prev_value=None, hover=None, showlegend=True):
+    """A two-point dotted trace: last complete bucket -> projected bucket end.
+
+    Returns "" when there is no projection for the series, so every call
+    site degrades to the plain chart. The baseline is `actuals[-2]`
+    unless *prev_value* names it explicitly (the stacked chart draws its
+    forecasts at running stack positions, not at a series value) — and
+    it is read only after the None check, so a single-bucket axis (where
+    nothing is projected) never indexes past the start of a series.
+    """
+    if projected is None:
+        return ""
+    prev = actuals[-2] if prev_value is None else prev_value
+    hover_text = hover if hover is not None else "projected: %{y}"
+    return (
+        ",\n  {x: "
+        + js_quotes([bucket_labels[-2], bucket_labels[-1]])
+        + ", y: "
+        + js_array([prev, projected])
+        + ", name: '"
+        + name
+        + "', type: 'scatter', mode: 'lines+markers', "
+        + ("" if showlegend else "showlegend: false, ")
+        + "line: {color: '"
+        + color
+        + "', dash: 'dot'}, "
+        + "hovertemplate: '%{x}<br>"
+        + hover_text
+        + "<extra></extra>'}"
+    )
+
 
 # Build stacked-band traces in STACK_ORDER. With the default config that
 # resolves to `fixed_released, open_pr_merged, open_triaged,
@@ -732,6 +865,41 @@ for cat in STACK_ORDER:
         f"fillcolor: '{color}', hoveron: 'points+fills'}}"
     )
 stacked_block = ",\n".join(stacked_traces)
+
+# Lifecycle-band projections. The bands are stacked, so each band's
+# forecast is drawn at its projected position in the STACK — the running
+# sum bottom-up, matching the order the traces are emitted in above —
+# and the hover carries the band's own projected count, not the stack
+# top it is drawn at. Legend entries are suppressed: five extra rows
+# would double the legend for no information the colours don't carry.
+proj_states_traces = ""
+_stack_prev = 0
+_stack_proj = 0
+for cat in STACK_ORDER:
+    if cat not in counts:
+        continue
+    band_proj = PROJECTIONS.get(f"band:{cat}")
+    if band_proj is None:
+        continue
+    _stack_prev += counts[cat][-2]
+    _stack_proj += band_proj
+    proj_states_traces += _proj_trace(
+        f"projected {cat}",
+        CAT_COLORS.get(cat, "#888888"),
+        _stack_proj,
+        prev_value=_stack_prev,
+        hover=f"projected {cat}: {band_proj}",
+        showlegend=False,
+    )
+
+# Defined here rather than with the other projection traces below
+# because the rejections chart's JS is assembled before that point.
+proj_rej_trace = _proj_trace(
+    f"projected rejected ({bucket_word}-end)",
+    "#7f8c8d",
+    PROJECTIONS.get("rejected"),
+    rejected_series,
+)
 
 # Milestone shapes + annotations (multi-milestone capable).
 ms_shapes = []
@@ -798,7 +966,7 @@ if REJECTIONS_LEDGER_LABEL and (rejections_total or ledger_issues):
         f"  {{x: buckets, y: {js_array(rejected_series)}, "
         f"name: 'rejected (no tracker)', type: 'scatter', "
         f"mode: 'lines+markers', connectgaps: true, line: {{color: '#7f8c8d'}}, "
-        f"fill: 'tozeroy'}}\n"
+        f"fill: 'tozeroy'}}{proj_rej_trace}\n"
         f"], {{\n"
         f"  ...MILESTONES_LAYOUT,\n"
         f"  title: 'Reports rejected without a tracker (per {bucket_word}, dated; "
@@ -849,6 +1017,58 @@ if REJECTIONS_LEDGER_LABEL and (rejections_total or ledger_issues):
 else:
     rep_ou_trace = ""
 
+# Projections for the remaining charts: intake + backlog on the
+# opened-vs-untriaged chart, the cumulative lines, and the standalone
+# rejections chart. Each is "" when the projection is off, so the charts
+# fall back to their un-projected form.
+proj_ou_traces = _proj_trace(
+    f"projected opened ({bucket_word}-end)", "#1f77b4", PROJECTIONS.get("opened"), opened_in_b
+) + _proj_trace(
+    f"projected untriaged ({bucket_word}-end)",
+    "#d62728",
+    PROJECTIONS.get("band:open_untriaged"),
+    untriaged_at_bend,
+)
+proj_cum_traces = _proj_trace(
+    "projected cumulative opened", "#1f77b4", PROJECTIONS.get("cum_opened"), cum_opened
+) + _proj_trace("projected cumulative closed", "#2ca02c", PROJECTIONS.get("cum_closed"), cum_closed)
+
+if REJECTIONS_LEDGER_LABEL and (rejections_total or ledger_issues):
+    proj_ou_traces += _proj_trace(
+        f"projected reported ({bucket_word}-end)",
+        "#9467bd",
+        PROJECTIONS.get("reported"),
+        reported_in_b,
+    )
+    proj_cum_traces += _proj_trace(
+        "projected cumulative rejected", "#7f8c8d", PROJECTIONS.get("cum_rejected"), cum_rejected
+    ) + _proj_trace(
+        "projected reported (opened + rejected)",
+        "#9467bd",
+        PROJECTIONS.get("cum_reported"),
+        cum_reported,
+    )
+
+# Header banner — the operational headline: what is coming in, and what
+# the untriaged backlog is on course to be at bucket end.
+if not PROJECTIONS:
+    proj_header_html = ""
+else:
+    proj_bits = [f"opened <strong>{PROJECTIONS['opened']}</strong> (from {opened_in_b[-1]} so far)"]
+    if REJECTIONS_LEDGER_LABEL and (rejections_total or ledger_issues):
+        proj_bits.insert(
+            0,
+            f"reported <strong>{PROJECTIONS['reported']}</strong> (from {reported_in_b[-1]} so far)",
+        )
+    untriaged_proj = PROJECTIONS.get("band:open_untriaged")
+    if untriaged_proj is not None:
+        proj_bits.append(f"untriaged backlog <strong>{untriaged_proj}</strong> (now {untriaged_at_bend[-1]})")
+    proj_header_html = (
+        f'<div class="banner">Projected end of {bucket_word} '
+        f"<strong>{bucket_labels[-1]}</strong> at the rate so far "
+        f"({cur_elapsed:.0%} of the {bucket_word} elapsed): " + " · ".join(proj_bits) + "</div>\n"
+    )
+
 
 HTML = f"""<!DOCTYPE html>
 <html lang="en">
@@ -866,7 +1086,7 @@ body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; 
 </head>
 <body>
 
-{rej_header_html}
+{rej_header_html}{proj_header_html}
 <div class="grid">
 
 <div class="card full"><div id="c_states"></div></div>
@@ -889,7 +1109,7 @@ const MILESTONES_LAYOUT = {{shapes: milestoneShapes, annotations: milestoneAnnot
 
 // Stacked-line lifecycle bands
 Plotly.newPlot('c_states', [
-{stacked_block}
+{stacked_block}{proj_states_traces}
 ], {{
   ...MILESTONES_LAYOUT,
   title: 'Issue lifecycle bands (stacked, end-of-{bucket_word} snapshots)',
@@ -905,7 +1125,7 @@ Plotly.newPlot('c_open_vs_untriaged', [
     line: {{color: '#1f77b4'}}}},
   {{x: buckets, y: {js_array(untriaged_at_bend)},  name: 'untriaged at {bucket_word}-end',
     type: 'scatter', mode: 'lines+markers', connectgaps: true,
-    line: {{color: '#d62728'}}}}{rep_ou_trace}
+    line: {{color: '#d62728'}}}}{rep_ou_trace}{proj_ou_traces}
 ], {{
   ...MILESTONES_LAYOUT,
   title: 'Reported vs. opened vs. untriaged backlog (per {bucket_word})',
@@ -919,7 +1139,7 @@ Plotly.newPlot('c_cum', [
     line: {{color: '#1f77b4'}}, fill: 'tozeroy'}},
   {{x: buckets, y: {js_array(cum_closed)}, name: 'cumulative closed',
     type: 'scatter', mode: 'lines+markers', connectgaps: true,
-    line: {{color: '#2ca02c'}}, fill: 'tozeroy'}}{cum_rej_traces}
+    line: {{color: '#2ca02c'}}, fill: 'tozeroy'}}{cum_rej_traces}{proj_cum_traces}
 ], {{
   ...MILESTONES_LAYOUT,
   title: 'Cumulative reported (opened + rejected) vs. opened vs. closed (gap = open backlog)',

--- a/tools/security-tracker-stats-dashboard/src/security_tracker_stats_dashboard/core.py
+++ b/tools/security-tracker-stats-dashboard/src/security_tracker_stats_dashboard/core.py
@@ -133,6 +133,68 @@ def iter_weeks(y0: int, w0: int, y1: int, w1: int) -> Iterator[tuple[int, int]]:
         cur += dt.timedelta(days=7)
 
 
+def bucket_bounds(y: int, k: int, buckets_mode: str = "monthly") -> tuple[dt.datetime, dt.datetime]:
+    """Return (first instant, last instant) of a bucket, UTC.
+
+    `k` is the month (1..12), quarter (1..4) or ISO week number, matching
+    the second element of the bucket key tuples produced by `month_of` /
+    `quarter_of` / `week_of`.
+    """
+    if buckets_mode == "monthly":
+        return dt.datetime(y, k, 1, tzinfo=dt.UTC), month_end(y, k)
+    if buckets_mode == "quarterly":
+        return dt.datetime(y, (k - 1) * 3 + 1, 1, tzinfo=dt.UTC), quarter_end(y, k)
+    if buckets_mode == "weekly":
+        monday = dt.date.fromisocalendar(y, k, 1)
+        return dt.datetime(monday.year, monday.month, monday.day, tzinfo=dt.UTC), week_end(y, k)
+    raise ValueError(f"unknown buckets mode: {buckets_mode!r}")
+
+
+def elapsed_fraction(now: dt.datetime, start: dt.datetime, end: dt.datetime) -> float:
+    """How far *now* is through the [start, end] span, clamped to 0.0 .. 1.0.
+
+    A bucket whose end has already passed reads 1.0 (complete); a bucket
+    that has not started yet reads 0.0.
+    """
+    span = (end - start).total_seconds()
+    if span <= 0:
+        return 1.0
+    return max(0.0, min(1.0, (now - start).total_seconds() / span))
+
+
+def project_bucket_total(observed: int, fraction: float) -> int | None:
+    """Linear pro-rata projection of a partial bucket's end-of-bucket count.
+
+    For RATE series — per-bucket counts that accumulate from zero inside
+    the bucket (reports opened, reports rejected). Assumes the rate
+    observed so far holds for the rest of the bucket: `observed /
+    fraction`, rounded to a whole count. Returns None when the elapsed
+    fraction is zero (nothing to extrapolate from). The result is never
+    below *observed* — a projection may not un-count what already
+    happened.
+    """
+    if fraction <= 0:
+        return None
+    return max(observed, round(observed / fraction))
+
+
+def project_bucket_level(previous: int, observed: int, fraction: float) -> int | None:
+    """Linear projection of a partial bucket's end-of-bucket *level*.
+
+    For LEVEL series — cumulative totals and end-of-bucket snapshots,
+    which do not start each bucket at zero but carry over from the
+    previous bucket. Only the movement *within* the bucket is
+    extrapolated: `previous + (observed - previous) / fraction`. A level
+    that is falling (a backlog being worked down) projects further down,
+    floored at zero, since these series are counts.
+
+    Returns None when the elapsed fraction is zero.
+    """
+    if fraction <= 0:
+        return None
+    return max(0, round(previous + (observed - previous) / fraction))
+
+
 def milestone_x(milestone_date: str, buckets_mode: str = "monthly") -> str:
     """Map a milestone date string (YYYY-MM-DD) to a bucket-axis label."""
     y = int(milestone_date[:4])

--- a/tools/security-tracker-stats-dashboard/tests/test_core.py
+++ b/tools/security-tracker-stats-dashboard/tests/test_core.py
@@ -21,8 +21,10 @@ import pytest
 
 from security_tracker_stats_dashboard.core import (
     _minimal_yaml_load,
+    bucket_bounds,
     build_triage_regex,
     deep_merge,
+    elapsed_fraction,
     eval_predicate,
     is_bot_body,
     iter_months,
@@ -36,6 +38,8 @@ from security_tracker_stats_dashboard.core import (
     month_label,
     month_of,
     parse_dt,
+    project_bucket_level,
+    project_bucket_total,
     quarter_end,
     quarter_label,
     quarter_of,
@@ -277,6 +281,110 @@ class TestIterWeeks:
     def test_consecutive_count(self):
         result = list(iter_weeks(2026, 1, 2026, 10))
         assert len(result) == 10
+
+
+# ---------------------------------------------------------------------------
+# bucket_bounds / elapsed_fraction / project_bucket_total
+# ---------------------------------------------------------------------------
+
+
+class TestBucketBounds:
+    def test_monthly(self):
+        start, end = bucket_bounds(2026, 9, "monthly")
+        assert (start.year, start.month, start.day) == (2026, 9, 1)
+        assert (start.hour, start.minute, start.second) == (0, 0, 0)
+        assert (end.year, end.month, end.day) == (2026, 9, 30)
+        assert (end.hour, end.minute, end.second) == (23, 59, 59)
+
+    def test_monthly_february_leap(self):
+        _, end = bucket_bounds(2024, 2, "monthly")
+        assert end.day == 29
+
+    def test_quarterly(self):
+        start, end = bucket_bounds(2026, 3, "quarterly")
+        assert (start.year, start.month, start.day) == (2026, 7, 1)
+        assert (end.year, end.month, end.day) == (2026, 9, 30)
+
+    def test_weekly(self):
+        # ISO 2026-W01 runs Mon 2025-12-29 .. Sun 2026-01-04.
+        start, end = bucket_bounds(2026, 1, "weekly")
+        assert (start.year, start.month, start.day) == (2025, 12, 29)
+        assert (end.year, end.month, end.day) == (2026, 1, 4)
+
+    def test_is_utc(self):
+        start, end = bucket_bounds(2026, 9, "monthly")
+        assert start.tzinfo == dt.UTC
+        assert end.tzinfo == dt.UTC
+
+    def test_unknown_mode_raises(self):
+        with pytest.raises(ValueError):
+            bucket_bounds(2026, 9, "daily")
+
+
+class TestElapsedFraction:
+    def test_midway(self):
+        start, end = bucket_bounds(2026, 9, "monthly")
+        now = dt.datetime(2026, 9, 16, 0, 0, 0, tzinfo=dt.UTC)  # 15 of 30 days in
+        assert elapsed_fraction(now, start, end) == pytest.approx(0.5, abs=0.01)
+
+    def test_before_start_is_zero(self):
+        start, end = bucket_bounds(2026, 9, "monthly")
+        assert elapsed_fraction(dt.datetime(2026, 8, 20, tzinfo=dt.UTC), start, end) == 0.0
+
+    def test_after_end_is_one(self):
+        start, end = bucket_bounds(2026, 9, "monthly")
+        assert elapsed_fraction(dt.datetime(2026, 10, 5, tzinfo=dt.UTC), start, end) == 1.0
+
+    def test_zero_span_is_one(self):
+        t = dt.datetime(2026, 9, 1, tzinfo=dt.UTC)
+        assert elapsed_fraction(t, t, t) == 1.0
+
+
+class TestProjectBucketTotal:
+    def test_linear_extrapolation(self):
+        assert project_bucket_total(9, 0.3) == 30
+
+    def test_rounds_to_whole_count(self):
+        assert project_bucket_total(5, 0.3) == 17  # 16.67 -> 17
+
+    def test_complete_bucket_is_identity(self):
+        assert project_bucket_total(12, 1.0) == 12
+
+    def test_never_below_observed(self):
+        # Rounding must not project fewer reports than already happened.
+        assert project_bucket_total(9, 0.999) == 9
+
+    def test_zero_observed(self):
+        assert project_bucket_total(0, 0.4) == 0
+
+    def test_zero_fraction_is_none(self):
+        assert project_bucket_total(3, 0.0) is None
+
+
+class TestProjectBucketLevel:
+    def test_only_the_in_bucket_movement_is_scaled(self):
+        # 300 at the previous bucket end, +9 so far, a quarter elapsed
+        # -> +36 over the bucket. The 300 of history is NOT scaled.
+        assert project_bucket_level(300, 309, 0.25) == 336
+
+    def test_falling_level_projects_further_down(self):
+        # A backlog worked down from 16 to 14 in a quarter of the bucket.
+        assert project_bucket_level(16, 14, 0.25) == 8
+
+    def test_floored_at_zero(self):
+        assert project_bucket_level(4, 1, 0.1) == 0
+
+    def test_flat_level_stays_flat(self):
+        assert project_bucket_level(150, 150, 0.3) == 150
+
+    def test_complete_bucket_is_identity(self):
+        assert project_bucket_level(300, 309, 1.0) == 309
+
+    def test_zero_baseline_matches_rate_projection(self):
+        assert project_bucket_level(0, 9, 0.3) == project_bucket_total(9, 0.3)
+
+    def test_zero_fraction_is_none(self):
+        assert project_bucket_level(10, 12, 0.0) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The final bucket on every chart is cut short by "now", so regenerating the dashboard mid-month reads as a collapse in reports rather than a month that is only a quarter over. On the reference tracker today (8 September, 23 % elapsed) September shows 9 opened against August's 65.

## Two kinds of series, two extrapolations

| Kind | Series | Formula |
|---|---|---|
| rate — accumulates from zero inside the bucket | opened / rejected / reported in bucket | `observed / elapsed` |
| level — carries over from the previous bucket | cumulative opened / closed / rejected / reported, every lifecycle band, the untriaged backlog | `prev + (observed - prev) / elapsed` |

Scaling a level series whole would multiply years of accumulated history by four, so only the movement *inside* the bucket is extrapolated. A falling level (a backlog being worked down) projects further down, floored at zero; a rate projection is never below what already happened.

## Where it lands

Every chart that carries a projectable series: the lifecycle bands, opened-vs-untriaged, the cumulative lines, and the rejections chart. Each projection is a dotted two-point segment from the last complete bucket to the projected bucket end, so a forecast cannot be mistaken for a measurement. On the stacked lifecycle chart each band is drawn at its projected position *in the stack*, with the band's own projected count in the hover and legend entries suppressed. Because the bands partition every tracker, their projections sum to the projected cumulative opened — a free consistency check.

**The mean-time charts are deliberately not projected.** A mean over the items seen so far is already an estimate of the bucket's mean, not a partial accumulation; scaling it by elapsed time would be meaningless.

## Config

```yaml
projection:
  enabled: true
  min_elapsed_fraction: 0.1
```

`min_elapsed_fraction` suppresses the projection early in a bucket, where one report extrapolates to a dozen. The projection is also skipped on a single-bucket axis (no baseline for the level series) and when the bucket is already complete; stdout always says which.

## Reference output

```text
Current-bucket projection (2026-09, 23% elapsed, now -> month-end):
  opened                      9 -> 38
  reported                   12 -> 51
  cum_opened                355 -> 384
  band:open_untriaged        14 -> 7
  band:open_triaged          16 -> 39
```

## Testing

- 25 new unit tests over the three new pure helpers (`bucket_bounds`, `elapsed_fraction`, `project_bucket_total` / `project_bucket_level`) — bounds in all three bucket modes, clamping, rounding, the never-below-observed floor, the zero-floor on falling levels.
- Full `prek` run green (ruff, mypy, pytest, markdownlint, doctoc); lychee offline clean.
- Rendered against a live 355-tracker cache in monthly, quarterly and weekly modes, and all four skip paths exercised (disabled, below threshold, single-bucket axis, complete bucket).
- Emitted JS executed under Node against a stubbed Plotly to confirm all 13 projection traces parse and land on the right charts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJopDiCvbwSG6t4k15JE4H
