### PR TITLE
fix(setup): document the Docker CLI and plugin paths the socket allowlist misses

### DIFF
--- a/docs/setup/sandbox-troubleshooting.md
+++ b/docs/setup/sandbox-troubleshooting.md
@@ -277,6 +277,19 @@ Cannot connect to Podman. Please verify your connection to the Linux system usin
 installed and the runtime is running on the host — the sandbox is
 just blocking access to its socket.
 
+On macOS with Docker Desktop the failure usually arrives *earlier*
+than that, as one of:
+
+```text
+zsh: operation not permitted: docker
+docker: unknown command: docker compose
+```
+
+The first means the sandbox is blocking the `docker` binary itself;
+the second means it is blocking the CLI plugins. Neither reaches the
+socket at all, so the socket allowlist below does not fix them on its
+own — see the CLI paths in the same block.
+
 ### Root cause
 
 The runtime CLI talks to its daemon via a unix-domain socket. The
@@ -287,6 +300,19 @@ and lists `~/.docker` in the broader filesystem `denyRead` set.
 Both block the socket file under `~/.docker/run/docker.sock`,
 which is where Docker.app for Mac drops its socket.
 
+On macOS the same `~/.docker` denial also blocks two things that
+are not the socket, and that a socket-only allowlist therefore
+leaves broken:
+
+- **The CLI binary.** Docker Desktop installs it *inside* the denied
+  directory — `docker` on `PATH` is `~/.docker/bin/docker`, a symlink
+  into `/Applications/Docker.app`. Denied, the shell cannot execute it
+  at all (`operation not permitted: docker`).
+- **The CLI plugins.** `docker compose` and `docker buildx` are not
+  builtins; they are separate binaries in `~/.docker/cli-plugins/`.
+  Denied, `docker ps` works while `docker compose` reports
+  `unknown command`, which breaks any compose-driven workflow.
+
 For Colima the socket lives under `~/.colima/...` (not currently
 covered by any allow / deny in the framework reference, so it
 works by default), and for rootless Podman it lives under
@@ -296,8 +322,8 @@ generic `~/.docker` denial.
 
 ### Fix
 
-Allow Bash subprocesses to read the *socket file* without opening
-the `~/.docker/` directory generally:
+Allow Bash subprocesses to read the *socket file*, the CLI, and its
+plugins without opening the `~/.docker/` directory generally:
 
 ```jsonc
 // ~/.claude/settings.json
@@ -308,7 +334,9 @@ the `~/.docker/` directory generally:
         // ...existing entries...
         "~/.docker/run/docker.sock",                    // Docker.app for Mac socket
         "~/.colima/default/docker.sock",                // Colima default socket (defensive; usually not blocked)
-        "/var/run/docker.sock"                          // Linux daemon socket (root-managed install)
+        "/var/run/docker.sock",                         // Linux daemon socket (root-managed install)
+        "~/.docker/bin/",                               // Docker Desktop CLI binaries (`docker` itself lives here on macOS)
+        "~/.docker/cli-plugins/"                        // `docker compose`, `docker buildx` — separate plugin binaries
       ]
     }
   },
@@ -333,6 +361,14 @@ Per-entry rationale:
   the generic `~/.` denial.
 - `/var/run/docker.sock` — Linux systems with daemon Docker;
   socket is root-managed but world-readable by convention.
+- `~/.docker/bin/` — Docker Desktop for Mac installs the `docker`
+  CLI here (as a symlink into `/Applications/Docker.app`), so
+  without it the binary cannot be executed and no socket entry
+  matters. Not needed for Homebrew or Linux installs, where the
+  CLI lives on a normal `PATH` directory outside `~/.docker`.
+- `~/.docker/cli-plugins/` — `docker compose` and `docker buildx`
+  are plugin binaries, not builtins. Without it `docker ps`
+  succeeds but `docker compose` fails as `unknown command`.
 - The narrowed `permissions.deny` keeps the agent's `Read` tool
   from seeing Docker auth tokens (`config.json`) and saved
   contexts (which include host IPs and credentials), while

--- a/docs/setup/sandbox-troubleshooting.md
+++ b/docs/setup/sandbox-troubleshooting.md
@@ -290,6 +290,16 @@ the second means it is blocking the CLI plugins. Neither reaches the
 socket at all, so the socket allowlist below does not fix them on its
 own — see the CLI paths in the same block.
 
+A third form appears once the CLI runs but the connection is still
+refused, on every platform:
+
+```text
+permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
+```
+
+That one is the missing `sandbox.network.allowUnixSockets` entry, not a
+filesystem permission — see below.
+
 ### Root cause
 
 The runtime CLI talks to its daemon via a unix-domain socket. The
@@ -312,6 +322,22 @@ leaves broken:
   builtins; they are separate binaries in `~/.docker/cli-plugins/`.
   Denied, `docker ps` works while `docker compose` reports
   `unknown command`, which breaks any compose-driven workflow.
+
+Separately, and on **every** platform: listing a socket in
+`sandbox.filesystem.allowRead` grants permission to *read the file*,
+not to *connect to it*. Socket connections are gated by their own
+`sandbox.network.allowUnixSockets` list. With the path allowed for
+reading but absent from that list, the CLI starts, finds the socket,
+and is refused at `connect(2)`:
+
+```console
+$ docker ps
+permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
+```
+
+Both settings are required; neither substitutes for the other. This is
+not macOS-specific — a Linux adopter using `/var/run/docker.sock` needs
+the `allowUnixSockets` entry just the same.
 
 For Colima the socket lives under `~/.colima/...` (not currently
 covered by any allow / deny in the framework reference, so it
@@ -337,6 +363,15 @@ plugins without opening the `~/.docker/` directory generally:
         "/var/run/docker.sock",                         // Linux daemon socket (root-managed install)
         "~/.docker/bin/",                               // Docker Desktop CLI binaries (`docker` itself lives here on macOS)
         "~/.docker/cli-plugins/"                        // `docker compose`, `docker buildx` — separate plugin binaries
+      ]
+    },
+    "network": {
+      // Reading the socket file is not the same permission as connecting
+      // to it. Without these, the CLI runs but every command is refused
+      // with "permission denied while trying to connect to the docker API".
+      "allowUnixSockets": [
+        "/var/run/docker.sock",
+        "~/.docker/run/docker.sock"
       ]
     }
   },
@@ -369,6 +404,13 @@ Per-entry rationale:
 - `~/.docker/cli-plugins/` — `docker compose` and `docker buildx`
   are plugin binaries, not builtins. Without it `docker ps`
   succeeds but `docker compose` fails as `unknown command`.
+- `sandbox.network.allowUnixSockets` — the connect-side permission,
+  required on every platform. `allowRead` on the same path only
+  lets a process *open the file*; the sandbox gates socket
+  *connections* through this separate list. Verified by removing
+  it while leaving the `allowRead` entries in place: `docker
+  compose version` still ran, and `docker ps` failed with
+  `permission denied while trying to connect to the docker API`.
 - The narrowed `permissions.deny` keeps the agent's `Read` tool
   from seeing Docker auth tokens (`config.json`) and saved
   contexts (which include host IPs and credentials), while


### PR DESCRIPTION
The *Docker / Podman command fails with a socket error* recipe cannot produce a working docker. It has three gaps — one on every platform, two specific to macOS with Docker Desktop.

### 1. `allowUnixSockets` — every platform

Listing a socket in `sandbox.filesystem.allowRead` grants permission to **read the file**, not to **connect to it**. Socket connections are gated by the separate `sandbox.network.allowUnixSockets` list, which the recipe never mentions. With the path allowed for reading but absent from that list:

```console
$ docker ps
permission denied while trying to connect to the docker API at unix:///var/run/docker.sock
```

This is not macOS-specific — a Linux adopter on `/var/run/docker.sock` hits it identically. As published, the recipe could not produce a working docker on any platform.

### 2. The CLI itself — macOS

Docker Desktop installs the `docker` binary *inside* the denied directory:

```
docker (on PATH) = ~/.docker/bin/docker -> /Applications/Docker.app/Contents/Resources/bin/docker
```

Denied, the shell cannot execute it at all — `operation not permitted: docker`, before the socket is ever consulted.

### 3. The CLI plugins — macOS

Allowing `~/.docker/bin/` gets `docker ps` working, so it looks fixed. But `docker compose` and `docker buildx` are not builtins — they are plugin binaries under `~/.docker/cli-plugins/`, also inside the denial:

```console
$ docker ps
CONTAINER ID   IMAGE ...          # works

$ docker compose version
docker: unknown command: docker compose
```

Any compose-driven workflow stays broken, which reads as a Docker Desktop fault rather than a sandbox one.

### Symptom section

The listed symptoms were all "daemon not running" errors. None of the three failures above produces one, so an adopter had nothing to match against and no reason to land on this entry. All three forms added.

### Verification

macOS 26, Docker Desktop, server 29.7.2.

| | before | after |
|---|---|---|
| `docker ps` | `operation not permitted: docker` | exit 0 |
| `docker compose version` | `unknown command` | v5.5.1 |
| `docker buildx version` | `unknown command` | v0.36.1 |
| `~/.docker/config.json` | denied | still denied |

Gap 1 was isolated by removing `allowUnixSockets` while leaving the `allowRead` socket paths in place: `docker compose version` still ran — the plugin binary never touches the daemon — while `docker ps` failed at connect. Restoring it fixed `docker ps` with nothing else changed, which is what distinguishes the two permissions.

The credential denial is unaffected throughout: `docker` emits a benign `Error loading config file` warning and works normally, preserving the intended split — Bash may use the socket, the agent may not read the tokens.

`prek run --files docs/setup/sandbox-troubleshooting.md`: all green.

---
Generated-by: Claude Code (Opus 5)
