### PR TITLE
chore(version): stamp the dev version with the UTC time it lands

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,67 +9,67 @@
     {
       "name": "magpie",
       "source": ".",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "All Apache Magpie skills (all 10 families; ~21.7k always-on tokens)."
     },
     {
       "name": "magpie-contributor-growth",
       "source": "./plugins/magpie-contributor-growth",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie contributor-growth family (6 skills)."
     },
     {
       "name": "magpie-issue",
       "source": "./plugins/magpie-issue",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie issue family (8 skills)."
     },
     {
       "name": "magpie-mentoring",
       "source": "./plugins/magpie-mentoring",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie mentoring family (4 skills)."
     },
     {
       "name": "magpie-pairing",
       "source": "./plugins/magpie-pairing",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie pairing family (2 skills)."
     },
     {
       "name": "magpie-pr-management",
       "source": "./plugins/magpie-pr-management",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie pr-management family (8 skills)."
     },
     {
       "name": "magpie-release-management",
       "source": "./plugins/magpie-release-management",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie release-management family (10 skills)."
     },
     {
       "name": "magpie-repo-health",
       "source": "./plugins/magpie-repo-health",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie repo-health family (7 skills)."
     },
     {
       "name": "magpie-security",
       "source": "./plugins/magpie-security",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie security family (15 skills)."
     },
     {
       "name": "magpie-setup",
       "source": "./plugins/magpie-setup",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie setup family (9 skills)."
     },
     {
       "name": "magpie-utilities",
       "source": "./plugins/magpie-utilities",
-      "version": "0.2.0.dev0",
+      "version": "0.2.0.dev202609080121",
       "description": "Apache Magpie utilities family (5 skills)."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "description": "Apache Magpie — a reusable, governance-agnostic framework of agentic skills for maintaining open-source projects: release management, security triage, PR and issue workflows, contributor growth, and repo health.",
   "author": { "name": "Apache Magpie", "url": "https://magpie.apache.org/" },
   "homepage": "https://magpie.apache.org/",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "description": "Apache Magpie — agentic skills for maintaining open-source projects.",
   "skills": "./skills",
   "hooks": {

--- a/apm.yml
+++ b/apm.yml
@@ -6,7 +6,7 @@
 # Gemini). Schema is v0.1 and may change — verify against the current
 # https://microsoft.github.io/apm/ before publishing.
 name: magpie
-version: 0.2.0.dev0
+version: 0.2.0.dev202609080121
 type: skill
 description: >-
   Apache Magpie — a reusable, governance-agnostic framework of agentic skills

--- a/docs/setup/marketplaces.md
+++ b/docs/setup/marketplaces.md
@@ -453,10 +453,33 @@ network calls and touches nothing in the adopter repo.
 
 The plugin version tracks the framework version in `pyproject.toml`, which is
 the single authority every manifest mirrors verbatim — **including the `.devN`
-suffix**. Between releases the manifests therefore read `0.2.0.dev0`, not
-`0.2.0`: a bare `0.2.0` would advertise a release that does not exist yet. Only
-a tagged release carries a bare version, and only released versions are ever
-published to a marketplace, so the PEP 440 suffix never reaches a consumer.
+suffix**. Between releases the manifests therefore read
+`0.2.0.dev<YYYYMMDDHHMM>`, not `0.2.0`: a bare `0.2.0` would advertise a
+release that does not exist yet. Only a tagged release carries a bare version.
+
+**The dev suffix is a UTC timestamp, and it has to move for adopters to pick
+anything up.** This marketplace is served straight from the `main` branch of a
+git repo, so consumers *do* install dev versions — the suffix reaching them is
+the normal case, not the exception. `claude plugin update` compares version
+strings, not commit SHAs: while the suffix stays frozen at a constant like
+`.dev0`, an adopter's `claude plugin update` answers "already at the latest
+version" and never moves the pinned commit, however far behind `main` the
+installed copy has fallen. Their only recovery is
+`claude plugin marketplace update` followed by a full uninstall + reinstall of
+every plugin, which nobody discovers on their own.
+
+**When to bump.** Not every PR — that would put every contributor in conflict
+with every other over one line, for no gain on changes nobody is waiting for.
+Bump when the work needs to reach installed copies: before pointing anyone at
+`claude plugin update`, before announcing a change adopters should take, or
+when a batch of merged work has piled up behind a stale stamp. A bump is a
+one-line edit plus a regeneration, so it costs little whenever it is actually
+wanted.
+
+The stamp is minute-resolution and **UTC**, not local time: a repo with
+contributors in several timezones needs the string to sort in the order the
+bumps were actually made, and a date alone would collide whenever a day carries
+more than one.
 
 Nothing is hand-edited. `pyproject.toml` feeds the four ecosystem manifests,
 and the all-in-one [`.claude-plugin/plugin.json`](../../.claude-plugin/plugin.json)

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "description": "Apache Magpie — agentic skills for maintaining open-source projects. Skills are auto-discovered from ./skills.",
   "contextFileName": "GEMINI.md"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "magpie",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "description": "Apache Magpie — a reusable, governance-agnostic framework of agentic skills for maintaining open-source projects: release management, security triage, PR and issue workflows, contributor growth, and repo health.",
   "author": { "name": "Apache Magpie", "url": "https://magpie.apache.org/" },
   "homepage": "https://magpie.apache.org/",

--- a/plugins/magpie-contributor-growth/.claude-plugin/plugin.json
+++ b/plugins/magpie-contributor-growth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-contributor-growth",
   "description": "Apache Magpie \u2014 path-to-committer: activity sweeps, nominations, sentiment, readiness, committer/post-vote onboarding.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-issue/.claude-plugin/plugin.json
+++ b/plugins/magpie-issue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-issue",
   "description": "Apache Magpie \u2014 issue lifecycle: triage, reproduction, fix drafting, reassess, stale-sweep, dedup, backlog stats.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-mentoring/.claude-plugin/plugin.json
+++ b/plugins/magpie-mentoring/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-mentoring",
   "description": "Apache Magpie \u2014 newcomer mentoring: welcome, newcomer-issue explanations, good-first-issue authoring + sweep.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-pairing/.claude-plugin/plugin.json
+++ b/plugins/magpie-pairing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-pairing",
   "description": "Apache Magpie \u2014 pair a change with a structured self-review or a multi-agent adversarial review.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-pr-management/.claude-plugin/plugin.json
+++ b/plugins/magpie-pr-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-pr-management",
   "description": "Apache Magpie \u2014 PR-queue management: triage, stats, deep code review, quick-merge, stale-sweep, reviewer routing, pre-first-PR checks.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-release-management/.claude-plugin/plugin.json
+++ b/plugins/magpie-release-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-release-management",
   "description": "Apache Magpie \u2014 ASF release lifecycle: plan, RC cut/sign, vote, tally, promote, announce, archive, audit.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-repo-health/.claude-plugin/plugin.json
+++ b/plugins/magpie-repo-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-repo-health",
   "description": "Apache Magpie \u2014 read-only repo-health audits: runner labels, workflow security, dependency/license/NOTICE, flaky tests, audit-finding fixes.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-security/.claude-plugin/plugin.json
+++ b/plugins/magpie-security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-security",
   "description": "Apache Magpie \u2014 security-issue handling lifecycle \u2014 import through CVE publication, triage, sync, dedup, invalidate. Maintainer-only.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-setup/.claude-plugin/plugin.json
+++ b/plugins/magpie-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-setup",
   "description": "Apache Magpie \u2014 framework install/maintenance: install (adopt), upgrade, verify, override, status, secure-agent setup, shared-config sync.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-utilities/.claude-plugin/plugin.json
+++ b/plugins/magpie-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-utilities",
   "description": "Apache Magpie \u2014 framework meta-skills: write-skill, optimize-skill, skill-reconciler, list-skills.",
-  "version": "0.2.0.dev0",
+  "version": "0.2.0.dev202609080121",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/projects/magpie/release-management-config.md
+++ b/projects/magpie/release-management-config.md
@@ -75,10 +75,31 @@ mandatory ASF approval + announce mechanisms (`dev-list-vote`,
 
 `pyproject.toml`'s `project.version` is the **single authority** for the
 framework version; every other file above mirrors it verbatim, including a
-`.devN` suffix (between releases the manifests read `0.2.0.dev0`, not `0.2.0`).
-Dev versions are never published to a marketplace, so the PEP 440 suffix never
-reaches a consumer — and keeping one identical string across every manifest is
-what lets the Step 2a bump work as a single literal search/replace.
+`.devN` suffix (between releases the manifests read `0.2.0.dev<YYYYMMDDHHMM>`,
+not `0.2.0`). Keeping one identical string across every manifest is what lets
+the Step 2a bump work as a single literal search/replace.
+
+The dev suffix is a **UTC timestamp that moves when adopters need to pick work
+up**, not a constant carried between releases. The marketplace is served from
+`main`, so adopters install dev versions directly, and `claude plugin update`
+compares version strings — a frozen suffix makes it a silent no-op no matter
+how far the installed copy has drifted. Minute resolution keeps two bumps on
+the same day distinct; UTC keeps the ordering honest across contributors'
+timezones.
+
+Bumping is deliberate, not per-PR: do it before pointing adopters at
+`claude plugin update`, before announcing a change they should take, or when
+merged work has piled up behind a stale stamp. Requiring it of every PR would
+only put contributors in conflict over one line.
+
+```bash
+sed -i '' "s/^version = .*/version = \"0.2.0.dev$(date -u +%Y%m%d%H%M)\"/" pyproject.toml
+python3 tools/dev/check-family-plugins.py --fix
+uv lock
+```
+
+See
+[`docs/setup/marketplaces.md`](../../docs/setup/marketplaces.md) (*Versioning*).
 
 `uv.lock` is the one entry `--fix` does **not** touch: it carries the version
 because it locks this workspace's own package, and it is refreshed by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@
 # Package name matches the project's canonical name. Not published to
 # PyPI — this name only frames the framework root as a uv-managed project.
 name = "apache-magpie"
-version = "0.2.0.dev0"
+version = "0.2.0.dev202609080121"
 description = "Reusable, governance-agnostic framework of agentic skills for maintaining open-source projects."
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -136,7 +136,7 @@ wheels = [
 
 [[package]]
 name = "apache-magpie"
-version = "0.2.0.dev0"
+version = "0.2.0.dev202609080121"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
The marketplace is served straight from `main`, so adopters install dev versions — the `.devN` suffix reaching a consumer is the normal case, not the exception the docs assumed.

`claude plugin update` compares **version strings, not commit SHAs**. With every manifest frozen at `0.2.0.dev0` since #907, an adopter's update answers *"already at the latest version"* and never moves the pinned commit, however far behind `main` the installed copy has fallen. Observed today on a real install: three magpie plugins pinned at `a1cff444` (#1134), 14 commits stale, with `claude plugin update` reporting all three as current. Recovery means `claude plugin marketplace update` plus a full uninstall + reinstall of every plugin — nobody discovers that unaided.

This moves the suffix to a timestamp: `0.2.0.dev0` → `0.2.0.dev202609080121`. Ordinary `claude plugin update` then works.

- **Minute resolution**, not date alone, so two bumps on the same day stay distinct — this repo routinely lands several changes a day.
- **UTC**, not local time, so the string sorts in the order the bumps were made regardless of the contributor's timezone.

## Mechanical apart from three files

`project.version` and the two docs that stated the old convention were hand-edited. Everything else is generated: `tools/dev/check-family-plugins.py --fix` propagated the version to the four ecosystem manifests and the ten per-family `plugin.json` files plus their marketplace entries, and `uv lock` refreshed the workspace pin.

`release-management-config.md` now carries the bump as a copy-pasteable recipe rather than prose:

```bash
sed -i '' "s/^version = .*/version = \"0.2.0.dev$(date -u +%Y%m%d%H%M)\"/" pyproject.toml
python3 tools/dev/check-family-plugins.py --fix
uv lock
```

The docs also drop the claim that *"only released versions are ever published to a marketplace, so the PEP 440 suffix never reaches a consumer"* — untrue for a marketplace served from a git branch, and the assumption this bug rested on.

## Bumping stays deliberate

Not every PR. Requiring a bump of every change would put every contributor in conflict with every other over one line, for no gain on changes nobody is waiting for. The docs land the narrower rule instead: bump when the work needs to reach installed copies — before pointing adopters at `claude plugin update`, before announcing a change they should take, or when merged work has piled up behind a stale stamp. A bump is a one-line edit plus a regeneration, so it costs little whenever it is actually wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJopDiCvbwSG6t4k15JE4H
