### PR TITLE
fix(setup): allow static.rust-lang.org; correct the rust-toolchain paths in the doc

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -47,7 +47,8 @@
         "cveawg.mitre.org",
         "oauth2.googleapis.com",
         "gmail.googleapis.com",
-        "*.crates.io"
+        "*.crates.io",
+        "static.rust-lang.org"
       ],
       "enableWeakerNetworkIsolation": true
     },

--- a/docs/setup/secure-agent-setup.md
+++ b/docs/setup/secure-agent-setup.md
@@ -437,7 +437,7 @@ below, annotated.
     // cargo/brew lychee links): online link checks fail every external
     // URL with `OSStatus -26276` even though the certs are valid and
     // `enableWeakerNetworkIsolation` is set. Building lychee still
-    // needs the rust toolchain (see the `~/.rustup`/`~/.cargo` +
+    // needs the rust toolchain (see the `~/.cache/` +
     // `*.crates.io`/`static.rust-lang.org` entries below); only its
     // *runtime* network use is eliminated.
     "filesystem": {
@@ -447,25 +447,22 @@ below, annotated.
         "~/.gitconfig",               // git's user.name / user.email
         "~/.config/git/",             // git's per-host config
         "~/.config/gh/",              // gh CLI auth (token in hosts.yml)
-        "~/.cache/",                  // dev tool caches (uv HTTP cache, prek logs, ruff/mypy caches)
+        "~/.cache/",                  // dev tool caches (uv HTTP cache, prek logs, ruff/mypy caches, and prek's own rustup + CARGO_HOME for the `lychee` rust hook)
         "~/.local/share/uv/",         // uv's tool venvs (prek, etc.)
-        "~/.rustup/",                 // rustup toolchains (the `lychee` rust hook builds against them)
-        "~/.cargo/",                  // cargo registry + the lychee binary the rust hook installs
         "~/.local/bin/",              // uv-installed tool entry points
         "~/.config/apache-magpie/",  // Gmail OAuth refresh token (oauth-draft tool)
         "~/.gnupg/",                  // gpg keys (commit signing)
         "/run/user/*/gnupg/"          // gpg-agent socket dir (ssh-via-gpg-agent commit signing)
       ],
       "allowWrite": [
-        "~/.cache/",                  // uv lock files, prek log + state, ruff/mypy caches
-        "~/.local/share/uv/",         // uv's tool venvs (prek installs new hook envs here)
-        "~/.rustup/",                 // rustup writes settings.toml + downloaded toolchains (first run of the `lychee` rust hook)
-        "~/.cargo/"                   // cargo registry cache + the compiled lychee binary
+        "~/.cache/",                  // uv lock files, prek log + state, ruff/mypy caches, prek's rustup toolchains + cargo registry
+        "~/.local/share/uv/"          // uv's tool venvs (prek installs new hook envs here)
       ]
     },
     "network": {
       "allowedDomains": [          // every host the framework legitimately reaches
-        "github.com", "api.github.com", "raw.githubusercontent.com",
+        "github.com", "api.github.com", "api.bitbucket.org",
+        "raw.githubusercontent.com",
         "objects.githubusercontent.com", "codeload.github.com", "uploads.github.com",
         "pypi.org", "files.pythonhosted.org",
         "lists.apache.org", "dist.apache.org", "downloads.apache.org", "archive.apache.org",
@@ -473,8 +470,13 @@ below, annotated.
         "oauth2.googleapis.com", "gmail.googleapis.com",
         // `*.crates.io` + `static.rust-lang.org` let the `lychee` rust
         // hook bootstrap a rustup toolchain and `cargo install` lychee
-        // on first run (rustup downloads the toolchain from
-        // static.rust-lang.org; crate deps come from crates.io). These
+        // on first run: prek downloads `rustup-init` from
+        // static.rust-lang.org (see `crates/prek/src/languages/rust/rustup.rs`),
+        // installs it plus the `stable` toolchain under
+        // `~/.cache/prek/tools/rustup/`, and points CARGO_HOME at
+        // `~/.cache/prek/cache/cargo/` — so the existing `~/.cache/`
+        // entries cover it and the user's own `~/.rustup` / `~/.cargo`
+        // are never read or written. Crate deps come from crates.io. These
         // are the ONLY hosts lychee needs: it runs offline (see
         // `.lychee.toml`), so it never fetches the external URLs the
         // docs link to — the wildcard link-target hosts that used to

--- a/tools/sandbox-lint/expected.json
+++ b/tools/sandbox-lint/expected.json
@@ -47,7 +47,8 @@
         "cveawg.mitre.org",
         "oauth2.googleapis.com",
         "gmail.googleapis.com",
-        "*.crates.io"
+        "*.crates.io",
+        "static.rust-lang.org"
       ],
       "enableWeakerNetworkIsolation": true
     },


### PR DESCRIPTION
Two related defects in how the framework's own sandbox config describes and permits the `lychee` rust hook. Both originate in #501, which rewrote the annotated block in `docs/setup/secure-agent-setup.md` but applied only the domain *removals* to `.claude/settings.json` and `tools/sandbox-lint/expected.json`.

### 1. `static.rust-lang.org` is required but was never allowed

The `lychee` hook is `language: rust` with `additional_dependencies: ["cli:lychee"]`, so prek bootstraps its own toolchain on first run. It downloads `rustup-init` from `static.rust-lang.org`:

```rust
// crates/prek/src/languages/rust/rustup.rs:115
let url = format!("https://static.rust-lang.org/rustup/dist/{triple}/{filename}");
```

That host was not in `allowedDomains`, so a contributor with a cold prek cache cannot build the hook env in-sandbox. `*.crates.io` was allowed, which is why this looked fine — crate deps resolve, but the toolchain that consumes them can never be fetched.

### 2. The doc over-stated the framework's home-directory reach

The annotated block claimed the framework needs `~/.rustup/` and `~/.cargo/` in both `allowRead` and `allowWrite`. It does not. prek redirects everything into its own cache:

```
~/.cache/prek/tools/rustup/rustup       # prek's own rustup + toolchains
~/.cache/prek/cache/cargo/registry/     # CARGO_HOME
~/.cache/prek/hooks/rust-*/bin/lychee   # the built binary
```

All under the `~/.cache/` entries that were already present. The user's own `~/.rustup` / `~/.cargo` are never read or written — verified on a machine where both exist and neither contains a lychee binary.

Since those four lines were never in the real `.claude/settings.json`, the doc has been describing a config that does not exist, and claiming more home-directory access than the framework actually takes.

### Also

The doc's `allowedDomains` list omitted `api.bitbucket.org`, which the real file has. Added so the block matches what it claims to reproduce.

### Verification

- `sandbox-lint`: OK (`.claude/settings.json` matches `expected.json`)
- `prek run --files <the three changed files>`: all green
- `pytest tools/sandbox-lint`: 111 passed

---
Generated-by: Claude Code (Opus 5)
