### PR TITLE
fix(skill-evals): do not scavenge JSON out of a prose step's output

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,67 +9,67 @@
     {
       "name": "magpie",
       "source": ".",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "All Apache Magpie skills (all 10 families; ~21.7k always-on tokens)."
     },
     {
       "name": "magpie-contributor-growth",
       "source": "./plugins/magpie-contributor-growth",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie contributor-growth family (6 skills)."
     },
     {
       "name": "magpie-issue",
       "source": "./plugins/magpie-issue",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie issue family (8 skills)."
     },
     {
       "name": "magpie-mentoring",
       "source": "./plugins/magpie-mentoring",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie mentoring family (4 skills)."
     },
     {
       "name": "magpie-pairing",
       "source": "./plugins/magpie-pairing",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie pairing family (2 skills)."
     },
     {
       "name": "magpie-pr-management",
       "source": "./plugins/magpie-pr-management",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie pr-management family (8 skills)."
     },
     {
       "name": "magpie-release-management",
       "source": "./plugins/magpie-release-management",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie release-management family (10 skills)."
     },
     {
       "name": "magpie-repo-health",
       "source": "./plugins/magpie-repo-health",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie repo-health family (7 skills)."
     },
     {
       "name": "magpie-security",
       "source": "./plugins/magpie-security",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie security family (15 skills)."
     },
     {
       "name": "magpie-setup",
       "source": "./plugins/magpie-setup",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie setup family (9 skills)."
     },
     {
       "name": "magpie-utilities",
       "source": "./plugins/magpie-utilities",
-      "version": "0.2.0.dev202609080121",
+      "version": "0.2.0.dev202609081000",
       "description": "Apache Magpie utilities family (5 skills)."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "description": "Apache Magpie — a reusable, governance-agnostic framework of agentic skills for maintaining open-source projects: release management, security triage, PR and issue workflows, contributor growth, and repo health.",
   "author": { "name": "Apache Magpie", "url": "https://magpie.apache.org/" },
   "homepage": "https://magpie.apache.org/",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "description": "Apache Magpie — agentic skills for maintaining open-source projects.",
   "skills": "./skills",
   "hooks": {

--- a/apm.yml
+++ b/apm.yml
@@ -6,7 +6,7 @@
 # Gemini). Schema is v0.1 and may change — verify against the current
 # https://microsoft.github.io/apm/ before publishing.
 name: magpie
-version: 0.2.0.dev202609080121
+version: 0.2.0.dev202609081000
 type: skill
 description: >-
   Apache Magpie — a reusable, governance-agnostic framework of agentic skills

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "description": "Apache Magpie — agentic skills for maintaining open-source projects. Skills are auto-discovered from ./skills.",
   "contextFileName": "GEMINI.md"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "magpie",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "description": "Apache Magpie — a reusable, governance-agnostic framework of agentic skills for maintaining open-source projects: release management, security triage, PR and issue workflows, contributor growth, and repo health.",
   "author": { "name": "Apache Magpie", "url": "https://magpie.apache.org/" },
   "homepage": "https://magpie.apache.org/",

--- a/plugins/magpie-contributor-growth/.claude-plugin/plugin.json
+++ b/plugins/magpie-contributor-growth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-contributor-growth",
   "description": "Apache Magpie \u2014 path-to-committer: activity sweeps, nominations, sentiment, readiness, committer/post-vote onboarding.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-issue/.claude-plugin/plugin.json
+++ b/plugins/magpie-issue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-issue",
   "description": "Apache Magpie \u2014 issue lifecycle: triage, reproduction, fix drafting, reassess, stale-sweep, dedup, backlog stats.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-mentoring/.claude-plugin/plugin.json
+++ b/plugins/magpie-mentoring/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-mentoring",
   "description": "Apache Magpie \u2014 newcomer mentoring: welcome, newcomer-issue explanations, good-first-issue authoring + sweep.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-pairing/.claude-plugin/plugin.json
+++ b/plugins/magpie-pairing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-pairing",
   "description": "Apache Magpie \u2014 pair a change with a structured self-review or a multi-agent adversarial review.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-pr-management/.claude-plugin/plugin.json
+++ b/plugins/magpie-pr-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-pr-management",
   "description": "Apache Magpie \u2014 PR-queue management: triage, stats, deep code review, quick-merge, stale-sweep, reviewer routing, pre-first-PR checks.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-release-management/.claude-plugin/plugin.json
+++ b/plugins/magpie-release-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-release-management",
   "description": "Apache Magpie \u2014 ASF release lifecycle: plan, RC cut/sign, vote, tally, promote, announce, archive, audit.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-repo-health/.claude-plugin/plugin.json
+++ b/plugins/magpie-repo-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-repo-health",
   "description": "Apache Magpie \u2014 read-only repo-health audits: runner labels, workflow security, dependency/license/NOTICE, flaky tests, audit-finding fixes.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-security/.claude-plugin/plugin.json
+++ b/plugins/magpie-security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-security",
   "description": "Apache Magpie \u2014 security-issue handling lifecycle \u2014 import through CVE publication, triage, sync, dedup, invalidate. Maintainer-only.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-setup/.claude-plugin/plugin.json
+++ b/plugins/magpie-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-setup",
   "description": "Apache Magpie \u2014 framework install/maintenance: install (adopt), upgrade, verify, override, status, secure-agent setup, shared-config sync.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-utilities/.claude-plugin/plugin.json
+++ b/plugins/magpie-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-utilities",
   "description": "Apache Magpie \u2014 framework meta-skills: write-skill, optimize-skill, skill-reconciler, list-skills.",
-  "version": "0.2.0.dev202609080121",
+  "version": "0.2.0.dev202609081000",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@
 # Package name matches the project's canonical name. Not published to
 # PyPI — this name only frames the framework root as a uv-managed project.
 name = "apache-magpie"
-version = "0.2.0.dev202609080121"
+version = "0.2.0.dev202609081000"
 description = "Reusable, governance-agnostic framework of agentic skills for maintaining open-source projects."
 requires-python = ">=3.11"
 

--- a/tools/skill-evals/src/skill_evals/runner.py
+++ b/tools/skill-evals/src/skill_evals/runner.py
@@ -1288,7 +1288,18 @@ def main(argv: list[str] | None = None) -> int:
                 continue
             actual = {"raw_output": stdout, "stderr": stderr, "exit_code": rc}
         else:
-            actual, parse_err = extract_json_from_output(stdout)
+            # A suite whose expected side addresses a wrap key is declaring
+            # that this step emits prose, not JSON. Do not run the extractor
+            # on it: its last-resort strategy takes the largest balanced
+            # `{...}` / `[...]` block, and ordinary Markdown supplies plenty —
+            # a task-list `- [ ]` parses as the JSON value `[]`, a link's
+            # `[text]` as a malformed one. When that fires, the scavenged
+            # fragment replaces the prose and every raw_output assertion then
+            # fails against output the model got right.
+            if wrap_is_asserted(expected, assertions):
+                actual, parse_err = {"raw_output": stdout}, None
+            else:
+                actual, parse_err = extract_json_from_output(stdout)
             if parse_err is not None:
                 if args.exact:
                     # Exact mode requires literal JSON; non-JSON is an error.

--- a/tools/skill-evals/tests/test_runner.py
+++ b/tools/skill-evals/tests/test_runner.py
@@ -1014,6 +1014,43 @@ def test_wrap_is_asserted_via_expected_json_key():
     assert wrap_is_asserted({"raw_output": "prose"}, {}) is True
 
 
+def test_prose_step_is_not_scavenged_for_json(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """A prose step must not be JSON-parsed, even when its prose contains brackets.
+
+    ``extract_json_from_output``'s last-resort strategy takes the largest
+    balanced ``{...}`` / ``[...]`` block. Markdown supplies those freely — a
+    task-list ``- [ ]`` parses as the JSON value ``[]``. When that fires on a
+    step whose output is prose, the scavenged fragment replaces the whole body
+    and every ``raw_output`` assertion fails against output the model got
+    right. That is what happened to all four cases of
+    ``security-issue-deduplicate/step-3-merge-body``.
+    """
+    body = "## Checklist\n\n- [ ] done\n"
+    fixtures_dir, _ = _make_cli_case(tmp_path, expected={"raw_output": body})
+    script = tmp_path / "emit.py"
+    script.write_text(f"import sys; sys.stdout.write({body!r})\n", encoding="utf-8")
+    rc, stdout, _ = _run_main(
+        capsys,
+        ["--cli", f"python3 {shlex.quote(str(script))}", "--grader-cli", _GRADER_YES, str(fixtures_dir)],
+    )
+    assert rc == 0
+    assert "PASS" in stdout
+
+
+def test_json_step_is_still_parsed_normally(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
+    """The prose path must not swallow ordinary JSON steps: a suite asserting on
+    real keys keeps going through the extractor."""
+    fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "ok"})
+    script = tmp_path / "emit_json.py"
+    script.write_text('import sys; sys.stdout.write(\'{"verdict": "ok"}\')\n', encoding="utf-8")
+    rc, stdout, _ = _run_main(
+        capsys,
+        ["--cli", f"python3 {shlex.quote(str(script))}", "--grader-cli", _GRADER_YES, str(fixtures_dir)],
+    )
+    assert rc == 0
+    assert "PASS" in stdout
+
+
 def test_cli_mode_extracts_json_from_fenced_response(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     """The runner should find JSON inside a ```json fence in the CLI's stdout."""
     fixtures_dir, _ = _make_cli_case(tmp_path, expected={"verdict": "ok"})

--- a/uv.lock
+++ b/uv.lock
@@ -119,7 +119,7 @@ wheels = [
 
 [[package]]
 name = "apache-magpie"
-version = "0.2.0.dev202609080121"
+version = "0.2.0.dev202609081000"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary

Running all 75 eval suites turned up four failures in
`security-issue-deduplicate/step-3-merge-body` — the whole step, every case.
Reading the model's actual output back, **it was correct in all four**. The
harness threw it away.

`extract_json_from_output`'s last-resort strategy takes the largest balanced
`{...}` / `[...]` block in the CLI's stdout. Ordinary Markdown supplies those
freely: a task-list `- [ ]` parses as the JSON value `[]`, and a link's
`[text]` as a malformed one. On a step whose output is *prose*, that scavenged
fragment replaces the whole body — `actual` becomes `[]`, `raw_output` no longer
exists, and every assertion addressing it fails against a correct answer.

## What the model actually produced

For `case-1-basic-merge`, graded as a failure:

```markdown
## Reporter credited as

- Alice Example
- Bob Researcher

## Security mailing list thread

- Alice Example (initial report): https://lists.apache.org/thread/abc123
- Bob Researcher (redirect-chain vector): https://lists.apache.org/thread/xyz789
```

Both credits on separate lines, both threads, severity `Unknown`, the widened
version range, the CWE agreement noted — every assertion satisfied. The reported
failure was `field 'raw_output' not present in output`.

## The fix

A suite whose expected side addresses a wrap key (`raw_output`, `stderr`,
`exit_code` — via `expected.json` or an `assertions.json` `field`) is
**declaring that the step emits prose**. Skip extraction for those and pass the
body through untouched.

This reuses `wrap_is_asserted` from #1161 against the mirror-image problem:

| | |
|---|---|
| #1161 | stopped the harness **passing** what it never graded |
| this | stops it **failing** what it graded wrong |

Both are the same underlying confusion — treating "no JSON here" as a fact about
the model rather than a fact about the step.

## Verification

- [x] All four `step-3-merge-body` cases pass after the change (0 → 4)
- [x] Two regression tests, both directions: prose containing a task-list stays
      prose; an ordinary JSON step still goes through the extractor
- [x] `prek run --all-files` passes (exit 0)
- [x] Workspace: pytest, ruff, ruff-format, mypy all green

## Version bump

Also bumps the framework to `0.2.0.dev202609081000` and regenerates the
manifests, per `marketplace-distribution.md`. The marketplace is served from
`main` and `claude plugin update` compares version *strings*, not commit SHAs —
so without a bump, adopters are told they are already up to date and never
receive this fix.

## Notes for reviewers

This came out of a full 1196-case run. That run is not finished: 850 cases
returned `ERROR` from quota exhaustion, not defects — the CLI was healthy when
re-tested. **29 genuine failures remain**, clustered in a way that suggests more
shared causes rather than 29 separate bugs (`issue-reproducer` 7,
`issue-fix-workflow` 4, `audit-finding-fix` 3, and two suites failing cases with
matching `scope-check` / `drive-by-reformat` names). Those are follow-up work,
not in this PR.

Worth stating plainly: this bug and #1161's were both invisible for as long as
they existed, because each produced a plausible-looking result. The eval harness
needs the same scepticism as the things it grades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So3JRGXrbqSGrohtZuHWKg
