### PR TITLE
fix(prek): drop the .git suffix from the doctoc repo URL

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
         name: Print input to the static check hooks for troubleshooting
       - id: check-hooks-apply
         name: Check if all hooks apply to the repository
-  - repo: https://github.com/thlorenz/doctoc.git
+  - repo: https://github.com/thlorenz/doctoc
     rev: v2.5.0
     hooks:
       - id: doctoc


### PR DESCRIPTION
## Summary

zizmor `0.6.3` — arriving via dependabot #1167 — audits
`.pre-commit-config.yaml` for the first time, and its `ref-confusion` audit
hard-fails on ours:

```
fatal: no audit was performed
'ref-confusion' audit failed on file://./.pre-commit-config.yaml
    0: error in 'ref-confusion' audit
```

That is an audit **crash**, not a finding — so the whole zizmor job exits 1 with
nothing reported, and #1167 cannot go green.

## Cause

`ref-confusion` resolves each pre-commit repo against the GitHub API to decide
whether its `rev:` is ambiguous between a tag and a branch. Our doctoc entry
declared a `.git` suffix, and it is carried into the lookup:

```
GET /repos/thlorenz/doctoc       200
GET /repos/thlorenz/doctoc.git   404
```

The 404 aborts the audit. doctoc was the only one of the four remote hooks
carrying `.git` — `pre-commit-hooks`, `markdownlint-cli2` and `typos` already
omit it — so this is a consistency fix as much as a repair.

## Why this lands on `main`, not on the dependabot branch

Pushing to `dependabot/github_actions/…` would be overwritten on its next push.
With this on `main`, #1167 goes green on rebase.

`main` is not currently broken: the pinned v0.6.2 does not audit pre-commit
configs, which is why zizmor passes in 9s on every other open PR. But the action
requests `version: latest`, so a future image reaches `main` regardless of
whether the action bump merges — this is worth fixing on its own account, not
only to unblock #1167.

## Verification

- [x] Mechanism confirmed against the GitHub API directly (200 vs 404 above)
- [x] `prek run doctoc --all-files` passes — the hook re-clones under the new
      URL and its environment rebuilds
- [x] `prek run --all-files` passes (exit 0)

Not reproducible locally: `ref-confusion` is an online-only audit and zizmor
falls back to offline mode without a token, where the config passes cleanly. I
did not hand a credential to a subprocess to force the online path; the API
check establishes the mechanism without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01So3JRGXrbqSGrohtZuHWKg
