### PR TITLE
feat(vetted-ops): extend the catalogue to the issue family

### DIFF
--- a/tools/spec-loop/specs/vetted-command-surface.md
+++ b/tools/spec-loop/specs/vetted-command-surface.md
@@ -80,9 +80,17 @@ per [`docs/adapters/registry.md`](../../../docs/adapters/registry.md).
    operations covering list / view / diff / reviews, the label, milestone,
    assignee and reviewer edits, the three review verdicts, draft/ready, close,
    branch update, CI re-run and workflow approval, plus two allowlisted GraphQL
-   queries (`pr-liveness`, `pr-review-threads`). Repo health and release
-   management remain; each needs its own operations and its own caller
-   manifests, and none needs a second dispatcher.
+   queries (`pr-liveness`, `pr-review-threads`). *The issue family has landed* —
+   ten `repo-issue-*` operations against the **upstream** repository, kept
+   distinct from the `issue-*` operations that address the private tracker, with
+   a test asserting the two never cross. Repo health, release management,
+   mentoring and contributor growth remain; each needs its own operations and
+   its own caller manifests, and none needs a second dispatcher.
+
+   Two shapes are refused rather than wrapped, and will stay refused: free-text
+   search (`gh search issues`) has no fixed shape, and creation (`gh issue
+   create` / `gh pr create`) would need a free-text title, since `gh` offers
+   `--body-file` but no `--title-file`. Both keep their `ask` rule.
 
    Note what the PR family deliberately does *not* include: there is no
    `pr-merge`. Merging is this framework's deferred Agentic Autonomous mode —

--- a/tools/vetted-ops/README.md
+++ b/tools/vetted-ops/README.md
@@ -128,7 +128,7 @@ upstream = "acme/product"
 
 [values]
 labels        = ["needs triage", "cve allocated", "pr merged"]
-pr_labels     = ["ready for maintainer review", "area:scheduler"]
+upstream_labels = ["ready for maintainer review", "area:scheduler"]  # issues *and* PRs
 milestones    = ["1.2.3", "1.3.0"]
 assignees     = ["alice", "bob"]
 issue_states  = ["open", "closed", "all"]
@@ -154,6 +154,12 @@ board_status_field_id = "PVTSSF_…"    # its Status field id
                                "gql-pr-review-threads", "pr-review-approve",
                                "pr-review-request-changes", "pr-review-comment"]
 "pr-management-stats"   = ["pr-list", "pr-view", "gql-pr-review-threads"]
+"issue-triage"          = ["repo-issue-view", "repo-issue-comments", "repo-issue-list",
+                           "repo-issue-add-label", "repo-issue-remove-label",
+                           "repo-issue-comment"]
+"issue-stale-sweep"     = ["repo-issue-list", "repo-issue-view", "repo-issue-comment",
+                           "repo-issue-close", "repo-issue-reopen"]
+"issue-backlog-stats"   = ["repo-issue-list"]
 ```
 
 Grant the narrowest set that lets a skill finish its job: `pr-management-stats`

--- a/tools/vetted-ops/src/vetted_ops/ops.py
+++ b/tools/vetted-ops/src/vetted_ops/ops.py
@@ -671,7 +671,7 @@ _register(
         params=("number", "label"),
         writes=True,
         summary="Add a configured label to an upstream PR.",
-        enums={"label": "pr_labels"},
+        enums={"label": "upstream_labels"},
         build=lambda cfg, number, label: [
             "gh",
             "pr",
@@ -691,7 +691,7 @@ _register(
         params=("number", "label"),
         writes=True,
         summary="Remove a configured label from an upstream PR.",
-        enums={"label": "pr_labels"},
+        enums={"label": "upstream_labels"},
         build=lambda cfg, number, label: [
             "gh",
             "pr",
@@ -913,6 +913,218 @@ _register(
             "-X",
             "POST",
             f"repos/{_upstream(cfg)}/actions/runs/{run_id}/approve",
+        ],
+    )
+)
+
+
+# ---- upstream-issue family -------------------------------------------------
+#
+# The `issue-*` operations above address the *tracker* — the private repository
+# the security lifecycle runs in. The issue family works on the project's own
+# public issues, which is a different repository and therefore a different set
+# of operations: `repo-` here means upstream, matching `repo-file`.
+#
+# Two shapes the family uses are deliberately absent:
+#
+#   * `gh search issues` — the search query is free text with no fixed shape, so
+#     wrapping it would re-introduce the unbounded surface the catalogue exists
+#     to remove.
+#   * `gh issue create` / `gh pr create` — `gh` has `--body-file` but no
+#     `--title-file`, so a title could only arrive as a free-text parameter.
+#     Creation is also a genuinely novel action, which the spec's non-goals
+#     already say keeps its confirmation.
+#
+# Both keep their `ask` rule. The catalogue covers the sweep, not everything.
+
+_register(
+    Op(
+        name="repo-issue-view",
+        params=("number",),
+        summary="Read one upstream issue as JSON.",
+        build=lambda cfg, number: [
+            "gh",
+            "issue",
+            "view",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--json",
+            "number,title,state,body,labels,milestone,assignees,author,url,"
+            "createdAt,updatedAt,closedAt,comments",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-list",
+        params=("state",),
+        summary="List upstream issues in a given state.",
+        enums={"state": "issue_states"},
+        build=lambda cfg, state: [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            _upstream(cfg),
+            "--state",
+            state,
+            "--limit",
+            "1000",
+            "--json",
+            "number,title,state,labels,milestone,assignees,author,createdAt,updatedAt,closedAt",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-comments",
+        params=("number",),
+        summary="Read every comment on one upstream issue.",
+        build=lambda cfg, number: [
+            "gh",
+            "api",
+            f"repos/{_upstream(cfg)}/issues/{number}/comments",
+            "--paginate",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-comment",
+        params=("number", "body"),
+        writes=True,
+        summary="Post a comment on an upstream issue from a body file.",
+        body_files=("body",),
+        build=lambda cfg, number, body: [
+            "gh",
+            "issue",
+            "comment",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--body-file",
+            body,
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-add-label",
+        params=("number", "label"),
+        writes=True,
+        summary="Add a configured label to an upstream issue.",
+        enums={"label": "upstream_labels"},
+        build=lambda cfg, number, label: [
+            "gh",
+            "issue",
+            "edit",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--add-label",
+            label,
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-remove-label",
+        params=("number", "label"),
+        writes=True,
+        summary="Remove a configured label from an upstream issue.",
+        enums={"label": "upstream_labels"},
+        build=lambda cfg, number, label: [
+            "gh",
+            "issue",
+            "edit",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--remove-label",
+            label,
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-set-milestone",
+        params=("number", "milestone"),
+        writes=True,
+        summary="Set a configured milestone on an upstream issue.",
+        enums={"milestone": "milestones"},
+        build=lambda cfg, number, milestone: [
+            "gh",
+            "issue",
+            "edit",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--milestone",
+            milestone,
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-add-assignee",
+        params=("number", "login"),
+        writes=True,
+        summary="Assign a configured user to an upstream issue.",
+        enums={"login": "assignees"},
+        build=lambda cfg, number, login: [
+            "gh",
+            "issue",
+            "edit",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--add-assignee",
+            login,
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-close",
+        params=("number", "reason"),
+        writes=True,
+        summary="Close an upstream issue with a configured reason.",
+        enums={"reason": "close_reasons"},
+        build=lambda cfg, number, reason: [
+            "gh",
+            "issue",
+            "close",
+            number,
+            "--repo",
+            _upstream(cfg),
+            "--reason",
+            reason,
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-issue-reopen",
+        params=("number",),
+        writes=True,
+        summary="Reopen an upstream issue (the stale-sweep reversal).",
+        build=lambda cfg, number: [
+            "gh",
+            "issue",
+            "reopen",
+            number,
+            "--repo",
+            _upstream(cfg),
         ],
     )
 )

--- a/tools/vetted-ops/tests/test_vetted_ops.py
+++ b/tools/vetted-ops/tests/test_vetted_ops.py
@@ -36,7 +36,7 @@ milestones = ["1.2.3"]
 assignees = ["alice"]
 issue_states = ["open", "closed", "all"]
 pr_states = ["open", "closed", "merged", "all"]
-pr_labels = ["ready for maintainer review", "area:scheduler"]
+upstream_labels = ["ready for maintainer review", "area:scheduler"]
 close_reasons = ["completed", "not planned"]
 board_project_id = "PVT_proj"
 board_status_field_id = "PVTSSF_field"
@@ -320,3 +320,52 @@ def test_every_shipped_query_carries_the_asf_licence_header() -> None:
         text = query.read_text(encoding="utf-8")
         assert "Licensed to the Apache Software Foundation" in text, query.name
         assert "http://www.apache.org/licenses/LICENSE-2.0" in text, query.name
+
+
+# --- tracker and upstream are different repositories -------------------------
+
+
+def test_tracker_and_upstream_operations_never_cross(policy: config.Config) -> None:
+    """
+    `issue-*` addresses the private tracker; `repo-issue-*` addresses the public
+    project. Confusing the two would post security-lifecycle content to a public
+    issue, or hunt for a public issue in the tracker — so assert the split holds
+    for every operation rather than trusting the naming.
+    """
+    sample = {
+        "number": "1",
+        "comment_id": "1",
+        "run_id": "42",
+        "ref": "main",
+        "base": "main",
+        "head": "v1",
+        "prefix": "v1",
+        "path": "a/b.py",
+        "login": "alice",
+        "ghsa": "GHSA-aaaa-bbbb-cccc",
+        "item_id": "PVTI_abc",
+        "label": "needs triage",
+        "milestone": "1.2.3",
+        "state": "open",
+        "reason": "completed",
+        "column": "Assessed",
+        "body": "unused",
+    }
+    body = policy.workspace / "split.md"
+    body.write_text("x")
+    tracker, upstream = "acme/tracker", "acme/product"
+
+    for name, op in ops.OPS.items():
+        params = {}
+        for p in op.params:
+            if p in op.body_files:
+                params[p] = str(body)
+            elif p in op.enums:
+                params[p] = policy.enum_values(op.enums[p])[0]
+            else:
+                params[p] = sample[p]
+        argv = " ".join(op.build(policy.as_mapping(), **params))
+        if name.startswith("repo-issue-") or name.startswith("pr-") or name.startswith("gql-"):
+            assert tracker not in argv, f"{name} reached the tracker"
+        elif name.startswith("issue-") or name in {"label-list", "milestone-list", "collaborators"}:
+            assert upstream not in argv, f"{name} reached the upstream repo"


### PR DESCRIPTION
Second family in the series, after #1177.

The existing `issue-*` operations address the *tracker* — the private repository the security lifecycle runs in. The issue family works on the project's own public issues, which is a different repository and so needs a different set of operations. `repo-` marks upstream here, matching the existing `repo-file`. Ten operations: view, list, comments, comment, add/remove label, set milestone, add assignee, close, reopen.

Confusing the two repositories is the failure that would actually hurt — security-lifecycle content posted to a public issue — so a test walks the whole catalogue and asserts that no `repo-issue-*` / `pr-*` / `gql-*` operation ever names the tracker, and no tracker operation ever names upstream.

`pr_labels` becomes `upstream_labels`. GitHub labels are repo-scoped and shared between issues and PRs, so two keys for one label set would have been wrong the moment the issue family arrived; correcting it while the series is still in flight is cheaper than living with it. This is the one change here that touches #1177's surface.

**Two shapes are refused rather than wrapped.** `gh search issues` takes a free-text query with no fixed shape, and wrapping it would re-introduce exactly the unbounded surface the catalogue exists to remove. `gh issue create` / `gh pr create` would need a free-text title, since `gh` has `--body-file` but no `--title-file` — and creation is a genuinely novel action, which the spec's non-goals already say keeps its confirmation. Both keep their `ask` rule, and the code says so where a reader will look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qpVgY8ADkD9c7vYZk5imP