### PR TITLE
feat(agent-guard): run the guard from the installed plugin, not a per-worktree copy

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,6 +13,12 @@
       "description": "All Apache Magpie skills (all 10 families; ~21.7k always-on tokens)."
     },
     {
+      "name": "magpie-agent-guard",
+      "source": "./plugins/magpie-agent-guard",
+      "version": "0.2.0.dev202609080121",
+      "description": "Apache Magpie \u2014 deterministic pre-execution command guard: a PreToolUse hook that denies shell commands which would break a hard framework rule. Runs from the installed plugin, so no repository or worktree needs a local copy."
+    },
+    {
       "name": "magpie-contributor-growth",
       "source": "./plugins/magpie-contributor-growth",
       "version": "0.2.0.dev202609080121",

--- a/docs/setup/install-recipes.md
+++ b/docs/setup/install-recipes.md
@@ -123,13 +123,13 @@ cat >> .gitignore <<'GITIGNORE'
 __pycache__/
 *.pyc
 
-# Deterministic agent-guard PreToolUse hook — framework code synced
-# from the snapshot by /magpie-setup (and seeded into each worktree),
-# not an adopter artefact. The committed .claude/settings.json wires
-# it; the script itself stays gitignored. Force-add your own guards
-# under guards.d/ with `git add -f` if you want them tracked.
-/.claude/hooks/agent-guard.py
-/.claude/hooks/guards.d/
+# (No agent-guard entries. The deterministic PreToolUse guard runs
+# from the install — the magpie-agent-guard plugin, or a
+# settings.local.json entry resolving the engine inside the snapshot
+# — so nothing repository-local exists to ignore, and no worktree
+# needs seeding. Repos adopted before that change can drop their
+# leftover /.claude/hooks/agent-guard.py and /.claude/hooks/guards.d/
+# lines along with the files.)
 
 # Framework-skill symlinks created by /magpie-setup. One uniform
 # block per skills dir you use: the `magpie-*` glob ignores them

--- a/plugins/magpie-agent-guard/.claude-plugin/plugin.json
+++ b/plugins/magpie-agent-guard/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "magpie-agent-guard",
+  "description": "Apache Magpie \u2014 deterministic pre-execution command guard: a PreToolUse hook that denies shell commands which would break a hard framework rule. Runs from the installed plugin, so no repository or worktree needs a local copy.",
+  "version": "0.2.0.dev202609080121",
+  "author": {
+    "name": "Apache Magpie",
+    "url": "https://magpie.apache.org/"
+  },
+  "homepage": "https://magpie.apache.org/",
+  "repository": "https://github.com/apache/magpie",
+  "license": "Apache-2.0",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/tools/agent-guard/src/agent_guard/__init__.py\"",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/magpie-agent-guard/tools/agent-guard
+++ b/plugins/magpie-agent-guard/tools/agent-guard
@@ -1,0 +1,1 @@
+../../../tools/agent-guard

--- a/skills/setup/install.md
+++ b/skills/setup/install.md
@@ -586,8 +586,6 @@ idempotent — re-add them if they're missing.
 /.apache-magpie-sources
 /.apache-magpie.sources.local.lock
 /.claude/settings.local.json
-/.claude/hooks/agent-guard.py
-/.claude/hooks/guards.d/
 __pycache__/
 *.pyc
 ```
@@ -623,24 +621,23 @@ scripts emit when run from the adopter checkout (e.g.
 out of the tree. Most adopters already carry these from a stock
 Python `.gitignore`; the install flow adds them if missing.
 
-The `/.claude/hooks/agent-guard.py` and `/.claude/hooks/guards.d/`
-lines keep the deterministic `PreToolUse` guard **gitignored** —
-it is framework code synced from the snapshot
-([Step 12 pass 1](#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)),
-not an adopter artefact, so it is regenerated on `/magpie-setup`
-rather than committed (the same rule that keeps the snapshot and
-the framework-skill symlinks out of git — the only committed
-framework artefact is `magpie-setup`). The `hooks.PreToolUse`
-**wiring** that references it also lives in `.claude/settings.local.json`
-(above), gitignored alongside the script itself. Neither is
-committed, so no worktree inherits either via git. Every worktree is
-seeded from the main checkout by the post-checkout hook
-([Step 10](#step-10--worktree-aware-post-checkout-hook-fresh-only))
-or by [`worktree-init` Step 1d](worktree-init.md#step-1d--seed-the-worktrees-agent-guard-pretooluse-hook),
-which seed the wiring together with the script.
-An adopter who keeps their own non-framework guards under
-`.claude/hooks/guards.d/` and wants them tracked should commit them
-with `git add -f` (the directory is ignored by default).
+There is deliberately **no** `/.claude/hooks/agent-guard.py` line.
+The deterministic `PreToolUse` guard
+([`tools/agent-guard`](../../tools/agent-guard/README.md)) is no
+longer copied into the adopter tree: its `hooks.PreToolUse` wiring
+in `.claude/settings.local.json` (above) resolves the engine inside
+the snapshot, and skill-owned guards are discovered where they live.
+Nothing repository-local exists to ignore, and — because the
+snapshot is shared by every worktree via the
+[`worktree-init` Step 1 symlink](worktree-init.md#step-1--create-the-snapshot-symlink)
+— nothing has to be seeded per worktree either.
+
+An adopter upgrading from a version that *did* install the copy
+should delete the leftover `.claude/hooks/agent-guard.py` and
+`.claude/hooks/guards.d/` (and drop the two `.gitignore` lines);
+[`upgrade`](upgrade.md#step-6b--sync-locally-installed-hooks-and-configuration)
+reports them. An adopter who keeps their own non-framework guards
+outside the framework tree points `$MAGPIE_GUARD_DIRS` at them.
 
 **Symlink entries — one uniform block per active target
 ([`agents.md`](agents.md)), no per-layout variation.** Every
@@ -683,7 +680,8 @@ framework skill.
 `.claude/settings.local.json` is the project-local
 per-machine settings file that
 [Step 12 pass 1](#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
-populates with the agent-guard `hooks.PreToolUse` wiring and that
+populates with the agent-guard `hooks.PreToolUse` wiring (one entry,
+resolving the snapshot) and that
 [Step 12 pass 3](#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
 separately populates with the project-root sandbox-allowlist entry
 (and that each worktree carries independently). Most adopters
@@ -1138,26 +1136,11 @@ guarded independently so neither can gate the git operation:
    — see
    [`setup-isolated-setup-install/SKILL.md` → Step P](../setup-isolated-setup-install/SKILL.md#step-p--project-root-coverage-in-the-sandbox-allowlists)).
 
-2. **agent-guard seeding.** The gitignored, per-machine
-   `.claude/settings.local.json` wires the deterministic
-   `PreToolUse` guard
-   ([`tools/agent-guard`](../../tools/agent-guard/README.md)) at
-   `$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py` — a
-   **per-worktree** path. The script, its `guards.d/`, and the
-   wiring entry itself are all adopter-installed local files synced
-   into the **main** checkout
-   by [Step 12 pass 1](#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
-   and **gitignored** ([Step 7](#step-7--gitignore-entries-fresh-only)).
-   Because they are gitignored, **no** worktree inherits any of them
-   via `git worktree add`. Every freshly-created worktree starts
-   without the script or the wiring and would run with the guard
-   **silently inactive**. The hook seeds the script from the main
-   checkout's already-synced copy only when this worktree has none
-   (never overwriting a copy the worktree already
-   carries, which may hold worktree-local guards), then wires it into
-   this worktree's own `settings.local.json` by the same idempotent
-   merge as Step 12 pass 1, so the guard is live in every worktree
-   from its first checkout.
+The hook does **not** deal with the agent-guard. That guard runs
+from the install — the `magpie-agent-guard` plugin, or a
+`settings.local.json` entry resolving the shared snapshot — so a
+worktree needs nothing seeded for it
+([`worktree-init` Step 1d](worktree-init.md#step-1d--agent-guard-needs-nothing-here)).
 
 The hook is a small shell script. Surface the exact content to
 the user before writing:
@@ -1177,57 +1160,6 @@ if [ -x "$HOME/.claude/scripts/sandbox-add-project-root.sh" ]; then
   "$HOME/.claude/scripts/sandbox-add-project-root.sh" || true
 fi
 
-# (b) agent-guard PreToolUse guard: settings.local.json resolves it at
-#     $CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py (per-worktree). Seed
-#     this worktree from the main checkout's already-synced copy when it has
-#     none — never overwrite a copy the worktree already carries.
-wt="$(git rev-parse --show-toplevel 2>/dev/null)" || wt=""
-main="$(dirname "$(cd "$(git rev-parse --git-common-dir 2>/dev/null)" 2>/dev/null && pwd)")"
-if [ -n "$wt" ] && [ "$main" != "$wt" ] \
-   && [ -f "$main/.claude/hooks/agent-guard.py" ] \
-   && [ ! -f "$wt/.claude/hooks/agent-guard.py" ]; then
-  mkdir -p "$wt/.claude/hooks/guards.d"
-  cp "$main/.claude/hooks/agent-guard.py" "$wt/.claude/hooks/agent-guard.py" || true
-  [ -d "$main/.claude/hooks/guards.d" ] &&
-    cp "$main/.claude/hooks/guards.d/"*.py "$wt/.claude/hooks/guards.d/" 2>/dev/null || true
-fi
-
-# (c) agent-guard PreToolUse wiring: settings.local.json is gitignored and
-#     per-worktree too, so the wiring entry is not inherited via
-#     `git worktree add` any more than the script is. Merge it into this
-#     worktree's own settings.local.json whenever the script is present here
-#     (just seeded above, or already carried) and the entry is missing.
-if [ -n "$wt" ] && [ -f "$wt/.claude/hooks/agent-guard.py" ]; then
-  python3 - "$wt/.claude/settings.local.json" <<'PYEOF' || true
-import json, sys
-
-path = sys.argv[1]
-command = 'python3 "$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py"'
-
-try:
-    with open(path) as f:
-        data = json.load(f)
-except FileNotFoundError:
-    data = {}
-except json.JSONDecodeError:
-    sys.exit(0)  # hand-edited or corrupt file, leave it alone
-
-pre_tool_use = data.setdefault("hooks", {}).setdefault("PreToolUse", [])
-for entry in pre_tool_use:
-    if entry.get("matcher") == "Bash" and any(
-        "agent-guard.py" in h.get("command", "") for h in entry.get("hooks", [])
-    ):
-        sys.exit(0)  # already wired
-
-pre_tool_use.append(
-    {"matcher": "Bash", "hooks": [{"type": "command", "command": command, "timeout": 30}]}
-)
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-PYEOF
-fi
-
 exit 0
 ```
 
@@ -1239,18 +1171,19 @@ a gate.
 If the operator has not yet run `/magpie-setup-isolated-setup-install`,
 the helper-script line (a) is a no-op (the `-x` test fails). When
 they later install the secure setup, no hook re-write is needed:
-the next `post-checkout` fires the helper automatically. Likewise
-(b) is a no-op when the main checkout has no agent-guard yet (the
-`-f "$main/.claude/hooks/agent-guard.py"` test fails) or when the
-worktree already carries its own copy, and (c) is a no-op once this
-worktree's `settings.local.json` already carries the wiring (or when
-(b) found no script to wire).
+the next `post-checkout` fires the helper automatically.
 
-**Why agent-guard seeding is shell-safe but symlink
-reconciliation is not.** Seeding agent-guard is a plain
-`cp` of files that already exist in the main checkout — a pure
-shell operation with no dependency on the agent harness. Recreating
-the gitignored framework-skill symlinks is **not**: earlier
+Earlier versions of this hook also copied the agent-guard into each
+new worktree. They no longer need to, and an adopter still carrying
+that block should let [`upgrade`](upgrade.md#step-6b--sync-locally-installed-hooks-and-configuration)
+re-install the current template: a hook that seeds a per-worktree
+copy keeps alive the wiring that breaks **every** `Bash` call in any
+worktree the copy did not reach.
+
+**Why the allowlist line is shell-safe but symlink
+reconciliation is not.** Line (a) shells out to a helper script — a
+pure shell operation with no dependency on the agent harness.
+Recreating the gitignored framework-skill symlinks is **not**: earlier
 template versions of this hook also called
 `/magpie-setup verify --auto-fix-symlinks` to recreate
 gitignored symlinks after a checkout. That line printed a spurious
@@ -1428,48 +1361,45 @@ Four passes, in this order:
    `gh`/`git` commands which would ping maintainers, carry a
    `Co-Authored-By` trailer, mark a PR ready prematurely, leak
    security language publicly, or empty a PR via force-push. Sync
-   it like the post-checkout hook:
-   - Copy the single self-contained script
-     `tools/agent-guard/src/agent_guard/__init__.py` (from the
-     snapshot) to `<repo-root>/.claude/hooks/agent-guard.py`, and
-     populate `<repo-root>/.claude/hooks/guards.d/` from **two**
-     snapshot sources: the engine's bundled
-     `tools/agent-guard/src/agent_guard/guards.d/*.py`, **and every
-     skill-owned guard** — `skills/*/guards/*.py` (e.g. the
-     `pr-management-triage` `mention` + `mark-ready` guards, the
-     `security-issue-fix` `security-language` guard). Collecting all
-     of them into the single `guards.d` is what lets each skill own
-     its own deterministic guard while the hook is wired only once.
-     The dispatcher auto-discovers every `*.py` in the `guards.d`
-     sibling of the script — adding a skill (or a skill adding a
-     guard) needs no re-wiring, only this re-sync (see the tool README).
+   **Nothing is copied for it.** The engine stays in the snapshot and
+   the wiring points at it there, so this pass writes exactly one
+   thing — and only for adopters not using the
+   `magpie-agent-guard` plugin, which carries its own hook and needs
+   no adopter-side wiring at all:
    - **Wire the hook once** in the **gitignored, per-machine**
      `.claude/settings.local.json` under `hooks.PreToolUse` (matcher
-     `Bash`), at the same moment this pass deposits `agent-guard.py`.
-     Read the file if it exists (`{}` if absent), then merge in the
-     entry. **Idempotent**: preserve every other top-level key and
-     every other `hooks.PreToolUse` matcher untouched, and skip the
-     write if a `Bash` entry already invokes `agent-guard.py`:
+     `Bash`). Read the file if it exists (`{}` if absent), then merge
+     in the entry. **Idempotent**: preserve every other top-level key
+     and every other `hooks.PreToolUse` matcher untouched, and skip
+     the write if a `Bash` entry already invokes `agent_guard`:
 
      ```json
      { "matcher": "Bash", "hooks": [ { "type": "command",
-       "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\"",
+       "command": "python3 \"$CLAUDE_PROJECT_DIR/.apache-magpie/tools/agent-guard/src/agent_guard/__init__.py\"",
        "timeout": 30 } ] }
      ```
 
-     Because the wiring is now written in the same pass that deposits
-     the script (never committed ahead of it), the command needs no
-     existence guard: unlike the old committed-`settings.json` shape,
-     there is no fresh-clone state where the wiring exists but the
-     script does not. A plain `python3 "..."` call runs identically on
-     POSIX and Windows, so the inline `python3 -c` existence check and
-     the earlier POSIX-only `[ -f ... ] && ... || true` guard are both
-     unnecessary here.
+     The path resolves in **every** worktree, because
+     [`worktree-init` Step 1](worktree-init.md#step-1--create-the-snapshot-symlink)
+     symlinks each worktree's `.apache-magpie/` at the main
+     checkout's snapshot. That is what removes the per-worktree
+     seeding this step used to require. A plain `python3 "..."` call
+     runs identically on POSIX and Windows.
 
-     Wiring happens **only once** per machine. Thereafter guards are
-     added or removed purely by syncing `guards.d`, with no
-     settings.local.json change. If the `hooks.PreToolUse` entry is
-     already present, this pass only re-syncs the script + `guards.d`.
+     Rewrite an existing entry that still names the retired
+     per-repository copy
+     (`$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py`): in any
+     worktree without that copy, Claude Code reports the missing hook
+     script as a tool error and **every `Bash` call fails**. Report
+     leftover `.claude/hooks/agent-guard.py` + `guards.d/` as
+     removable.
+
+     Wiring happens **only once** per machine, and guards need no
+     further syncing: the engine discovers the snapshot's bundled
+     `guards.d/*.py` and every skill-owned `skills/*/guards/*.py` in
+     place, so a new skill — or a skill that newly adds a guard —
+     reaches an already-adopted repo through the snapshot refresh
+     alone (see the tool README).
 
    **Codex project policy is the reviewed Codex half of the runtime
    support.** Merge the snapshot's `.codex/config.toml` and
@@ -1607,8 +1537,8 @@ A summary of what was written:
 ✓ Locks:    .apache-magpie.lock (committed) + .apache-magpie.local.lock (gitignored)
 ✓ Symlinks: <list of created symlinks>
 ✓ Overrides scaffold: .apache-magpie-overrides/ (committed)
-✓ post-checkout hook installed (seeds sandbox allowlist + agent-guard per worktree)
-✓ agent-guard PreToolUse hook synced (.claude/hooks/agent-guard.py + guards.d/ — gitignored)
+✓ post-checkout hook installed (adds the worktree to the sandbox allowlist)
+✓ agent-guard PreToolUse hook wired to the snapshot (nothing copied; no per-worktree seeding)
 ✓ Codex project policy merged and validated (.codex/config.toml + rules/magpie.rules)
 ✓ <repo>/README.md updated with adoption note
 
@@ -1626,9 +1556,7 @@ Committed (you'll see in `git status`):
 Gitignored (do NOT commit):
   .apache-magpie/
   .apache-magpie.local.lock
-  .claude/settings.local.json   # per-machine, per-worktree sandbox allowlist (issue #197)
-  .claude/hooks/agent-guard.py  # framework code synced from the snapshot; seeded into each worktree
-  .claude/hooks/guards.d/       # bundled + skill-owned guards; re-collected on /magpie-setup
+  .claude/settings.local.json   # per-machine sandbox allowlist (issue #197) + agent-guard wiring
   __pycache__/ + *.pyc       # byte-compiled artefacts from skill scripts; added to .gitignore if missing
   .agents/skills/magpie-*   (except magpie-setup, committed above)  # canonical links into the snapshot: opt-in + always-on families
   .claude/skills/magpie-*   (except magpie-setup, committed above)  # relays → ../../.agents/skills/magpie-*

--- a/skills/setup/uninstall.md
+++ b/skills/setup/uninstall.md
@@ -9,9 +9,10 @@ committed lock, gitignored local lock, framework-skill
 symlinks **in every active target dir** ([`agents.md`](agents.md)
 — `.agents/skills/`, `.claude/skills/`, `.github/skills/`, plus
 any present holdout), the matching `.gitignore` blocks,
-post-checkout hook, the gitignored agent-guard hook
-(`.claude/hooks/agent-guard.py` + `guards.d/` + the
-`settings.local.json` `hooks.PreToolUse` wiring), the Magpie-owned
+post-checkout hook, the agent-guard `hooks.PreToolUse` wiring in
+`settings.local.json` (plus any leftover
+`.claude/hooks/agent-guard.py` + `guards.d/` from a framework
+version that still copied the engine), the Magpie-owned
 Codex project policy (`.codex/config.toml` values +
 `.codex/rules/magpie.rules`), the adoption
 sections in `README.md` / `AGENTS.md` / `CONTRIBUTING.md`, and the
@@ -105,8 +106,8 @@ every artefact).
 | Committed lock | `<committed-lock>` | exists |
 | `.gitignore` entries | `<repo-root>/.gitignore` | which of the entries from [`install.md` Step 7](install.md) are present |
 | Framework-skill symlinks | **Every active target dir** ([`agents.md`](agents.md)): the canonical `.agents/skills/` (always present), the `.claude/skills/` + `.github/skills/` relay pair, and any present holdout (`.windsurf/skills/`, `.goose/skills/`) | each `magpie-*` symlink — canonical entries resolving into `<snapshot-dir>/skills/`, relays resolving into `.agents/skills/magpie-*` — in **each** target dir |
-| Post-checkout hook | `<repo-root>/.git/hooks/post-checkout` | exists + invokes `~/.claude/scripts/sandbox-add-project-root.sh` and/or seeds `.claude/hooks/agent-guard.py` |
-| agent-guard hook | `<repo-root>/.claude/hooks/agent-guard.py` + `<repo-root>/.claude/hooks/guards.d/` + the `hooks.PreToolUse` entry in `<repo-root>/.claude/settings.local.json` | exist (all gitignored, per-machine). Unlike the committed `settings.json`, `settings.local.json` is agent-writable, so remove the entry directly rather than surfacing it for manual removal. |
+| Post-checkout hook | `<repo-root>/.git/hooks/post-checkout` | exists + invokes `~/.claude/scripts/sandbox-add-project-root.sh` (older hooks additionally seeded `.claude/hooks/agent-guard.py`) |
+| agent-guard wiring | the `hooks.PreToolUse` entry in `<repo-root>/.claude/settings.local.json`, plus any leftover `<repo-root>/.claude/hooks/agent-guard.py` + `guards.d/` | exist (gitignored, per-machine). Unlike the committed `settings.json`, `settings.local.json` is agent-writable, so remove the entry directly rather than surfacing it for manual removal. The `magpie-agent-guard` **plugin**, if installed, is outside this repo — uninstalling the framework from a repo does not touch it; say so rather than silently leaving the guard active. |
 | Codex policy | `.codex/config.toml`, `.codex/rules/magpie.rules` | identify Magpie-owned values separately from unrelated adopter Codex configuration |
 | Doc section: `README.md` | `<repo-root>/README.md` | contains the `## Agent-assisted contribution (apache-magpie)` heading |
 | Doc section: `AGENTS.md` | `<repo-root>/AGENTS.md` | contains the `## apache-magpie framework` heading |
@@ -139,8 +140,8 @@ The following will be REMOVED:
     .github/skills/magpie-<skill-1>      → ../../.agents/skills/magpie-<skill-1>   (relay)
     <holdout>/skills/magpie-<skill-1>    → ../../.agents/skills/magpie-<skill-1>   (relay; e.g. .windsurf/skills/, .goose/skills/ — only if present)
     .git/hooks/post-checkout              (if it contains the magpie recipe)
-    .claude/hooks/agent-guard.py          (gitignored framework code)
-    .claude/hooks/guards.d/               (gitignored; bundled + skill-owned guards)
+    .claude/hooks/agent-guard.py          (only if a previous framework version copied it)
+    .claude/hooks/guards.d/               (only if a previous framework version collected it)
     .claude/settings.local.json           (hooks.PreToolUse entry removed; other keys kept)
     # Target dirs (per agents.md): canonical .agents/skills/, the
     #   .claude/skills/ + .github/skills/ relay pair, plus any present
@@ -244,8 +245,8 @@ pointing at a deleted snapshot.
    the magpie recipe verbatim (i.e. the hook the install flow
    wrote — the two-part body that chains
    `~/.claude/scripts/sandbox-add-project-root.sh` (guarded by
-   the `-x` test) **and** seeds `.claude/hooks/agent-guard.py`
-   from the main checkout; see
+   the `-x` test); older hooks additionally seeded
+   `.claude/hooks/agent-guard.py` from the main checkout — see
    [`install.md` Step 10](install.md#step-10--worktree-aware-post-checkout-hook-fresh-only)
    for the exact text). If the hook contains additional adopter
    logic, surface that, leave the hook in place, and tell the
@@ -254,7 +255,9 @@ pointing at a deleted snapshot.
    (a Claude Code slash command that does not work from a shell
    hook — removed in a later framework release) should be
    replaced with the current Step 10 template.
-3. **agent-guard hook files.** `rm -f
+3. **agent-guard leftovers.** Current installs put nothing here;
+   these exist only on repos adopted before the guard moved to
+   running from the install. `rm -f
    <repo-root>/.claude/hooks/agent-guard.py` and `rm -rf
    <repo-root>/.claude/hooks/guards.d/` — gitignored framework
    code, no `git rm` needed. If the adopter force-added their own
@@ -323,10 +326,12 @@ After the deletions, verify the post-state:
   the removed `<snapshot-dir>/` nor relays into the now-empty
   `.agents/skills/`.
 - `.gitignore` no longer contains the magpie entries.
-- `.claude/hooks/agent-guard.py` and `.claude/hooks/guards.d/`
-  do not exist (save any adopter-authored guards the user chose
-  to keep); the matching `hooks.PreToolUse` entry in
-  `.claude/settings.local.json` is gone too.
+- The agent-guard `hooks.PreToolUse` entry in
+  `.claude/settings.local.json` is gone, and no leftover
+  `.claude/hooks/agent-guard.py` / `guards.d/` remain (save any
+  adopter-authored guards the user chose to keep). An installed
+  `magpie-agent-guard` plugin is untouched and still active — it
+  is not part of this repository's adoption.
 - Magpie-owned Codex policy is gone while unrelated `.codex`
   configuration remains.
 - The doc sections are gone from the affected files.

--- a/skills/setup/upgrade.md
+++ b/skills/setup/upgrade.md
@@ -377,22 +377,22 @@ rather than pulls in via symlink. Examples:
 - `<repo-root>/.git/hooks/post-checkout` (the worktree-aware
   hook installed during installation). Its expected content is the
   [`install.md` Step 10](install.md#step-10--worktree-aware-post-checkout-hook-fresh-only)
-  template — which now both chains the sandbox-allowlist helper
-  **and** seeds a new worktree's agent-guard from the main
-  checkout. An adopter on an older hook (sandbox-only, or the
-  long-removed `--auto-fix-symlinks` line) is re-installed to the
-  current template by this drift sync.
-- `<repo-root>/.claude/hooks/agent-guard.py` and the
-  `<repo-root>/.claude/hooks/guards.d/` directory (the
-  deterministic `PreToolUse` guard dispatcher and its guards — see
-  [`install.md` Step 12](install.md#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
-  and [`tools/agent-guard`](../../tools/agent-guard/README.md)).
-  `guards.d/` is populated from **both** the engine's bundled
-  `guards.d/*.py` **and** every skill-owned `skills/*/guards/*.py`
-  in the snapshot. Re-syncing it is how a new skill — or a skill
-  that newly adds a guard — reaches an already-adopted repo; the
-  `settings.local.json` `hooks.PreToolUse` wiring is unchanged (already
-  wired, or re-added via the same idempotent merge if missing).
+  template — which chains the sandbox-allowlist helper. An adopter
+  on an older hook (one that also seeded a per-worktree
+  agent-guard copy, or the long-removed `--auto-fix-symlinks`
+  line) is re-installed to the current template by this drift
+  sync.
+- The `settings.local.json` `hooks.PreToolUse` wiring for the
+  deterministic guard ([`tools/agent-guard`](../../tools/agent-guard/README.md)).
+  The engine itself is **not** copied anywhere: the wiring resolves
+  it inside the snapshot, so `upgrade` refreshing the snapshot
+  refreshes the engine and every skill-owned guard with it. An
+  adopter whose entry still names the retired per-repository copy
+  (`$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py`) is rewritten
+  to the snapshot path — that stale entry breaks every `Bash` call
+  in any worktree that has no copy. Any leftover
+  `<repo-root>/.claude/hooks/agent-guard.py` and `guards.d/` are
+  reported as removable.
 - The committed `.codex/config.toml` and `.codex/rules/magpie.rules`:
   compare them with the current snapshot policy. Preserve unrelated
   Codex settings; surface conflicts and hand edits rather than

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -292,17 +292,16 @@ Two sub-checks on `<repo-root>/.git/hooks/post-checkout`:
 
 1. **Presence + executable.** File exists, is executable,
    and carries the current hook body — the sandbox-allowlist
-   helper chain **and** the agent-guard seeding block (see
+   helper chain (see
    [`install.md` Step 10](install.md#step-10--worktree-aware-post-checkout-hook-fresh-only)).
    It must **not** contain the long-removed
    `/magpie-setup verify --auto-fix-symlinks` line (a slash
    command is not shell-callable; it printed a spurious error on
    every checkout).
    - ⚠ if missing — strictly optional, but worktrees off this
-     repo will then not get their sandbox allowlist or
-     agent-guard seeded automatically on `git worktree add`
-     (they fall back to `/magpie-setup worktree-init`). Print
-     the install recipe.
+     repo will then not get their sandbox allowlist added
+     automatically on `git worktree add` (they fall back to
+     `/magpie-setup worktree-init`). Print the install recipe.
 
 2. **Content drift vs the framework's expected.** Diff the
    installed hook against the framework's expected hook
@@ -321,48 +320,47 @@ Two sub-checks on `<repo-root>/.git/hooks/post-checkout`:
      remediation, no operator prompt needed; the sync
      pass overwrites silently.
 
-### 8a. agent-guard PreToolUse hook installed and wired
+### 8a. agent-guard PreToolUse hook active
 
-Three sub-checks for the deterministic guard
-([`tools/agent-guard`](../../tools/agent-guard/README.md)):
+One check, against whichever of the three installs the operator
+uses ([`tools/agent-guard`](../../tools/agent-guard/README.md)).
+Establish that a `PreToolUse` hook on the `Bash` matcher exists and
+that the engine path it names **resolves**; a wired hook pointing at
+a file that is not there is the failure mode worth catching, because
+a guard that never loads does not raise — it silently stops denying.
 
-1. **Script present + matches the snapshot.** `<repo-root>/.claude/hooks/agent-guard.py`
-   exists and its content matches the snapshot's
-   `tools/agent-guard/src/agent_guard/__init__.py`.
-   - ⚠ / ✗ on missing / stale — remediation is `/magpie-setup`
-     (adopt or upgrade), whose sync pass re-installs it.
-2. **`guards.d` populated.** `<repo-root>/.claude/hooks/guards.d/`
-   exists and contains every guard the snapshot ships — the
-   engine's bundled `guards.d/*.py` **and** each skill-owned
-   `skills/*/guards/*.py` (e.g. `mention`, `mark_ready`,
-   `security_language`). Flag a *missing* expected guard or a stale
-   copy; extra locally-added `*.py` are fine. A missing skill guard
-   means that skill's deterministic protection is silently inactive
-   — remediation is `/magpie-setup` (adopt/upgrade), which re-collects.
-3. **Hook wired in settings.local.json.** `<repo-root>/.claude/settings.local.json`
+1. **Plugin install** — the `magpie-agent-guard` plugin is
+   installed. Its manifest carries the hook, so there is nothing
+   repository-local to check and nothing to remediate per worktree.
+   - ⚠ if no agent-guard install of any kind is found: print
+     `/plugin install magpie-agent-guard@apache-magpie`.
+2. **Snapshot install** — `<repo-root>/.claude/settings.local.json`
    has a `hooks.PreToolUse` entry (matcher `Bash`) whose command
-   runs `agent-guard.py`.
-   - If missing, the script is present but not active. Write the
-     entry directly (idempotent merge, per
-     [`install.md` Step 12](install.md#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)),
-     no operator prompt needed since `settings.local.json` is
-     gitignored and agent-writable, unlike the committed `settings.json`.
+   runs the engine, and that command's path resolves.
+   - ✗ if the entry names a path that does not exist. In
+     particular, an entry still pointing at the retired
+     per-repository copy
+     (`$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py`) fails in
+     every worktree that has no copy — **and breaks every `Bash`
+     call there**, since Claude Code surfaces a missing hook script
+     as a tool error. Rewrite it to the snapshot path
+     (`$CLAUDE_PROJECT_DIR/.apache-magpie/tools/agent-guard/src/agent_guard/__init__.py`);
+     `settings.local.json` is gitignored and agent-writable, unlike
+     the committed `settings.json`, so no operator prompt is needed.
+   - Leftover `<repo-root>/.claude/hooks/agent-guard.py` and
+     `guards.d/` from an older install are inert once the wiring
+     points at the snapshot; report them as removable, do not fail.
+3. **User-scope secure setup** — `~/.claude/scripts/agent-guard.py`
+   wired from `~/.claude/settings.json`
+   ([`setup-isolated-setup-install`](../setup-isolated-setup-install/SKILL.md)).
 
-The script + `guards.d` are **gitignored** framework code
-([`install.md` Step 7](install.md#step-7--gitignore-entries-fresh-only)),
-synced from the snapshot rather than committed — so a *missing*
-script is the expected state of a fresh checkout, not a defect, and
-the fix is always a re-sync (never `git add`). When this check runs
-**inside a worktree**, the script, `guards.d`, **and** the
-`settings.local.json` wiring are all per-worktree (each worktree's own
-`settings.local.json` resolves
-`$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py` against that
-worktree's own root, and is not inherited via git). The remediation
-for a *missing* script or wiring entry in a worktree is not the
-main-checkout sync but
-[`worktree-init.md` Step 1d](worktree-init.md#step-1d--seed-the-worktrees-agent-guard-pretooluse-hook)
-(or the post-checkout hook on the next `git worktree add`), which
-seeds both from the main checkout's already-synced copy.
+Skill-owned guards are **not** separately checked: the engine
+discovers every `skills/*/guards` in the framework tree it runs
+from, so there is no collected copy that can drift out of sync.
+
+This check is worktree-independent. None of the three installs puts
+anything in a worktree, so a worktree result never differs from the
+main checkout's.
 
 ### 8b. Sandbox-allowlist coverage of the current worktree
 

--- a/skills/setup/worktree-init.md
+++ b/skills/setup/worktree-init.md
@@ -187,64 +187,37 @@ one-line recap row for the Step 2 summary:
 `worktree-init` does **not** fail when the helper is absent;
 secure-agent isolation is independent of framework adoption.
 
-## Step 1d — Seed the worktree's agent-guard PreToolUse hook
+## Step 1d — agent-guard needs nothing here
 
-The gitignored, per-machine `.claude/settings.local.json` wires the
-deterministic guard ([`tools/agent-guard`](../../tools/agent-guard/README.md))
-at `$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py`, a
-**per-worktree** path. The script, its `guards.d/`, and the
-`hooks.PreToolUse` wiring itself are all adopter-installed local
-files synced into the **main** checkout by
-[`install.md` Step 12 pass 1](install.md#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
-/ [`upgrade.md` Step 6b](upgrade.md#step-6b--sync-locally-installed-hooks-and-configuration)
-and **gitignored** ([`install.md` Step 7](install.md#step-7--gitignore-entries-fresh-only)).
-Because they are gitignored, no worktree inherits any of them via
-git. Every worktree starts without the script or the wiring and
-would run with the guard **silently inactive** until seeded.
+Nothing to do. This step is retained only to say so, because
+earlier versions of the framework seeded a per-worktree copy of
+the guard here and operators may still expect it.
 
-This is the agent-driven counterpart of the
-[post-checkout hook's agent-guard seeding](install.md#step-10--worktree-aware-post-checkout-hook-fresh-only):
-the git hook covers `git worktree add`, this step covers worktrees
-that pre-date the hook or where its best-effort copy did not run.
+The deterministic guard
+([`tools/agent-guard`](../../tools/agent-guard/README.md)) runs
+from wherever it is installed **once**, never from a per-worktree
+copy:
 
-Seed the script from the main checkout's already-synced copy, a
-plain file copy of the same `<main>` resolved in Step 0:
+- **Plugin install** (`magpie-agent-guard`) — the plugin's own
+  manifest registers the `PreToolUse` hook and resolves the engine
+  under `${CLAUDE_PLUGIN_ROOT}`. Nothing is repository-local, so a
+  worktree is covered the moment it exists.
+- **Snapshot install** — the `settings.local.json` wiring resolves
+  the engine inside the snapshot
+  (`$CLAUDE_PROJECT_DIR/.apache-magpie/tools/agent-guard/src/agent_guard/__init__.py`),
+  and Step 1 above already points this worktree's `.apache-magpie/`
+  at the main checkout's. The path therefore resolves here with no
+  further work.
+- **User-scope secure setup** — `~/.claude/scripts/agent-guard.py`,
+  wired from `~/.claude/settings.json`, is repository-independent
+  by construction.
 
-```bash
-# Only when the main has a guard and this worktree has none — never
-# overwrite a copy the worktree already carries (worktree-local guards).
-if [ -f "<main>/.claude/hooks/agent-guard.py" ] &&
-   [ ! -f "<worktree>/.claude/hooks/agent-guard.py" ]; then
-  mkdir -p "<worktree>/.claude/hooks/guards.d"
-  cp "<main>/.claude/hooks/agent-guard.py" "<worktree>/.claude/hooks/agent-guard.py"
-  cp "<main>/.claude/hooks/guards.d/"*.py "<worktree>/.claude/hooks/guards.d/" 2>/dev/null || true
-fi
-```
+Skill-owned guards need no seeding either: the engine scans every
+`skills/<skill>/guards` in the framework tree it runs from, so they
+are live wherever the framework is.
 
-Idempotent: a no-op when the worktree already has the script, and
-a no-op when the main has no agent-guard yet (an adopter who has
-not run the Step 12 / Step 6b sync). Surface a one-line recap row
-for Step 2:
-
-- ✓ already present, OR
-- + seeded from `<main>` (script + N guards), OR
-- ⚠ main has no agent-guard yet — run `/magpie-setup` (or
-  `/magpie-setup upgrade`) from the main checkout to sync it.
-
-Then seed the wiring into this worktree's own `settings.local.json`
-the same way [`install.md` Step 12 pass 1](install.md#step-12--post-install-sync--worktree-propagation--sandbox-allowlist--sanity-check)
-does for the main checkout: an idempotent merge that preserves every
-other key and is skipped once a `Bash` entry already invokes
-`agent-guard.py`. Do this whenever the script was just copied above,
-and also when the worktree already has the script but is missing
-the wiring (an older worktree created before this step covered
-wiring, or one where a prior pass copied the script but not the
-entry). Add a `+ wired` row alongside the recap above when this
-ran and the script was already present.
-
-`worktree-init` does **not** fail when the main carries no
-agent-guard; the guard is an opt-in adopter-side file, and the
-worktree's framework-skill symlinks are usable without it.
+Surface one recap row for Step 2: `✓ agent-guard runs from the
+install, nothing seeded per worktree`.
 
 ## Step 2 — Recap
 
@@ -259,8 +232,8 @@ Print a short summary:
   pair, any present holdout), split into *opt-in* and
   *always-on*, with per-skill ✓ / + / ↻ counts.
 - The sandbox-allowlist recap row from Step 1c.
-- The agent-guard recap row from Step 1d (✓ already present /
-  + seeded / ⚠ main has no agent-guard yet).
+- The agent-guard recap row from Step 1d (always ✓ — the guard
+  runs from the install, not from a per-worktree copy).
 - A reminder: `upgrade` from the main, not from the worktree.
 
 ## Inputs

--- a/tools/agent-guard/README.md
+++ b/tools/agent-guard/README.md
@@ -10,6 +10,7 @@
   - [Guards](#guards)
   - [Per-command overrides](#per-command-overrides)
   - [Wiring](#wiring)
+    - [Snapshot adopters (`/magpie-setup`)](#snapshot-adopters-magpie-setup)
     - [OpenCode](#opencode)
     - [Kiro CLI](#kiro-cli)
     - [Harness-neutral path (any runtime)](#harness-neutral-path-any-runtime)
@@ -101,10 +102,36 @@ for (default `ready for maintainer review`).
 
 ## Wiring
 
-The guard is registered as a `PreToolUse` hook on the `Bash` matcher in the
-gitignored, per-machine `.claude/settings.local.json` (not the committed
-`.claude/settings.json`, so no worktree inherits the wiring via git: each
-worktree is seeded independently, same as the script itself):
+Install the `magpie-agent-guard` plugin:
+
+```text
+/plugin marketplace add apache/magpie
+/plugin install magpie-agent-guard@apache-magpie
+```
+
+That is the whole installation. The plugin's manifest
+([`plugins/magpie-agent-guard/.claude-plugin/plugin.json`](../../plugins/magpie-agent-guard/.claude-plugin/plugin.json))
+registers the `PreToolUse` hook itself and resolves the engine under
+`${CLAUDE_PLUGIN_ROOT}`, so the guard runs out of the installed plugin. **No
+file is copied into any repository, no `settings.local.json` entry is written,
+and a git worktree needs no seeding** — it is an ordinary checkout, and the
+guard is active in it the moment the plugin is installed.
+
+Skill-owned guards work the same way: the engine discovers every
+`skills/<skill>/guards` in the framework tree it is running from, so a skill's
+guards take effect where they live and nothing collects or syncs them.
+
+The guard is its own plugin rather than a hook on `magpie` or on each family
+plugin because Claude Code merges hooks from **every** enabled plugin — wiring it
+into the families would run it once per enabled family on every `Bash` call. One
+dedicated owner runs it exactly once, whatever else is installed.
+
+### Snapshot adopters (`/magpie-setup`)
+
+A project that vendors the framework as a snapshot rather than installing the
+plugin wires the hook by hand, in the gitignored, per-machine
+`.claude/settings.local.json`. Point it at the **snapshot's** engine, not at a
+per-repository copy:
 
 ```json
 {
@@ -113,7 +140,7 @@ worktree is seeded independently, same as the script itself):
       {
         "matcher": "Bash",
         "hooks": [
-          { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py\"", "timeout": 30 }
+          { "type": "command", "command": "python3 \"$CLAUDE_PROJECT_DIR/.apache-magpie/tools/agent-guard/src/agent_guard/__init__.py\"", "timeout": 30 }
         ]
       }
     ]
@@ -121,11 +148,15 @@ worktree is seeded independently, same as the script itself):
 }
 ```
 
-`/magpie-setup` ships `agent_guard/__init__.py` as a single self-contained file
-into the adopter tree (`.claude/hooks/agent-guard.py`) and into the user-scope
-secure setup (`~/.claude/scripts/agent-guard.py`); `/magpie-setup upgrade`,
-`verify`, and the `setup-isolated-setup-install` / `…-update` skills keep it and
-the settings.local.json entry in sync. See those skills for the exact steps.
+Every worktree already symlinks `.apache-magpie/` to the main checkout's
+snapshot ([`worktree-init`](../../skills/setup/worktree-init.md)), so this path
+resolves in a worktree without seeding anything else. `/magpie-setup upgrade`
+refreshes the engine with the rest of the snapshot.
+
+The user-scope secure setup installs the engine once at
+`~/.claude/scripts/agent-guard.py` and wires it from `~/.claude/settings.json`;
+that path is worktree- and repository-independent by construction. See
+[`setup-isolated-setup-install`](../../skills/setup-isolated-setup-install/SKILL.md).
 
 ### OpenCode
 
@@ -245,15 +276,19 @@ for Claude Code setups — the file is the same and works for all three modes).
 ## Contributing guards
 
 The hook is **wired once**. Beyond the two bundled guards, additional guards are
-discovered at runtime from every `*.py` in a `guards.d` directory — the
-`guards.d` sibling of the running script, plus any directory listed in
-`$MAGPIE_GUARD_DIRS` (colon-separated). **No `settings.json` change is needed to
-add a guard.**
+discovered at runtime from every `*.py` in a discovered guard directory — any
+directory listed in `$MAGPIE_GUARD_DIRS` (colon-separated), then every
+`skills/*/guards` in the framework tree the engine runs from, then the
+`guards.d` sibling of the running script. **No `settings.json` change and no
+install step is needed to add a guard.**
 
-A skill owns its guards by shipping them under `skills/<skill>/guards/*.py`;
-`/magpie-setup` collects every `skills/*/guards/*.py` (plus the engine's bundled
-`guards.d`) into the adopter's `.claude/hooks/guards.d/` (and the user-scope
-`~/.claude/scripts/guards.d/`). A guard file is **import-free** — it defines:
+A skill owns its guards by shipping them under `skills/<skill>/guards/*.py`.
+The engine discovers them there — it resolves the framework tree it is running
+from and scans every `skills/*/guards` in it, alongside its own bundled
+`guards.d`. Nothing collects or copies them, so a new guard is live as soon as
+the framework is. (A single self-contained copy of the engine, with no framework
+tree above it, sees only its own `guards.d` and whatever `$MAGPIE_GUARD_DIRS`
+names.) A guard file is **import-free** — it defines:
 
 - `TRIGGERS` — optional list of command families to pre-filter on (`"gh"`,
   `"git:commit"`, `"git:push"`, …); omit to run on every guarded command.

--- a/tools/agent-guard/src/agent_guard/__init__.py
+++ b/tools/agent-guard/src/agent_guard/__init__.py
@@ -64,13 +64,15 @@ or disable the whole dispatcher (``MAGPIE_GUARD_OFF=1``). Overrides are read
 from the command string itself (and from the hook's own environment).
 
 **Contributing guards.** Beyond the two bundled guards, any skill adds its own
-deterministic guard **without re-wiring the hook**: drop an import-free
-``*.py`` file into a discovered ``guards.d`` directory (the ``guards.d`` sibling
-of this script, plus any dir in ``$MAGPIE_GUARD_DIRS``) that defines a
-module-level ``guard(ctx)`` returning a deny string or ``None`` — see
-``GuardContext`` and ``guards.d/no_verify_commit.py`` for the template. The hook
-is wired once at setup; thereafter guards are added/removed by managing files in
-``guards.d`` (which ``/magpie-setup`` keeps in sync from the snapshot).
+deterministic guard **without re-wiring the hook**: drop an import-free ``*.py``
+file that defines a module-level ``guard(ctx)`` returning a deny string or
+``None`` into any discovered guard directory — see ``GuardContext`` and
+``guards.d/no_verify_commit.py`` for the template. Three sources are discovered,
+in this order: every dir in ``$MAGPIE_GUARD_DIRS``, every
+``skills/<skill>/guards`` in the framework tree this file is running from, and
+the ``guards.d`` sibling of this file. A skill therefore owns its guards in its
+own directory and they take effect as soon as the framework is installed —
+nothing collects, copies, or syncs them.
 """
 
 from __future__ import annotations
@@ -334,8 +336,8 @@ def guard_empty_rebase(seg: Segment, cwd: str | None) -> str | None:
 # guards are owned and contributed by the skills that need them (e.g. the
 # mention + mark-ready guards live in `skills/pr-management-triage/guards/`, the
 # security-language guard in `skills/security-issue-fix/guards/`); they are
-# discovered at runtime from `guards.d` without editing this file or re-wiring
-# the hook — see "Contributing guards" below.
+# discovered at runtime, in place, without editing this file or re-wiring the
+# hook — see "Contributing guards" above.
 BUILTIN_GUARDS: tuple[Callable[[Segment, str | None], str | None], ...] = (
     guard_commit_trailer,
     guard_empty_rebase,
@@ -346,9 +348,9 @@ BUILTIN_GUARDS: tuple[Callable[[Segment, str | None], str | None], ...] = (
 # `gh` / `git` outbound/destructive surface.
 GUARDED_HEADS = frozenset({"gh", "git"})
 
-# Colon-separated extra guard directories (in addition to the default
-# ``guards.d`` sibling of this script). Lets a checkout point the hook at
-# skill-owned guard dirs without moving files.
+# Colon-separated extra guard directories, searched before the discovered ones.
+# Skill-owned guards no longer need it (``framework_root`` finds them in place);
+# it remains the escape hatch for guards kept outside the framework tree.
 GUARD_DIRS_ENV = "MAGPIE_GUARD_DIRS"
 
 
@@ -425,13 +427,32 @@ def command_kinds(seg: Segment) -> set[str]:
     return kinds
 
 
+def framework_root() -> Path | None:
+    """The framework tree this engine is running out of, or ``None``.
+
+    Recognised by the two directories the engine always sits beside: a
+    ``skills/`` tree and the ``tools/agent-guard`` package holding this file.
+    That holds whether the hook runs from an installed plugin, a framework
+    checkout, or an adopter's snapshot — and does not hold for a standalone copy
+    of this one file, which is why the result is optional rather than a path
+    computed by counting ``parents``.
+    """
+    for parent in Path(__file__).resolve().parents:
+        if (parent / "skills").is_dir() and (parent / "tools" / "agent-guard").is_dir():
+            return parent
+    return None
+
+
 def guard_dirs() -> list[Path]:
-    """Directories scanned for contributed guards: ``$MAGPIE_GUARD_DIRS`` entries
-    plus the ``guards.d`` sibling of this script."""
+    """Directories scanned for contributed guards: ``$MAGPIE_GUARD_DIRS`` entries,
+    then every ``skills/*/guards`` in the framework tree this file runs from, then
+    the ``guards.d`` sibling of this file."""
     dirs: list[Path] = []
     env = os.environ.get(GUARD_DIRS_ENV)
     if env:
         dirs.extend(Path(p) for p in env.split(os.pathsep) if p)
+    if (root := framework_root()) is not None:
+        dirs.extend(sorted((root / "skills").glob("*/guards")))
     dirs.append(Path(__file__).resolve().parent / "guards.d")
     seen: set[Path] = set()
     out: list[Path] = []

--- a/tools/agent-guard/tests/test_discovery.py
+++ b/tools/agent-guard/tests/test_discovery.py
@@ -1,0 +1,120 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for in-place guard discovery — the property that lets the hook run
+straight from an installed plugin with nothing copied into a consumer repo.
+
+The failure these guard against is silent: a guard directory that stops being
+discovered does not raise, it simply stops denying, and the operator finds out
+when an unguarded command lands."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+import agent_guard
+
+REPO_ROOT = Path(agent_guard.__file__).resolve().parents[4]
+
+
+@pytest.fixture(autouse=True)
+def _no_env_dirs(monkeypatch):
+    monkeypatch.delenv(agent_guard.GUARD_DIRS_ENV, raising=False)
+
+
+def test_framework_root_is_the_checkout_holding_skills_and_the_engine():
+    assert agent_guard.framework_root() == REPO_ROOT
+    assert (REPO_ROOT / "skills").is_dir()
+    assert (REPO_ROOT / "tools" / "agent-guard").is_dir()
+
+
+def test_framework_root_is_none_for_a_standalone_copy(tmp_path, monkeypatch):
+    """A single self-contained copy of the engine has no framework tree above it.
+    ``framework_root`` must say so rather than climbing to an unrelated ancestor
+    that happens to hold a ``skills/`` directory."""
+    lone = tmp_path / "hooks" / "agent-guard.py"
+    lone.parent.mkdir(parents=True)
+    lone.write_text(Path(agent_guard.__file__).read_text(encoding="utf-8"), encoding="utf-8")
+
+    spec = importlib.util.spec_from_file_location("_standalone_agent_guard", lone)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.framework_root() is None
+    assert module.guard_dirs() == []  # no guards.d sibling either
+
+
+def test_skill_guard_dirs_are_discovered_without_configuration():
+    """Every ``skills/*/guards`` in the framework tree is scanned as-is — this is
+    what removes the "collect skill guards into a local guards.d" install step."""
+    dirs = agent_guard.guard_dirs()
+    on_disk = sorted((REPO_ROOT / "skills").glob("*/guards"))
+    assert on_disk, "expected at least one skill-owned guards dir in the repo"
+    for d in on_disk:
+        assert d in dirs
+    assert dirs[-1] == Path(agent_guard.__file__).resolve().parent / "guards.d"
+
+
+def test_env_dirs_are_searched_before_discovered_ones(monkeypatch, tmp_path):
+    extra = tmp_path / "extra-guards"
+    extra.mkdir()
+    monkeypatch.setenv(agent_guard.GUARD_DIRS_ENV, str(extra))
+    assert agent_guard.guard_dirs()[0] == extra
+
+
+def test_a_skill_owned_guard_denies_with_no_env_configuration(monkeypatch):
+    """End-to-end: the mention guard lives in ``skills/pr-management-triage/guards``
+    and must fire on a plain dispatch with nothing pointing at it."""
+    for name in ("MAGPIE_GUARD_OFF", "MAGPIE_ALLOW_MENTIONS"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr(agent_guard, "_run", lambda args, cwd=None: None)
+
+    reason = agent_guard.dispatch('gh pr comment 123 --body "@somebody take a look"', None)
+
+    assert reason is not None
+    assert "mention" in reason
+
+
+def test_discovery_survives_being_reached_through_a_symlinked_plugin_root(tmp_path):
+    """How the published plugin actually resolves: ``plugins/magpie-agent-guard``
+    exposes the engine through a symlink, so ``__file__`` is a path outside the
+    framework tree until it is resolved."""
+    link_parent = tmp_path / "plugin" / "tools"
+    link_parent.mkdir(parents=True)
+    (link_parent / "agent-guard").symlink_to(REPO_ROOT / "tools" / "agent-guard")
+
+    entry = link_parent / "agent-guard" / "src" / "agent_guard" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("_linked_agent_guard", entry)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.framework_root() == REPO_ROOT
+    assert sorted((REPO_ROOT / "skills").glob("*/guards"))[0] in module.guard_dirs()
+
+
+def test_guard_dirs_are_deduplicated(monkeypatch):
+    """A skill guards dir named in the environment as well as discovered is
+    scanned once — otherwise its guards would run twice per command."""
+    skill_guards = sorted((REPO_ROOT / "skills").glob("*/guards"))[0]
+    monkeypatch.setenv(agent_guard.GUARD_DIRS_ENV, f"{skill_guards}{os.pathsep}{skill_guards}")
+    assert agent_guard.guard_dirs().count(skill_guards) == 1

--- a/tools/dev/check-family-plugins.py
+++ b/tools/dev/check-family-plugins.py
@@ -26,7 +26,11 @@ Checks that every plugin is properly defined:
   `plugins/magpie-<family>/` plugin whose manifest is well-formed, inherits the
   root manifest's shared metadata (version, author, homepage, repository,
   license), and whose `skills/` directory contains exactly that family's skills
-  as single-hop symlinks into the shared `skills/<skill>` tree.
+  as single-hop symlinks into the shared `skills/<skill>` tree;
+- every *substrate* plugin (`SUBSTRATE_PLUGINS` — a framework tool published as
+  its own plugin rather than a family of skills) has a well-formed manifest that
+  inherits the same shared metadata, declares the exact hook wiring the framework
+  expects, and reaches its tool through a symlink that actually resolves.
 
 Drift — a new skill, a changed family, a stale symlink, a malformed or
 mis-named manifest, a dangling marketplace entry, a family manifest left behind
@@ -53,6 +57,7 @@ MARKETPLACE = Path(".claude-plugin/marketplace.json")
 ROOT_MANIFEST = Path(".claude-plugin/plugin.json")  # the all-in-one `magpie` plugin
 HOOK_SCRIPT = Path("hooks/check-upgrade.sh")  # referenced by the all-in-one plugin hook
 SYMLINK_TARGET = "../../../skills/{skill}"  # relative to plugins/magpie-<f>/skills/
+TOOL_SYMLINK_TARGET = "../../../tools/{tool}"  # relative to plugins/magpie-<p>/tools/
 
 # The vendor-neutral Agent Plugins 1.0 manifest for the same all-in-one plugin.
 # It lives at the repo root (the spec permits no alternative location) and is
@@ -134,6 +139,47 @@ DESC = {
 }
 
 
+# Substrate plugins are *not* derived from any skill's `family:` frontmatter:
+# they publish a framework tool as its own plugin so the tool runs from the
+# installed plugin root, with nothing copied into a consumer repository. Each
+# declares the hook wiring the framework expects and reaches its tool through a
+# narrow symlink (the whole `tools/` tree is deliberately not exposed).
+#
+# A substrate plugin is a plugin of its own rather than a hook on the all-in-one
+# `magpie` plugin because Claude Code merges hooks from *every* enabled plugin:
+# wiring the guard into each family plugin would run it once per enabled family
+# on every single Bash call. One dedicated owner runs it exactly once, whatever
+# else is installed.
+AGENT_GUARD_ENGINE = "tools/agent-guard/src/agent_guard/__init__.py"
+SUBSTRATE_PLUGINS: dict[str, dict] = {
+    "magpie-agent-guard": {
+        "description": (
+            "Apache Magpie \u2014 deterministic pre-execution command guard: a PreToolUse hook "
+            "that denies shell commands which would break a hard framework rule. Runs from "
+            "the installed plugin, so no repository or worktree needs a local copy."
+        ),
+        # <link path under the plugin root> -> <tools/ subdirectory it exposes>
+        "links": {"tools/agent-guard": "agent-guard"},
+        # Files that must resolve *through* those links for the hook to fire.
+        "must_resolve": (AGENT_GUARD_ENGINE,),
+        "hooks": {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": f'python3 "${{CLAUDE_PLUGIN_ROOT}}/{AGENT_GUARD_ENGINE}"',
+                            "timeout": 30,
+                        }
+                    ],
+                }
+            ]
+        },
+    },
+}
+
+
 def load_json(path: Path):
     try:
         return json.loads(path.read_text(encoding="utf-8")), None
@@ -163,6 +209,78 @@ def validate_manifest(path: Path, expected_name: str, inherited: dict | None = N
                 f"{path}: {key!r} is {data.get(key)!r}, expected {want!r} (inherited from {ROOT_MANIFEST})"
             )
     return errors
+
+
+def substrate_manifest(name: str, shared: dict) -> dict:
+    """The manifest `--fix` writes for a substrate plugin — the single source of
+    truth `check` compares the on-disk file against."""
+    spec = SUBSTRATE_PLUGINS[name]
+    return {"name": name, "description": spec["description"], **shared, "hooks": spec["hooks"]}
+
+
+def check_substrate(name: str, shared: dict) -> list[str]:
+    """A substrate plugin's manifest, hook wiring, and tool symlinks.
+
+    Unlike a family plugin it declares no `skills`, so it gets its own checks
+    rather than `validate_manifest`'s.
+    """
+    spec = SUBSTRATE_PLUGINS[name]
+    pdir = PLUGINS / name
+    path = pdir / ".claude-plugin" / "plugin.json"
+    if not path.is_file():
+        return [f"{path}: missing plugin manifest"]
+    data, err = load_json(path)
+    if err:
+        return [err]
+
+    errors: list[str] = []
+    if data.get("name") != name:
+        errors.append(f"{path}: name is {data.get('name')!r}, expected {name!r}")
+    if not str(data.get("description", "")).strip():
+        errors.append(f"{path}: missing/empty 'description'")
+    if "skills" in data:
+        errors.append(f"{path}: substrate plugins ship a tool, not skills — drop 'skills'")
+    if data.get("hooks") != spec["hooks"]:
+        errors.append(
+            f"{path}: 'hooks' does not match the wiring the framework expects (regenerate with --fix)"
+        )
+    for key, want in (shared or {}).items():
+        if data.get(key) != want:
+            errors.append(
+                f"{path}: {key!r} is {data.get(key)!r}, expected {want!r} (inherited from {ROOT_MANIFEST})"
+            )
+
+    for link_path, tool in spec["links"].items():
+        link = pdir / link_path
+        want = Path(TOOL_SYMLINK_TARGET.format(tool=tool))
+        if not link.is_symlink():
+            errors.append(f"{name}: {link} is missing or not a symlink (expected -> {want})")
+        elif link.readlink() != want:
+            errors.append(f"{name}: {link} -> {link.readlink()} (expected {want})")
+
+    # A manifest and a symlink that both look right still leave the hook dead if
+    # the file the command names is not reachable from the plugin root.
+    for rel in spec["must_resolve"]:
+        if not (pdir / rel).is_file():
+            errors.append(
+                f"{name}: {pdir / rel} does not resolve — the hook command names it, "
+                f"so the guard would silently never run"
+            )
+    return errors
+
+
+def write_substrate(name: str, shared: dict) -> None:
+    """(Re)generate a substrate plugin dir: manifest + tool symlinks."""
+    spec = SUBSTRATE_PLUGINS[name]
+    pdir = PLUGINS / name
+    (pdir / ".claude-plugin").mkdir(parents=True)
+    for link_path, tool in spec["links"].items():
+        link = pdir / link_path
+        link.parent.mkdir(parents=True, exist_ok=True)
+        link.symlink_to(TOOL_SYMLINK_TARGET.format(tool=tool))
+    (pdir / ".claude-plugin" / "plugin.json").write_text(
+        json.dumps(substrate_manifest(name, shared), indent=2) + "\n", encoding="utf-8"
+    )
 
 
 def pyproject_version() -> tuple[str | None, list[str]]:
@@ -416,8 +534,16 @@ def check(fam: dict[str, set[str]]) -> list[str]:
             if have[skill] != want:
                 errors.append(f"{name}: {sdir / skill} -> {have[skill]} (expected {want})")
 
-    # 4) No orphan plugin dirs (a magpie-<x> with no skills declaring family x).
+    # 4) Substrate plugins: manifest + hook wiring + tool symlinks that resolve.
+    for name in sorted(SUBSTRATE_PLUGINS):
+        errors += check_substrate(name, shared)
+        if name not in listed:
+            errors.append(f"{MARKETPLACE}: missing entry for '{name}'")
+
+    # 5) No orphan plugin dirs (a magpie-<x> that is neither a family nor substrate).
     for pdir in sorted(PLUGINS.glob("magpie-*")):
+        if pdir.name in SUBSTRATE_PLUGINS:
+            continue
         family = pdir.name[len("magpie-") :]
         if family not in fam:
             errors.append(f"orphan plugin '{pdir.name}': no skill declares family '{family}'")
@@ -426,7 +552,7 @@ def check(fam: dict[str, set[str]]) -> list[str]:
 
 
 def unowned_entries(pdir: Path) -> list[str]:
-    """Anything in a family plugin dir that `--fix` did not generate.
+    """Anything in a plugin dir that `--fix` did not generate.
 
     A blanket `rmtree` is safe only for as long as these directories hold
     nothing but a generated manifest and symlinks. The moment a family grows a
@@ -436,12 +562,20 @@ def unowned_entries(pdir: Path) -> list[str]:
     """
     if not pdir.is_dir():
         return []
-    mdir, sdir = pdir / ".claude-plugin", pdir / "skills"
-    unexpected = sorted(p for p in pdir.iterdir() if p not in {mdir, sdir})
+    mdir = pdir / ".claude-plugin"
+    # A substrate plugin owns its tool-symlink parents instead of `skills/`.
+    if spec := SUBSTRATE_PLUGINS.get(pdir.name):
+        owned = {mdir} | {pdir / Path(link).parts[0] for link in spec["links"]}
+        link_dirs = [pdir / Path(link).parent for link in spec["links"]]
+    else:
+        owned = {mdir, pdir / "skills"}
+        link_dirs = [pdir / "skills"]
+    unexpected = sorted(p for p in pdir.iterdir() if p not in owned)
     if mdir.is_dir():
         unexpected += sorted(p for p in mdir.iterdir() if p.name != "plugin.json")
-    if sdir.is_dir():
-        unexpected += sorted(p for p in sdir.iterdir() if not p.is_symlink())
+    for sdir in link_dirs:
+        if sdir.is_dir():
+            unexpected += sorted(p for p in sdir.iterdir() if not p.is_symlink())
     if not unexpected:
         return []
     return [
@@ -493,6 +627,8 @@ def fix(fam: dict[str, set[str]]) -> int:
         return 1
     for pdir in stale:
         shutil.rmtree(pdir)
+    for name in sorted(SUBSTRATE_PLUGINS):
+        write_substrate(name, shared)
     for family, skills in sorted(fam.items()):
         name = f"magpie-{family}"
         pdir = PLUGINS / name
@@ -531,6 +667,15 @@ def fix(fam: dict[str, set[str]]) -> int:
             file=sys.stderr,
         )
         return 1
+    for name in sorted(SUBSTRATE_PLUGINS):
+        keep.append(
+            {
+                "name": name,
+                "source": f"./plugins/{name}",
+                "version": shared["version"],
+                "description": SUBSTRATE_PLUGINS[name]["description"],
+            }
+        )
     for family, skills in sorted(fam.items()):
         keep.append(
             {

--- a/tools/dev/tests/test_check_family_plugins.py
+++ b/tools/dev/tests/test_check_family_plugins.py
@@ -1,0 +1,189 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""Tests for the substrate-plugin half of ``check-family-plugins.py``.
+
+A substrate plugin exists to make a framework tool run from the installed plugin
+root, so the failures worth catching are the ones that leave a plugin looking
+correct while the hook it publishes never fires: a hook command that no longer
+matches the wiring, a tool symlink pointing somewhere else, or an engine path
+that does not resolve through it. Each is silent at runtime — a guard that is
+not there does not raise, it just stops denying."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "check-family-plugins.py"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("check_family_plugins", _SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load()
+NAME = "magpie-agent-guard"
+
+SHARED = {
+    "version": "9.9.9",
+    "author": {"name": "Apache Magpie", "url": "https://magpie.apache.org/"},
+    "homepage": "https://magpie.apache.org/",
+    "repository": "https://github.com/apache/magpie",
+    "license": "Apache-2.0",
+}
+
+
+@pytest.fixture
+def tree(tmp_path, monkeypatch):
+    """A minimal repo root holding the real tool tree the substrate plugin links
+    to, with the plugin itself generated the way ``--fix`` generates it."""
+    (tmp_path / "tools" / "agent-guard" / "src" / "agent_guard").mkdir(parents=True)
+    (tmp_path / "tools" / "agent-guard" / "src" / "agent_guard" / "__init__.py").write_text(
+        "# engine\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+    mod.write_substrate(NAME, SHARED)
+    return tmp_path
+
+
+def _manifest(tree: Path) -> Path:
+    return tree / "plugins" / NAME / ".claude-plugin" / "plugin.json"
+
+
+def _rewrite(path: Path, **changes) -> None:
+    data = json.loads(path.read_text(encoding="utf-8"))
+    data.update(changes)
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def test_generated_substrate_plugin_passes_its_own_check(tree):
+    assert mod.check_substrate(NAME, SHARED) == []
+
+
+def test_generated_manifest_wires_the_engine_under_the_plugin_root(tree):
+    manifest = json.loads(_manifest(tree).read_text(encoding="utf-8"))
+    command = manifest["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+    assert "${CLAUDE_PLUGIN_ROOT}" in command
+    assert mod.AGENT_GUARD_ENGINE in command
+    # The path the command names must be reachable through the generated symlink.
+    assert (tree / "plugins" / NAME / mod.AGENT_GUARD_ENGINE).is_file()
+
+
+def test_altered_hook_wiring_is_reported(tree):
+    _rewrite(_manifest(tree), hooks={"PreToolUse": []})
+    assert any("'hooks' does not match" in e for e in mod.check_substrate(NAME, SHARED))
+
+
+def test_a_substrate_plugin_declaring_skills_is_reported(tree):
+    _rewrite(_manifest(tree), skills="./skills")
+    assert any("drop 'skills'" in e for e in mod.check_substrate(NAME, SHARED))
+
+
+def test_metadata_not_inherited_from_the_root_manifest_is_reported(tree):
+    _rewrite(_manifest(tree), version="0.0.1")
+    assert any("'version' is '0.0.1'" in e for e in mod.check_substrate(NAME, SHARED))
+
+
+def test_a_repointed_tool_symlink_is_reported(tree):
+    link = tree / "plugins" / NAME / "tools" / "agent-guard"
+    link.unlink()
+    link.symlink_to("../../../tools/something-else")
+    assert any("expected ../../../tools/agent-guard" in e for e in mod.check_substrate(NAME, SHARED))
+
+
+def test_a_symlink_replaced_by_a_real_directory_is_reported(tree):
+    link = tree / "plugins" / NAME / "tools" / "agent-guard"
+    link.unlink()
+    link.mkdir()
+    assert any("not a symlink" in e for e in mod.check_substrate(NAME, SHARED))
+
+
+def test_an_engine_that_does_not_resolve_is_reported(tree):
+    """The manifest and the symlink can both be right while the file the hook
+    command names has moved — the case where the guard silently never runs."""
+    (tree / "tools" / "agent-guard" / "src" / "agent_guard" / "__init__.py").unlink()
+    assert any("does not resolve" in e for e in mod.check_substrate(NAME, SHARED))
+
+
+def test_substrate_plugins_are_not_flagged_as_orphans(tree):
+    """The orphan rule asks which skill declares family ``<x>`` for every
+    ``plugins/magpie-<x>``; a substrate plugin answers "none" by design, while a
+    genuinely stray dir must still be caught."""
+    mod.MARKETPLACE.parent.mkdir(parents=True, exist_ok=True)
+    mod.MARKETPLACE.write_text(json.dumps({"plugins": []}), encoding="utf-8")
+    (tree / "plugins" / "magpie-bogus").mkdir()
+
+    orphans = [e for e in mod.check({}) if "orphan plugin" in e]
+
+    assert any("magpie-bogus" in e for e in orphans)
+    assert not any(NAME in e for e in orphans)
+
+
+def test_unowned_entries_accepts_the_generated_substrate_layout(tree):
+    assert mod.unowned_entries(mod.PLUGINS / NAME) == []
+
+
+def test_unowned_entries_refuses_to_delete_a_hand_added_file(tree):
+    """``--fix`` rmtree's plugin dirs before regenerating them; anything it did
+    not generate has to stop that rather than be silently discarded."""
+    (tree / "plugins" / NAME / "README.md").write_text("hand-written\n", encoding="utf-8")
+    errors = mod.unowned_entries(mod.PLUGINS / NAME)
+    assert len(errors) == 1
+    assert "README.md" in errors[0]
+
+
+def test_the_real_repository_is_in_sync(monkeypatch):
+    """The checked-in tree matches what ``--fix`` would generate — the same
+    assertion CI makes, so a hand-edit to either manifest fails here first."""
+    monkeypatch.chdir(REPO_ROOT)
+    assert mod.check(mod.families_from_frontmatter()) == []
+
+
+def test_the_marketplace_lists_the_substrate_plugin(monkeypatch):
+    monkeypatch.chdir(REPO_ROOT)
+    entries = json.loads(mod.MARKETPLACE.read_text(encoding="utf-8"))["plugins"]
+    entry = next(e for e in entries if e["name"] == NAME)
+    assert entry["source"] == f"./plugins/{NAME}"
+
+
+def test_the_substrate_plugin_stays_out_of_the_non_claude_catalogs(monkeypatch):
+    """Its tool symlink resolves outside the plugin root, which Agent Plugins 1.0
+    forbids — the same reason the family plugins are Claude Code-only."""
+    monkeypatch.chdir(REPO_ROOT)
+    for path in mod.CLIENT_CATALOGS:
+        names = [e.get("name") for e in json.loads(path.read_text(encoding="utf-8"))["plugins"]]
+        assert NAME not in names, f"{path} advertises {NAME}"
+
+
+def test_fix_regenerates_a_deleted_substrate_plugin(tree, monkeypatch):
+    import shutil
+
+    shutil.rmtree(tree / "plugins" / NAME)
+    mod.write_substrate(NAME, SHARED)
+    assert mod.check_substrate(NAME, SHARED) == []
+    assert os.path.islink(tree / "plugins" / NAME / "tools" / "agent-guard")


### PR DESCRIPTION
## Summary

- The guard was installed by copying the engine into `<repo>/.claude/hooks/` and wiring `$CLAUDE_PROJECT_DIR/.claude/hooks/agent-guard.py` into a gitignored `settings.local.json`. Both are per-worktree and neither travels through git, so **three** separate mechanisms existed to seed every worktree — the post-checkout hook, the install Step 12 sync pass, and `worktree-init` Step 1d.
- When that seeding misses, the failure is worse than an inactive guard. The wiring still applies in the worktree (Claude Code resolves `$CLAUDE_PROJECT_DIR` against it while loading the main checkout's settings), so the hook names a script that is not there and **every `Bash` call in that worktree fails**. This was found the hard way: a fresh agent worktree of an adopter repo where no shell command could run at all.
- The new `magpie-agent-guard` plugin registers the `PreToolUse` hook in its own manifest and resolves the engine under `${CLAUDE_PLUGIN_ROOT}`. Nothing is repository-local, so a worktree is an ordinary checkout and all three seeding mechanisms are deleted.

### Why a separate plugin

Claude Code merges hooks from *every* enabled plugin. Putting the guard on the all-in-one `magpie` plugin or on each family plugin would run it once per enabled plugin on every `Bash` call — three enabled families means three Python startups per command. One dedicated owner runs it exactly once, whatever else is installed. It also keeps installing the guard an explicit opt-in, which matches the semantics it already had as an adopter-side file.

The family plugins are generated skill-only subsets with no `tools/`, so this is introduced as a *substrate* plugin: hand-declared rather than derived from `family:` frontmatter, shipping a tool instead of skills, reaching `tools/agent-guard` through a narrow symlink. `check-family-plugins.py` learns to generate and validate that shape.

### Snapshot adopters get the same property

The `settings.local.json` wiring now resolves the engine inside the snapshot, and `worktree-init` Step 1 already symlinks `.apache-magpie/` into every worktree — so the path resolves there with nothing seeded. Adopters whose entry still names the retired per-repository copy are rewritten by `upgrade`, since that stale entry is the one that breaks every `Bash` call.

### Skill-owned guards are discovered in place

`guard_dirs()` resolves the framework tree the engine is running from and scans every `skills/*/guards` in it, so a skill's guards are live wherever the framework is. The step that collected them into a local `guards.d/` is gone. Discovery stays **lazy** — `discover_guards()` is still only called once a `gh`/`git` segment is seen, so the fast path for every other command is unchanged.

## Type of change

- [x] Tool / bridge contract (`tools/<system>/*.md`)
- [x] Python package (`tools/*/` with `pyproject.toml`)
- [x] Cross-cutting (RFC, AGENTS.md, sandbox, privacy-LLM)
- [x] Documentation (`docs/`, `README.md`, `CONTRIBUTING.md`)
- [x] CI / dev loop (`prek`, workflows, validators)

## Test plan

- [x] `prek run --all-files` passes (including `check-family-plugins`, `check-doc-sync`, `symlink-lint`, `skill-and-tool-validate`, `lychee`, the workspace `pytest`/`ruff`/`mypy`)
- [x] For Python packages touched: `uv run --project tools/agent-guard pytest tools/agent-guard/tests` and `uv run --project tools/dev pytest tools/dev/tests` pass
- [x] Other: exercised end-to-end **through the published plugin path** (`plugins/magpie-agent-guard/tools/agent-guard/src/agent_guard/__init__.py`) with real `PreToolUse` payloads — a bundled guard denies (`commit-trailer`), a skill-owned guard denies (`mention`, discovered with no `MAGPIE_GUARD_DIRS` set), and an unguarded command takes the fast path.

New tests:

- `tools/agent-guard/tests/test_discovery.py` — `framework_root()` from a checkout, `None` for a standalone single-file copy, skill guard dirs discovered with no configuration, env dirs searched first, dedup, a skill-owned guard denying with nothing pointing at it, and discovery surviving a **symlinked plugin root** (how the published plugin actually resolves).
- `tools/dev/tests/test_check_family_plugins.py` — the substrate rules: altered hook wiring, a `skills` key that should not be there, metadata not inherited from the root manifest, a repointed or de-symlinked tool link, an engine path that does not resolve, the orphan-rule exemption (while a genuinely stray `plugins/magpie-*` is still caught), and `unowned_entries` refusing to `rmtree` a hand-added file.

The engine-path-resolves check is the one worth keeping: a manifest and a symlink can both look right while the file the hook command names has moved, and that is the case where the guard silently never runs.

## RFC-AI-0004 compliance

- [x] **Sandbox** — no new host access; the plugin's symlink exposes only `tools/agent-guard`, not the whole `tools/` tree
- [x] **Vendor neutrality** — no new project-specific literals; `check-placeholders` passes
- [x] **Conversational + correctable** — `$MAGPIE_GUARD_DIRS` remains the escape hatch for guards kept outside the framework tree

## Linked issues

<!-- none -->

## Notes for reviewers (optional)

Two decisions worth a second opinion:

1. **Substrate plugin vs. hook on the all-in-one.** Rejected wiring the hook into each family plugin (N× execution per `Bash` call) and rejected an in-engine dedupe for it: the only key derivable from a `PreToolUse` payload is `(session, cwd, command)`, so two identical commands in quick succession would let the second skip the guard — a real hole in a security control, in exchange for saving a plugin.
2. **`framework_root()` walks parents looking for `skills/` + `tools/agent-guard/`** rather than counting `parents[N]`. Counting breaks the moment the engine is reached through the plugin's symlink or lives in a snapshot at a different depth; the pair-of-directories test holds for a plugin, a checkout, and a snapshot alike, and correctly returns `None` for a standalone copy so it falls back to its own `guards.d`.

The user-scope secure setup (`~/.claude/scripts/agent-guard.py`) is untouched — it is already repository- and worktree-independent, and a standalone copy legitimately still needs its `guards.d` sibling.

---

Generated-by: Claude Code (Opus 5) following [the guidelines](https://github.com/apache/magpie/blob/main/CONTRIBUTING.md)

https://claude.ai/code/session_01GLcpHRb14rFsAnBR6NVBvf
