### PR TITLE
fix(skill-evals): a CLI that grades nothing is an ERROR, not a PASS

### DIFF
--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -63,7 +63,12 @@ Suites are currently implemented for:
   grading adds a judge CLI (default `claude -p --model haiku`).
 - **Credentials / auth:** None in print mode; in `--cli` mode whatever
   the chosen model CLI requires (e.g. a Claude / API key, or a local
-  Ollama install).
+  Ollama install). **Run `--cli` mode outside any sandbox that denies
+  the CLI its credentials.** An agent sandbox typically blocks the
+  keychain and `~/.claude.json`, so `claude -p` returns `Not logged in`;
+  every case then reports ERROR with "nothing was graded" (see *JSON
+  extraction* below). Before that guard existed the same situation
+  reported a green run.
 - **Network:** Evals mock all external tool calls, so the harness itself
   makes no network calls; any network use comes from the model CLI you
   point `--cli` / `--grader-cli` at.
@@ -133,17 +138,23 @@ stdout as JSON, look for the first ```` ```json ```` fenced block, then
 the largest balanced `{...}` (or `[...]`) substring. Models that wrap
 output in prose or markdown fences still work.
 
-If none of those strategies finds JSON, the runner silently wraps the
-raw stdout as `{"raw_output": <stdout>}` and proceeds with normal
-field-aware grading. Under the intersection-only comparator this means
-a model that refused to emit JSON (e.g. a prose-only refusal) will
-PASS any case whose `expected.json` doesn't declare a `raw_output`
-key. A non-zero exit from the CLI is wrapped the same way as
-`{"raw_output": <stdout>, "stderr": <stderr>, "exit_code": <rc>}`, so
-refusals that signal via exit code (some safety filters) also fall
-back to the comparator. Suite authors who want to gate on the prose
-can add `"raw_output": "<expected text>"` to their `expected.json`.
-In `--exact` mode, non-JSON and non-zero exits still ERROR.
+If none of those strategies finds JSON, the runner wraps the raw stdout
+as `{"raw_output": <stdout>}`. A non-zero exit is wrapped the same way
+plus `stderr` and `exit_code`. That wrap exists so a suite can still
+grade a step whose output is prose — either by declaring `raw_output`
+(or `stderr` / `exit_code`) in `expected.json`, or by pointing a
+structural assertion's `field` at one of them in `assertions.json`
+(`security-issue-deduplicate/step-3-merge-body` does the latter).
+
+**If nothing asserts on a wrap key, the case is an ERROR, not a PASS.**
+The intersection-only comparator only checks keys present on both sides,
+so a wrap that nothing addresses compares nothing — and reporting PASS
+there means a CLI that never produced an answer yields a fully green
+run. That is not hypothetical: a sandboxed `claude -p` returns
+`Not logged in`, and before this guard existed a full suite reported
+`35/35 passed` with no model having graded a single case. The ERROR
+message names the cause and prints the first 120 characters of stdout.
+In `--exact` mode, non-JSON and non-zero exits ERROR as they always did.
 
 **Structural cases (composition steps).** When `expected.json` describes
 prose properties via boolean flags (`has_security_model_quote`,

--- a/tools/skill-evals/src/skill_evals/runner.py
+++ b/tools/skill-evals/src/skill_evals/runner.py
@@ -651,6 +651,30 @@ _DETERMINISTIC_ASSERTION_TYPES: frozenset[str] = frozenset(
 _VALID_ASSERTION_TYPES: frozenset[str] = _DETERMINISTIC_ASSERTION_TYPES | {"judge"}
 
 
+# Keys the runner synthesises when the CLI produces no usable JSON. Wrapping
+# is only meaningful if the expected side actually asserts on one of them;
+# otherwise the intersection-only comparator has nothing to compare and the
+# case would report PASS without anything having been graded.
+_WRAP_KEYS = ("raw_output", "stderr", "exit_code")
+
+
+def wrap_is_asserted(expected: object, assertions: dict[str, dict]) -> bool:
+    """Return True when the expected side asserts on a synthetic wrap key.
+
+    Two legitimate ways to gate on a CLI's prose: a top-level ``raw_output``
+    (or ``stderr`` / ``exit_code``) key in ``expected.json``, or a structural
+    assertion in ``assertions.json`` whose ``field`` addresses one. Either
+    makes the wrap meaningful. Neither means the wrap asserts nothing.
+    """
+    for spec in assertions.values():
+        field = spec.get("field")
+        if isinstance(field, str) and field.split(".")[0] in _WRAP_KEYS:
+            return True
+    if isinstance(expected, dict):
+        return any(key in expected for key in _WRAP_KEYS)
+    return False
+
+
 def load_assertions(fixtures_dir: Path) -> dict[str, dict]:
     """Return the structural-assertion specs for cases in this fixtures dir.
 
@@ -1246,11 +1270,22 @@ def main(argv: list[str] | None = None) -> int:
                     print(stdout)
                 continue
             # Field-aware mode: a non-zero exit (often a refusal or a CLI
-            # safety filter) is wrapped just like a no-JSON case. The
-            # intersection-only comparator decides whether this case still
-            # passes based on the keys expected.json declares. Wrap is a
-            # silent implementation detail — the case still reports as
-            # PASS or FAIL like any other.
+            # safety filter) is wrapped just like a no-JSON case, so a suite
+            # that gates on the prose can still grade it. But if nothing
+            # asserts on a wrap key, the comparator would compare nothing and
+            # report PASS — so that case is an ERROR, not a pass.
+            if not wrap_is_asserted(expected, assertions):
+                print(
+                    f"ERROR   {case_label} (CLI exited {rc} and produced no JSON; "
+                    f"expected.json asserts no {'/'.join(_WRAP_KEYS)} key, so nothing was graded)"
+                )
+                errored += 1
+                if args.verbose:
+                    print("--- STDOUT ---")
+                    print(stdout)
+                    print("--- STDERR ---")
+                    print(stderr)
+                continue
             actual = {"raw_output": stdout, "stderr": stderr, "exit_code": rc}
         else:
             actual, parse_err = extract_json_from_output(stdout)
@@ -1263,10 +1298,23 @@ def main(argv: list[str] | None = None) -> int:
                         print("--- STDOUT ---")
                         print(stdout)
                     continue
-                # Field-aware mode: wrap the prose as a synthetic object so
-                # the intersection-only comparator can proceed. A model that
-                # produced prose-only output will PASS unless expected.json
-                # asserts on `raw_output`.
+                # Field-aware mode: wrap the prose as a synthetic object so a
+                # suite that gates on it can still grade it. Without such an
+                # assertion the comparator has nothing to compare, and
+                # reporting PASS there is how an unauthenticated or broken CLI
+                # produces a fully green run — the failure this guard exists
+                # to catch. See the "no JSON" note in README.md.
+                if not wrap_is_asserted(expected, assertions):
+                    print(
+                        f"ERROR   {case_label} ({parse_err}; expected.json asserts no "
+                        f"{'/'.join(_WRAP_KEYS)} key, so nothing was graded). "
+                        f"First 120 chars of stdout: {stdout.strip()[:120]!r}"
+                    )
+                    errored += 1
+                    if args.verbose:
+                        print("--- STDOUT ---")
+                        print(stdout)
+                    continue
                 actual = {"raw_output": stdout}
 
         if structural:

--- a/tools/skill-evals/tests/test_runner.py
+++ b/tools/skill-evals/tests/test_runner.py
@@ -51,6 +51,7 @@ from skill_evals.runner import (
     load_step_config,
     main,
     run_cli,
+    wrap_is_asserted,
 )
 
 _TESTS_DIR = Path(__file__).resolve().parent
@@ -896,12 +897,18 @@ def test_cli_mode_non_json_under_exact_errors(tmp_path: Path, capsys: pytest.Cap
     assert "1 errored" in stdout
 
 
-def test_cli_mode_non_json_wraps_and_passes_under_field_aware(
+def test_cli_mode_non_json_errors_when_nothing_asserts_on_the_wrap(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):
-    """Default field-aware mode wraps prose as {"raw_output": ...} so the
-    intersection-only comparator can proceed. With expected.json declaring
-    no raw_output key, the case passes."""
+    """A CLI that emits no JSON is an ERROR, not a PASS.
+
+    The wrap into ``{"raw_output": ...}`` only helps a suite that gates on the
+    prose. When ``expected.json`` declares none of the wrap keys, the
+    intersection-only comparator compares nothing, and reporting PASS there
+    means an unauthenticated CLI yields a fully green run — which is exactly
+    how a sandboxed `claude -p` returning "Not logged in" once produced a
+    reported 35/35 on suites no model had graded.
+    """
     fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "ok"})
     rc, stdout, _ = _run_main(
         capsys,
@@ -909,13 +916,14 @@ def test_cli_mode_non_json_wraps_and_passes_under_field_aware(
             "--cli",
             "echo 'just prose, no JSON here'",
             "--grader-cli",
-            _GRADER_YES,  # not actually invoked; no overlapping keys
+            _GRADER_YES,  # not invoked: the case never reaches grading
             str(fixtures_dir),
         ],
     )
-    assert rc == 0
-    assert "PASS" in stdout
-    assert "1 passed" in stdout
+    assert rc == 1
+    assert "ERROR" in stdout
+    assert "1 errored" in stdout
+    assert "nothing was graded" in stdout
 
 
 def test_cli_mode_non_json_wrap_can_assert_on_raw_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
@@ -946,10 +954,15 @@ def test_cli_mode_non_zero_exit_under_exact_errors(tmp_path: Path, capsys: pytes
     assert "ERROR" in stdout
 
 
-def test_cli_mode_non_zero_exit_wraps_under_field_aware(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-    """In the default field-aware mode, a non-zero CLI exit is wrapped as
-    raw_output (+ stderr + exit_code) and the intersection-only comparator
-    decides whether the case passes."""
+def test_cli_mode_non_zero_exit_errors_when_nothing_asserts_on_the_wrap(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """A non-zero CLI exit with nothing asserting on the wrap is an ERROR.
+
+    Same reasoning as the no-JSON case: some safety filters and auth failures
+    signal via exit code rather than prose, and a silent PASS there hides a
+    run in which nothing was graded.
+    """
     fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "ok"})
     rc, stdout, _ = _run_main(
         capsys,
@@ -961,8 +974,44 @@ def test_cli_mode_non_zero_exit_wraps_under_field_aware(tmp_path: Path, capsys: 
             str(fixtures_dir),
         ],
     )
+    assert rc == 1
+    assert "ERROR" in stdout
+    assert "nothing was graded" in stdout
+
+
+def test_cli_mode_non_zero_exit_still_grades_when_expected_asserts_exit_code(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """A suite that deliberately gates on the exit code still grades normally."""
+    fixtures_dir, _ = _make_cli_case(tmp_path, expected={"exit_code": 1})
+    rc, stdout, _ = _run_main(
+        capsys,
+        ["--cli", "false", "--grader-cli", _GRADER_YES, str(fixtures_dir)],
+    )
     assert rc == 0
     assert "PASS" in stdout
+
+
+def test_wrap_is_asserted_via_structural_assertions_field():
+    """A structural assertion addressing raw_output makes the wrap meaningful.
+
+    This is the shape `security-issue-deduplicate/step-3-merge-body` uses: the
+    step's output is prose, and `assertions.json` gates on it with regex and
+    judge predicates against `field: raw_output`. That must keep grading.
+    """
+    assertions = {
+        "has_details_disclosure": {"field": "raw_output", "type": "regex", "pattern": "<details>"},
+    }
+    assert wrap_is_asserted({"verdict": "ok"}, assertions) is True
+
+
+def test_wrap_is_asserted_false_when_nothing_addresses_a_wrap_key():
+    assertions = {"has_thing": {"field": "body.summary", "type": "regex", "pattern": "x"}}
+    assert wrap_is_asserted({"verdict": "ok"}, assertions) is False
+
+
+def test_wrap_is_asserted_via_expected_json_key():
+    assert wrap_is_asserted({"raw_output": "prose"}, {}) is True
 
 
 def test_cli_mode_extracts_json_from_fenced_response(tmp_path: Path, capsys: pytest.CaptureFixture[str]):


### PR DESCRIPTION
## Summary

When the model CLI produced no usable JSON, the runner wrapped its stdout as
`{"raw_output": …}` and handed that to the intersection-only comparator. The
comparator only checks keys present on **both** sides, so if `expected.json`
declared no wrap key it compared nothing — and printed `PASS`.

That turns a broken CLI into a fully green run.

This is not hypothetical. A sandboxed `claude -p` cannot reach the keychain or
`~/.claude.json`, so it returns `Not logged in`. #1156's test plan claims the
three `security-model-*` suites passed **35/35** on exactly that basis; no model
graded a single case. Re-run with credentials, the real result is **28/35**.

## The fix

The wrap stays, because a step whose output is prose has two legitimate ways to
gate on it:

- a `raw_output` / `stderr` / `exit_code` key in `expected.json`, or
- a structural assertion whose `field` addresses one of those in
  `assertions.json` — which is what
  `security-issue-deduplicate/step-3-merge-body` does.

`wrap_is_asserted()` checks both. When neither is present, the case reports
ERROR naming the cause and printing the first 120 characters of stdout, instead
of a pass that asserted nothing. The same guard covers the non-zero-exit branch,
since some auth failures and safety filters signal via exit code rather than
prose. `--exact` mode is unchanged.

## Blast radius

Narrow by construction: the guard only fires where **no JSON was extracted at
all**. A working CLI emits JSON, takes the normal path, and is unaffected — the
only runs that change are ones where nothing was being graded.

Verified end-to-end rather than by argument:

- Sandboxed (unauthenticated) `security-model-prepare`: was `9 passed`, now
  `0 passed, 9 errored`, each naming the cause. Same command, same fixtures.
- `security-issue-deduplicate/step-3-merge-body/case-1` — the one suite that
  grades prose via `raw_output` assertions — still reports FAIL, not ERROR, so
  the guard does not intercept it. (It fails for an unrelated pre-existing
  reason: the model returns `[]` rather than the prose body the step specifies.
  Not addressed here.)

## Test plan

- [x] `prek run --all-files` passes (exit 0)
- [x] Workspace: pytest 32/32 members, mypy 26/26, ruff + ruff-format 29/29
- [x] `skill-evals` suite: 161 tests pass
- [x] Two tests that asserted the old vacuous-PASS behaviour are inverted, with
      the reasoning in their docstrings
- [x] Three new tests cover the paths that must keep grading:
      `assertions.json` field, `expected.json` key, and a negative case

## Notes for reviewers

The two inverted tests are the interesting part of the diff —
`test_cli_mode_non_json_wraps_and_passes_under_field_aware` and
`test_cli_mode_non_zero_exit_wraps_under_field_aware` encoded the vacuous pass
as intended behaviour, which is why nothing caught this earlier.

The README passage describing the old behaviour is rewritten, and a note is
added to *Prerequisites*: `--cli` runs must happen outside any sandbox that
denies the CLI its credentials.

**Follow-up, not in this PR:** the seven real failures the corrected numbers
exposed (`security-model-prepare` 8/9, `verify` 9/11, `update` 11/15). Five of
the seven are rejection paths — cases asserting a cluster is *not* eligible for
a suppression rule, or that a widening suggestion must be refused. Each needs
diagnosing as either an over-specified fixture or a genuine gap in the skill
prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So3JRGXrbqSGrohtZuHWKg
