### PR TITLE
feat(vetted-ops): cover the remaining forge-touching families, and stop refs traversing

### DIFF
--- a/tools/spec-loop/specs/vetted-command-surface.md
+++ b/tools/spec-loop/specs/vetted-command-surface.md
@@ -87,10 +87,23 @@ per [`docs/adapters/registry.md`](../../../docs/adapters/registry.md).
    mentoring and contributor growth remain; each needs its own operations and
    its own caller manifests, and none needs a second dispatcher.
 
-   Two shapes are refused rather than wrapped, and will stay refused: free-text
-   search (`gh search issues`) has no fixed shape, and creation (`gh issue
-   create` / `gh pr create`) would need a free-text title, since `gh` offers
-   `--body-file` but no `--title-file`. Both keep their `ask` rule.
+   *Repo health, release management, contributor growth and mentoring have
+   landed*, completing the pass over the families that touch the forge. They
+   needed seven operations between them — `repo-view`, `repo-tree`, `run-list`,
+   `run-view`, `release-list`, `release-view`, `user-profile` — because they are
+   overwhelmingly read surfaces; mentoring needed none at all, working entirely
+   through the issue and PR operations. A family earns new operations only when
+   it has a shape the catalogue lacks.
+
+   Several shapes are refused rather than wrapped, and will stay refused:
+   free-text search (`gh search issues` / `prs`, and GraphQL's `search(...)`)
+   has no fixed shape; creation (`gh issue create` / `gh pr create`) would need
+   a free-text title, since `gh` offers `--body-file` but no `--title-file`;
+   release publication and deletion is vote-gated and irreversible; and
+   `gh run download` writes to local disk rather than to the forge, which is a
+   different risk class entirely. All keep their `ask` rule. The catalogue
+   covers the sweep, not everything — and **widening it must never widen the
+   posture**, which is why `pr-merge` and `release-delete` are both absent.
 
    Note what the PR family deliberately does *not* include: there is no
    `pr-merge`. Merging is this framework's deferred Agentic Autonomous mode —

--- a/tools/vetted-ops/README.md
+++ b/tools/vetted-ops/README.md
@@ -75,7 +75,9 @@ Being precise, because a security tool that overstates itself is worse than none
 - **A parameter can never become a flag.** Any parameter starting with `-` is
   refused before validation, which closes flag-injection into `gh`.
 - **The repo is not addressable.** No operation takes a repository parameter; it
-  is read from policy. An operation cannot be pointed at another repository.
+  is read from policy. An operation cannot be pointed at another repository, and
+  parameters that reach an API *path* — repo paths and git refs — refuse `..`,
+  so none of them can walk out of the pinned repository either.
 - **Body content is free; body *location* is not.** Comment bodies are passed by
   file reference, so the text may contain anything — backticks, `$(…)`,
   newlines. What is constrained is which file may be read: it must resolve inside
@@ -160,7 +162,16 @@ board_status_field_id = "PVTSSF_…"    # its Status field id
 "issue-stale-sweep"     = ["repo-issue-list", "repo-issue-view", "repo-issue-comment",
                            "repo-issue-close", "repo-issue-reopen"]
 "issue-backlog-stats"   = ["repo-issue-list"]
+"license-compliance-audit" = ["repo-view", "repo-tree", "repo-file"]
+"flaky-test-triage"     = ["run-list", "run-view", "pr-view"]
+"release-verify-rc"     = ["release-list", "release-view", "tags", "repo-file"]
+"contributor-nomination" = ["user-profile", "pr-list", "repo-issue-list"]
+"mentoring-welcome"     = ["repo-issue-view", "repo-issue-comment", "pr-view"]
 ```
+
+`mentoring-welcome` needs no operation of its own: it works on upstream issues
+and PRs, which the issue and PR families already cover. A family earns new
+operations only when it has a shape the catalogue lacks.
 
 Grant the narrowest set that lets a skill finish its job: `pr-management-stats`
 is a read-only dashboard, so it gets no write operation at all, and a

--- a/tools/vetted-ops/src/vetted_ops/ops.py
+++ b/tools/vetted-ops/src/vetted_ops/ops.py
@@ -85,6 +85,13 @@ def number(value: str) -> str:
 
 
 def ref(value: str) -> str:
+    # Refs are interpolated into API paths (`compare`, `repo-file`, `tags`,
+    # `repo-tree`), so a ref containing `..` could walk out of the
+    # policy-pinned repository once a client normalises the URL — defeating
+    # "the repo is not addressable". Git itself forbids `..` in ref names, so
+    # refusing it here costs nothing legitimate.
+    if ".." in value:
+        raise ParamError(f"path traversal in git ref: {value!r}")
     return _check(_REF, value, "git ref")
 
 
@@ -1126,6 +1133,147 @@ _register(
             "--repo",
             _upstream(cfg),
         ],
+    )
+)
+
+
+# ---- repo health, releases, and people -------------------------------------
+#
+# The remaining families are overwhelmingly *read* surfaces: a licence audit
+# walks the tree, a release check reads what is published, a contributor
+# assessment reads a public profile. They need few operations, and mentoring
+# needs none at all — it works on upstream issues and PRs, which the two
+# families above already cover.
+#
+# What is deliberately absent here is larger than what is present:
+#
+#   * `gh release create` / `upload` / `edit` / `delete` — publishing and
+#     deleting releases. Releases are vote-gated and maintainer-driven in this
+#     framework; a vetted delete would hand the agent an irreversible action the
+#     surrounding process deliberately keeps in human hands. Same reasoning as
+#     the absent `pr-merge`.
+#   * `gh search issues` / `prs`, and the GraphQL `search(...)` connection that
+#     contributor-growth leans on — the query is free text with no fixed shape.
+#   * `gh run download` — writes artifacts to local disk rather than to the
+#     forge. That is a different risk class (filesystem paths, archive
+#     extraction) and does not belong behind a forge dispatcher.
+#   * `gh repo clone` / `fork` / `create` — novel actions, which the spec's
+#     non-goals already say keep their confirmation.
+
+_register(
+    Op(
+        name="repo-view",
+        params=(),
+        summary="Read upstream repository metadata.",
+        build=lambda cfg: [
+            "gh",
+            "repo",
+            "view",
+            _upstream(cfg),
+            "--json",
+            "name,owner,description,defaultBranchRef,licenseInfo,isArchived,"
+            "visibility,pushedAt,repositoryTopics",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="repo-tree",
+        params=("ref",),
+        summary="List every upstream path at a ref (the licence/compliance walk).",
+        build=lambda cfg, ref: [
+            "gh",
+            "api",
+            f"repos/{_upstream(cfg)}/git/trees/{ref}",
+            "-F",
+            "recursive=1",
+            "--jq",
+            ".tree[].path",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="run-list",
+        params=(),
+        summary="List recent upstream workflow runs.",
+        build=lambda cfg: [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            _upstream(cfg),
+            "--limit",
+            "100",
+            "--json",
+            "databaseId,workflowName,headBranch,event,status,conclusion,createdAt",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="run-view",
+        params=("run_id",),
+        summary="Read one upstream workflow run, with its jobs.",
+        build=lambda cfg, run_id: [
+            "gh",
+            "run",
+            "view",
+            run_id,
+            "--repo",
+            _upstream(cfg),
+            "--json",
+            "databaseId,workflowName,headSha,status,conclusion,createdAt,jobs",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="release-list",
+        params=(),
+        summary="List upstream releases.",
+        build=lambda cfg: [
+            "gh",
+            "release",
+            "list",
+            "--repo",
+            _upstream(cfg),
+            "--limit",
+            "100",
+            "--json",
+            "tagName,name,isDraft,isPrerelease,publishedAt",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="release-view",
+        params=("ref",),
+        summary="Read one upstream release by tag.",
+        build=lambda cfg, ref: [
+            "gh",
+            "release",
+            "view",
+            ref,
+            "--repo",
+            _upstream(cfg),
+            "--json",
+            "tagName,name,body,isDraft,isPrerelease,publishedAt,assets",
+        ],
+    )
+)
+
+_register(
+    Op(
+        name="user-profile",
+        params=("login",),
+        summary="Read one public GitHub profile (contributor assessment).",
+        build=lambda cfg, login: ["gh", "api", f"users/{login}"],
     )
 )
 

--- a/tools/vetted-ops/tests/test_vetted_ops.py
+++ b/tools/vetted-ops/tests/test_vetted_ops.py
@@ -369,3 +369,61 @@ def test_tracker_and_upstream_operations_never_cross(policy: config.Config) -> N
             assert tracker not in argv, f"{name} reached the tracker"
         elif name.startswith("issue-") or name in {"label-list", "milestone-list", "collaborators"}:
             assert upstream not in argv, f"{name} reached the upstream repo"
+
+
+# --- a ref may not walk out of the policy-pinned repository -------------------
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "main/../../../users/attacker",
+        "../other/repo",
+        "v1.0/..",
+        "a/../b",
+    ],
+)
+def test_refs_may_not_traverse(hostile: str) -> None:
+    """
+    Refs are interpolated into API paths, so `..` in a ref could walk out of the
+    repository the policy pinned once a client normalises the URL — defeating
+    "the repo is not addressable". Git forbids `..` in ref names anyway.
+    """
+    with pytest.raises(ops.ParamError):
+        ops.ref(hostile)
+
+
+@pytest.mark.parametrize("legitimate", ["main", "v1.2.3", "release/0.2.0", "rc-1"])
+def test_ordinary_refs_still_pass(legitimate: str) -> None:
+    assert ops.ref(legitimate) == legitimate
+
+
+def test_no_operation_interpolates_a_traversing_ref(policy: config.Config) -> None:
+    """Belt and braces: no built argv may contain a `..` path segment."""
+    sample = {
+        "number": "1",
+        "comment_id": "1",
+        "run_id": "42",
+        "ref": "main",
+        "base": "main",
+        "head": "v1",
+        "prefix": "v1",
+        "path": "a/b.py",
+        "login": "alice",
+        "ghsa": "GHSA-aaaa-bbbb-cccc",
+        "item_id": "PVTI_abc",
+        "body": "unused",
+    }
+    body = policy.workspace / "ref.md"
+    body.write_text("x")
+    for op in ops.OPS.values():
+        params = {}
+        for p in op.params:
+            if p in op.body_files:
+                params[p] = str(body)
+            elif p in op.enums:
+                params[p] = policy.enum_values(op.enums[p])[0]
+            else:
+                params[p] = sample[p]
+        for arg in op.build(policy.as_mapping(), **params):
+            assert "/../" not in arg and not arg.endswith("/.."), op.name


### PR DESCRIPTION
Completes the pass over the families that touch the forge, after #1177 and #1178: repo health, release management, contributor growth and mentoring.

They needed seven operations between them — `repo-view`, `repo-tree`, `run-list`, `run-view`, `release-list`, `release-view`, `user-profile` — because they are overwhelmingly read surfaces. Mentoring needed none at all: it works on upstream issues and PRs, which the two merged families already cover. A family earns new operations only when it has a shape the catalogue lacks.

**What is absent here is larger than what is present, deliberately.** `gh release create/upload/edit/delete` stays out: releases are vote-gated and maintainer-driven, and a vetted delete would hand the agent an irreversible action the surrounding process keeps in human hands — the same reasoning that keeps `pr-merge` out. Free-text search (`gh search issues` / `prs`, and GraphQL's `search(...)`) stays out because the query has no fixed shape. `gh run download` stays out because it writes to local disk rather than to the forge, which is a different risk class. Each refusal is stated in the code where a reader will look for it.

### A real gap, found while adding `repo-tree`

`ref()` accepted `..`, unlike `repo_path()` — and refs are interpolated into API paths by `compare`, `repo-file` and `tags`. A ref of `main/../../../users/attacker` produced:

```
repos/<owner>/<repo>/compare/main/../../../users/attacker...v1
```

which a client normalising the URL walks straight out of the policy-pinned repository. That defeats *"the repo is not addressable"*, one of the tool's headline guarantees.

Git forbids `..` in ref names, so refusing it costs nothing legitimate. Three tests cover it, including a sweep asserting that no built argv contains a `..` segment for any operation in the catalogue.

---

Catalogue across the series: **19 → 58 operations**. 40 tests pass; full prek green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015qpVgY8ADkD9c7vYZk5imP