### PR TITLE
ci(prek): quieten the CI log — drop --verbose, skip the identity hook

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -124,14 +124,20 @@ jobs:
         # thing worth reading. Failures still print their output, and
         # `--show-diff-on-failure` still shows what a fixer hook changed.
         #
-        # Real streaming would mean allocating a pty (`script -qec …`),
-        # which fills the Actions log with ANSI redraw escapes. Waiting for
-        # the block is the better trade.
+        # `script -qec … /dev/null` allocates a pty so prek uses its
+        # streaming renderer instead. `-e` propagates the command's exit
+        # status, without which a failing prek would be reported as a
+        # passing step. `--no-progress` suppresses the spinner that the
+        # streaming renderer would otherwise redraw in place, which is
+        # what would otherwise fill this log with ESC[2K / ESC[2A
+        # sequences — the pty buys progress, --no-progress pays for it in
+        # cursor control we do not want.
         #
         # Note the repeated flag: `--skip a,b` is NOT a list — prek takes a
         # single HOOK|PROJECT per occurrence, and a comma-joined value
         # matches no hook at all. It warns rather than failing, so the
         # comma form looks like it worked while skipping nothing.
         run: >-
-          prek run --show-diff-on-failure --color=always --all-files
-          --skip workspace-pytest --skip identity
+          script -qec "prek run --show-diff-on-failure --color=always
+          --all-files --no-progress --skip workspace-pytest --skip identity"
+          /dev/null

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -103,11 +103,35 @@ jobs:
         # CI, so skip it — the hook still runs locally on `git commit` /
         # `prek run`, where there is no separate matrix.
         #
-        # `--verbose`: without it prek renders a progress UI that a
-        # non-TTY CI log buffers and only flushes at the end, so a long
-        # run shows nothing while it works. Verbose prints each hook's
-        # result and output as it completes, giving live progress in the
-        # Actions log.
+        # `--skip identity`: the `identity` meta-hook echoes every file
+        # passed to the static checks. That is a useful local
+        # troubleshooting aid, but on `--all-files` it prints the whole
+        # repository into the CI log ahead of any actual result, burying
+        # the failure a reader came for. It stays enabled locally.
+        #
+        # No `--verbose`. It was added believing it bought live progress in
+        # a non-TTY log. It does not — measured on this repo, first output
+        # and total runtime coincide with the flag and without it: prek
+        # emits nothing until the run finishes either way. prek streams
+        # only when stdout is a TTY, where it draws an in-place progress UI
+        # (spinner, cursor-control escapes, redrawn lines); with stdout a
+        # pipe it suppresses that renderer and prints the whole result
+        # block at the end. `--no-progress` behaves identically, and `-q`
+        # prints nothing at all on success.
+        #
+        # So the flag's only effect in CI is to add every *passing* hook's
+        # stdout to that final block — several hundred lines around the one
+        # thing worth reading. Failures still print their output, and
+        # `--show-diff-on-failure` still shows what a fixer hook changed.
+        #
+        # Real streaming would mean allocating a pty (`script -qec …`),
+        # which fills the Actions log with ANSI redraw escapes. Waiting for
+        # the block is the better trade.
+        #
+        # Note the repeated flag: `--skip a,b` is NOT a list — prek takes a
+        # single HOOK|PROJECT per occurrence, and a comma-joined value
+        # matches no hook at all. It warns rather than failing, so the
+        # comma form looks like it worked while skipping nothing.
         run: >-
           prek run --show-diff-on-failure --color=always --all-files
-          --verbose --skip workspace-pytest
+          --skip workspace-pytest --skip identity

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -125,13 +125,17 @@ jobs:
         # `--show-diff-on-failure` still shows what a fixer hook changed.
         #
         # `script -qec … /dev/null` allocates a pty so prek uses its
-        # streaming renderer instead. `-e` propagates the command's exit
-        # status, without which a failing prek would be reported as a
-        # passing step. `--no-progress` suppresses the spinner that the
-        # streaming renderer would otherwise redraw in place, which is
-        # what would otherwise fill this log with ESC[2K / ESC[2A
-        # sequences — the pty buys progress, --no-progress pays for it in
-        # cursor control we do not want.
+        # streaming renderer, which is the only way to get live progress:
+        # with stdout a plain pipe prek suppresses that renderer and emits
+        # one block when the whole run finishes. `-e` propagates the
+        # command's exit status, without which a failing prek would be
+        # reported as a passing step.
+        #
+        # No `--no-progress` here, despite the redraw escapes it would
+        # remove. That flag hides *the streaming renderer itself*, not
+        # just its spinner — pty plus --no-progress streams nothing, which
+        # is both halves of the cost and neither half of the benefit. The
+        # progress rendering and the live output are the same mechanism.
         #
         # Note the repeated flag: `--skip a,b` is NOT a list — prek takes a
         # single HOOK|PROJECT per occurrence, and a comma-joined value
@@ -139,5 +143,5 @@ jobs:
         # comma form looks like it worked while skipping nothing.
         run: >-
           script -qec "prek run --show-diff-on-failure --color=always
-          --all-files --no-progress --skip workspace-pytest --skip identity"
+          --all-files --skip workspace-pytest --skip identity"
           /dev/null

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -124,24 +124,33 @@ jobs:
         # thing worth reading. Failures still print their output, and
         # `--show-diff-on-failure` still shows what a fixer hook changed.
         #
-        # `script -qec … /dev/null` allocates a pty so prek uses its
-        # streaming renderer, which is the only way to get live progress:
-        # with stdout a plain pipe prek suppresses that renderer and emits
-        # one block when the whole run finishes. `-e` propagates the
-        # command's exit status, without which a failing prek would be
-        # reported as a passing step.
+        # No `--verbose`, and no pty. Live progress is not achievable here;
+        # this was measured on the runner rather than assumed. Three
+        # configurations, all with every hook-result line landing in the
+        # same one-second timestamp ~106s into the step:
         #
-        # No `--no-progress` here, despite the redraw escapes it would
-        # remove. That flag hides *the streaming renderer itself*, not
-        # just its spinner — pty plus --no-progress streams nothing, which
-        # is both halves of the cost and neither half of the benefit. The
-        # progress rendering and the live output are the same mechanism.
+        #   plain pipe                       one block at the end
+        #   pty (`script -qec`)              one block at the end
+        #   pty + `--no-progress`            one block at the end
+        #
+        # Locally, a pty does make prek stream (spinner, in-place redraws),
+        # so the renderer works — but that output does not survive to the
+        # Actions log, which shows only the final state. `--verbose` never
+        # helped either: with stdout a pipe, first output and total runtime
+        # coincide with the flag and without it.
+        #
+        # So the plain form is kept: same information, no `script`
+        # dependency, and no `-e` exit-status footgun (without `-e`,
+        # `script` returns its own status and a failing prek reports as a
+        # passing step). `--verbose` is dropped because its only remaining
+        # effect was to add every passing hook's stdout to that final
+        # block. Failures still print their output, and
+        # `--show-diff-on-failure` still shows what a fixer hook changed.
         #
         # Note the repeated flag: `--skip a,b` is NOT a list — prek takes a
         # single HOOK|PROJECT per occurrence, and a comma-joined value
         # matches no hook at all. It warns rather than failing, so the
         # comma form looks like it worked while skipping nothing.
         run: >-
-          script -qec "prek run --show-diff-on-failure --color=always
-          --all-files --skip workspace-pytest --skip identity"
-          /dev/null
+          prek run --show-diff-on-failure --color=always --all-files
+          --skip workspace-pytest --skip identity


### PR DESCRIPTION
## Summary

Two sources of noise in the `prek` CI log, around the one thing a reader opens
that log for.

```diff
-  prek run --show-diff-on-failure --color=always --all-files
-  --verbose --skip workspace-pytest
+  prek run --show-diff-on-failure --color=always --all-files
+  --skip workspace-pytest --skip identity
```

**`--skip identity`.** The `identity` meta-hook echoes every file passed to the
static checks. Useful locally when working out why a hook did or did not fire,
but on `--all-files` it prints the entire repository into the log *before* any
result appears. It stays enabled locally and is skipped only in CI.

**Drop `--verbose`** — see below, because the reason it was there turns out not
to hold.

## `--verbose` never bought live progress

The flag carried a comment saying that without it, prek renders a progress UI a
non-TTY log buffers to the end. The first half is true; the conclusion is not.
Measured on this repo, timestamping each line and comparing against total
runtime:

| Invocation | First output | Total |
|---|---|---|
| plain | 19s | 19s |
| `--verbose` | 19s | 20s |
| `--no-progress` | 19s | 19s |
| `-q` | *(no output)* | 18s |

First output and total runtime coincide in every mode. **prek emits nothing
until the run finishes, with or without the flag.**

It streams only when stdout is a **TTY**, where it draws an in-place progress UI
— spinner, `Running hooks...`, cursor-control escapes redrawing lines. Against a
pipe (CI) it suppresses that renderer and prints one block at the end. Confirmed
by running it under `script` to allocate a pty, which does stream — and fills the
output with `ESC[2K` / `ESC[2A` redraw sequences.

So in CI the flag's only effect was to add every *passing* hook's stdout to that
final block: several hundred lines wrapped around nothing. Failures still print
their output, and `--show-diff-on-failure` still shows what a fixer hook changed.

Real streaming would mean allocating a pty in the workflow (`script -qec …`),
which trades a clean block for a log full of ANSI redraw escapes. Waiting for the
block is the better trade.

For completeness: `PYTHONUNBUFFERED` does not apply — prek is a Rust binary, and
it captures each hook's stdout and replays it after the hook completes, so a
Python hook's own buffering is not in the path either.

## A trap worth documenting

My first attempt wrote `--skip workspace-pytest,identity`. Prek takes a single
`HOOK|PROJECT` per occurrence, so a comma-joined value matches no hook — and it
only *warns*:

```
warning: selector `--skip=workspace-pytest,identity` did not match any hooks
```

then runs `identity` anyway. The comma form reads as working while skipping
nothing. Caught by running the command instead of trusting the edit; the workflow
now carries a note so the next person does not repeat it.

## Why `workspace-pytest` stays skipped (unchanged behaviour)

`.github/workflows/tests.yml` already runs pytest as a data-driven matrix — one
parallel job per workspace member, named after the member, so a failure points at
the culprit. The `workspace-pytest` hook runs the same tests bundled serially
inside the `prek` job, where a failure is buried. Path filtering on PRs is not a
hole: four shared build inputs (`pyproject.toml`, `uv.lock`,
`tools/dev/run-workspace-check.sh`, `tests.yml`) force the full matrix, and
non-PR events always run everything. The hook still runs locally on
`git commit` / `prek run`, where there is no matrix to defer to.

## Test plan

- [x] Ran the exact post-change CI command locally — exit 0, `identity` absent
- [x] Timestamped every output line across four invocations to establish the
      buffering behaviour above, rather than asserting it
- [x] Confirmed under a pty that streaming exists but costs ANSI redraw escapes
- [x] Confirmed the comma form silently skips nothing

An earlier revision of this PR claimed per-hook lines "still stream" without
`--verbose`. That was wrong — they never streamed in CI either way — and the
commit and workflow comment have been corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So3JRGXrbqSGrohtZuHWKg
