### PR TITLE
ci(runners): move every job to the 1-vCPU ubuntu-slim runner

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -26,7 +26,7 @@ permissions:
   contents: read
 jobs:
   asf-allowlist-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,7 +33,7 @@ permissions:
 jobs:
   analyze:
     name: "Analyze (${{ matrix.language }})"
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
     permissions:
       # Writing security-events is required for CodeQL to upload results to
       # the repository's "Security" tab. The rest stay read-only.

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -27,7 +27,7 @@ permissions: {}
 
 jobs:
   prek:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:

--- a/.github/workflows/rat.yml
+++ b/.github/workflows/rat.yml
@@ -36,7 +36,7 @@ permissions: {}
 # https://archive.apache.org/dist/creadur/apache-rat-<version>/apache-rat-<version>-bin.tar.gz.sha512
 jobs:
   rat:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     env:

--- a/.github/workflows/sandbox-lint.yml
+++ b/.github/workflows/sandbox-lint.yml
@@ -42,7 +42,7 @@ permissions: {}
 jobs:
   sandbox-lint:
     name: lint .claude/settings.json against baseline
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     env:

--- a/.github/workflows/skill-and-tool-validator.yml
+++ b/.github/workflows/skill-and-tool-validator.yml
@@ -38,7 +38,7 @@ permissions: {}
 jobs:
   skill-and-tool-validator:
     name: validate skills and tool contracts
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
   # picks it up automatically.
   members:
     name: list-workspace-members
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
@@ -149,7 +149,7 @@ jobs:
   # signal — not the gate.
   pytest:
     name: "pytest (${{ matrix.project.name }})"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: members
     # Guard against an empty selection. When the path filter selects no
     # members (a PR that changed no project's Python), the members output
@@ -212,7 +212,7 @@ jobs:
   # entries no longer touches `.asf.yaml`.
   tests-ok:
     name: tests-ok
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     needs: pytest
     # `always()` — without it, this job would be skipped (not
     # failed) when an upstream matrix entry fails, and a skipped

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -29,7 +29,7 @@ permissions: {}
 jobs:
   zizmor:
     name: "zizmor"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -38,8 +38,29 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           persist-credentials: false
-      - name: "Run zizmor"
-        uses: zizmorcore/zizmor-action@70fb788f84895a7701f5643d103d587e460b5c99  # v0.6.3
+      # zizmor runs from the root uv workspace's `dev` group rather than
+      # through `zizmorcore/zizmor-action`. The action's `action.sh` runs
+      # the tool with `docker pull` + `docker run` and aborts with
+      # "Cannot run this action without Docker"; `ubuntu-slim` jobs are
+      # themselves containers with no Docker daemon, so the job failed
+      # before zizmor was ever invoked. Installing the CLI from PyPI also
+      # puts its version under the root lockfile and the
+      # `[tool.uv] exclude-newer` cooldown, same as prek.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
         with:
-          advanced-security: false
-          config: .zizmor.yml
+          enable-cache: true
+      - name: "Install zizmor"
+        # `--no-install-workspace` — zizmor is a leaf tool that imports
+        # nothing from this repo, so building the workspace's ~34 member
+        # packages to run it would be pure cost on a 1-vCPU runner.
+        run: uv sync --group dev --no-install-workspace
+      - name: "Run zizmor"
+        # `--persona regular` matches the action's default (and its
+        # `advanced-security: false`): report findings on the console and
+        # exit non-zero, with no SARIF upload to code scanning.
+        # GH_TOKEN enables the audits that need the REST API (the
+        # `actions: read` permission above); without it zizmor skips them
+        # with a warning instead of failing.
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: uv run zizmor --config .zizmor.yml --persona regular .

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,12 @@ logs
 __pycache__/
 *.py[cod]
 
+# uv workspace virtualenvs. uv writes a `*` .gitignore inside each one,
+# so git already skips them — but the `typos` prek hook walks the tree
+# itself (see .pre-commit-config.yaml) and an explicit entry keeps the
+# synced workspace out of every ignore-aware tool, not just git.
+.venv/
+
 # Lychee link-checker result cache. The workflow restores this from
 # Actions cache between runs; checking it in would commit machine-
 # specific resolution data.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -132,15 +132,35 @@ repos:
         # README.md files are NOT excluded — they are real docs.
         exclude: ^tools/skill-evals/evals/.+/fixtures/.+\.md$
   # typos — fast spell-checker. Allowlist is `.typos.toml`.
+  #
   # Override the default args (which include `--write-changes`) so
   # the hook never silently rewrites files; CI surfaces typos as
   # errors instead.
+  #
+  # `pass_filenames: false` + the trailing `.` arg → typos walks the
+  # repo itself instead of being handed the file list, the same shape
+  # as the `lychee` hook below. That is a memory requirement, not a
+  # preference: typos' peak RSS scales with the number of paths passed
+  # to one invocation (~1.2 MB per path), and prek splits the file list
+  # across roughly `cpu_count` invocations. On a 4-vCPU runner the ~4.9k
+  # tracked files arrive as ~1.2k-path chunks (~925 MB each); on the
+  # 1-vCPU `ubuntu-slim` runner they arrive as a single invocation that
+  # peaks at ~5.7 GB and is OOM-killed. prek reports that as a bare
+  # `exit code: 1` with no output — a signal-killed process has no exit
+  # code of its own — which reads like a hook failure with a missing
+  # message rather than the kill it is. Walking costs ~21 MB flat,
+  # whatever the core count.
+  #
+  # typos honours .gitignore while walking, and uv writes a `*`
+  # .gitignore inside `.venv`, so a synced workspace stays out of the
+  # walk: it covers the same files the list did.
   - repo: https://github.com/crate-ci/typos
     rev: v1.50.0
     hooks:
       - id: typos
         name: typos
-        args: [--force-exclude]
+        args: [--force-exclude, .]
+        pass_filenames: false
   # lychee — link checker (was the standalone `link-check.yml`
   # workflow; converted to this prek hook). Validates cross-file links,
   # `#anchor` fragments, and external URLs across markdown / rst /

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -819,7 +819,9 @@ Separate GitHub workflows:
 
 - **`pre-commit.yml`** — runs `prek run --all-files` in CI.
 - **`zizmor.yml`** — lints GitHub Actions workflows for known-bad
-  patterns; runs on every PR.
+  patterns; runs on every PR. zizmor is declared in the root
+  `pyproject.toml` dev group, so `uv run zizmor --config .zizmor.yml .`
+  reproduces the CI run locally.
 The link check ([lychee](https://lychee.cli.rs/)) is **not** a
 separate workflow — it runs as the `lychee` hook inside
 `prek run --all-files` (the `pre-commit.yml` workflow above), and so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@
 
 # Root pyproject.toml — frames the framework root as a uv-managed
 # project so the `[tool.uv] exclude-newer` cooldown below actually
-# applies to the root-level tooling (currently just `prek`, declared
+# applies to the root-level tooling (`prek` and `zizmor`, declared
 # under `[dependency-groups] dev`). `uv tool install` ignores
 # pyproject.toml settings, so prek is installed into a uv-managed
 # environment via `uv sync --group dev` instead.
@@ -55,6 +55,15 @@ requires-python = ">=3.11"
 #   the three pins in every member with an instruction to keep them in
 #   lockstep, and they had already drifted into three different mypy
 #   floors, two pytest floors, and two ruff floors.
+# - `zizmor` is the GitHub Actions security analyser run by
+#   `.github/workflows/zizmor.yml`. It is declared here rather than
+#   invoked through `zizmorcore/zizmor-action` because that action runs
+#   the tool via `docker pull` + `docker run` and aborts with "Cannot
+#   run this action without Docker" — and there is no Docker daemon on
+#   the container-based `ubuntu-slim` runners this repo uses.
+#   Installing the CLI from PyPI also brings zizmor under the
+#   `exclude-newer` cooldown and the root lockfile, and makes
+#   `uv run zizmor` reproduce CI locally.
 #
 # Lower bounds mirror what individual tools needed at their last
 # bump; the upper bound is enforced implicitly by the 7-day
@@ -63,6 +72,7 @@ requires-python = ">=3.11"
 dev = [
   "prek>=0.4.12",
   "magpie-dev",
+  "zizmor>=1.30.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -127,6 +127,7 @@ source = { virtual = "." }
 dev = [
     { name = "magpie-dev" },
     { name = "prek" },
+    { name = "zizmor" },
 ]
 
 [package.metadata]
@@ -135,6 +136,7 @@ dev = [
 dev = [
     { name = "magpie-dev", editable = "tools/dev" },
     { name = "prek", specifier = ">=0.4.12" },
+    { name = "zizmor", specifier = ">=1.30.0" },
 ]
 
 [[package]]
@@ -1928,3 +1930,21 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "magpie-dev", editable = "tools/dev" }]
+
+[[package]]
+name = "zizmor"
+version = "1.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/78/e32b0b913535def3e050cd0c4202aff11f10deb53e9844f42af37aa267e3/zizmor-1.30.0.tar.gz", hash = "sha256:9a17ac3bb043afbbd9d3c8b6f309fa5b319c6a32e3259fbaf050f6fcd3d0a9cd", size = 575489, upload-time = "2026-08-30T21:26:06.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/d2/a6eb24a670ce7466c0d6b2ca9e9673aa403f07786af7e5d7e593dace4e40/zizmor-1.30.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:51c96204572b9f96b940806a371a9c57c8cff30cf93d3bd73c2febe483f942df", size = 9108421, upload-time = "2026-08-30T21:25:40.257Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/3c/0b7fa1cf59784f743874a76db860a192bc319ff575f74277fa37e0a81d24/zizmor-1.30.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e4193537785dd07177227e4695871ffae1d7fe3f6043c217498445e71b477bc1", size = 8716981, upload-time = "2026-08-30T21:25:43.173Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b6/019b9af74ae9c9472e4804801c61f18b5394392142b0c6c2b4651161d21a/zizmor-1.30.0-py3-none-manylinux_2_24_aarch64.whl", hash = "sha256:7569a58319fb270c14a64663a6565929035f26f6f6d13059314f796e988129eb", size = 8969733, upload-time = "2026-08-30T21:25:45.482Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2d/a2f8d3d78d56fdaa5da4fc71e86dfed50006a197ff30b2363e759a1c4b92/zizmor-1.30.0-py3-none-manylinux_2_28_armv7l.whl", hash = "sha256:0e69a86290dff4c41b51c381a27029b5dc2b748c0510a9a333b18f862ea1bc68", size = 8601613, upload-time = "2026-08-30T21:25:47.963Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/79/ac655d04c89356b40a4f8166ede50ba207cfc0ea1410f99544e9d55a111b/zizmor-1.30.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:9c08a7c34b33ed6f9a3a3d28fcf8c64e3e078c53c51bc9ce05c32ec3ba7feae9", size = 9441765, upload-time = "2026-08-30T21:25:50.635Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/52/c88a4a492b21e7f5891140a48d97fc92b389ddce899d80ce12d7a60e278b/zizmor-1.30.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:baa02978518248bf9f011e6ceca7b7c5efb5b893810cd4954e01785e1b68f959", size = 9000409, upload-time = "2026-08-30T21:25:53.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/b9/649a07ff353d84362779bd747c945e5af23c54e94e4633751e3fa6b88099/zizmor-1.30.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0148b61f6315ad363ae748f838e8ed81e1cfb3ade6bbe480e7516e4fba630b82", size = 8570313, upload-time = "2026-08-30T21:25:55.926Z" },
+    { url = "https://files.pythonhosted.org/packages/97/84/ef925827d7d7d6baba31194bf9712d74df37a0e4ac361b8dbdbb2d4a9597/zizmor-1.30.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1f15ed62ff34ad7875427384b03a2f72995d9ab8ddcb50dc141b25763de3aaa2", size = 9502173, upload-time = "2026-08-30T21:25:58.86Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f5/e5296d51f494de21f5da44b3d7bf270d1aae7fdf92b240e871cd2e975717/zizmor-1.30.0-py3-none-win32.whl", hash = "sha256:39f15155db3e4af9bb5cf125a236c67fd84ddd3174f60b4111b27c691b337e00", size = 7763311, upload-time = "2026-08-30T21:26:01.313Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b9/95d0cc6d169a43ad0c2a33c1395c0e5cde265880fa62e5d26a3b502a003c/zizmor-1.30.0-py3-none-win_amd64.whl", hash = "sha256:ca321b5b1cb85d08ac0c3c86275bfd5a6b5564c176437e3b41e10bd1e4463296", size = 8888408, upload-time = "2026-08-30T21:26:04.103Z" },
+]


### PR DESCRIPTION
Nothing this repository runs in CI is heavy. Measured on the current
4-vCPU image:

| Job | Runtime |
|---|---|
| `prek` | 131s |
| `analyze (python)` / `(actions)` | 99s / 41s |
| `sandbox-lint` | ~88s |
| `rat` | 60s |
| `pytest (dev)` / `(vetted-ops)` | 20s / 18s |
| `validate skills and tool contracts` | 18s |
| `list-workspace-members` | 6s |
| `tests-ok` | 3s |

Paying for four cores to run a YAML linter and a 20-second pytest suite
is waste on infrastructure the foundation shares.

`ubuntu-slim` is GitHub-hosted (1 vCPU, 5 GB) rather than an ASF
self-hosted label, so it needs no Infra ticket — and 114 workflow files
across the `apache` org already use it. Jobs run in a container instead of
a dedicated VM and are killed at 15 minutes; the slowest job here uses 15%
of that budget, so the headroom survives the single-core slowdown.

## Two jobs needed a fix to survive the move

**`zizmor` ran through a Docker action.** `zizmorcore/zizmor-action`'s
`action.sh` runs the tool with `docker pull` + `docker run` and aborts
with "Cannot run this action without Docker"; `ubuntu-slim` jobs are
themselves containers with no Docker daemon, so the job failed before
zizmor was ever invoked. The CLI now comes from the root uv workspace's
`dev` group, which also puts its version under the lockfile and the
`[tool.uv] exclude-newer` cooldown, same as prek. This supersedes #1167's
pin bump of that action, which the rebase dropped.

**`typos` was OOM-killed.** It reported a bare `- exit code: 1` with no
output, which reads like a hook that lost its error message — but prek has
no exit code to report for a signal-killed process. typos' peak RSS scales
with the number of paths handed to a single invocation (~1.2 MB each), and
prek splits the file list across roughly `cpu_count` invocations. Measured
on this repo's ~4.9k tracked files, in a 1-vCPU `ubuntu:24.04` container
(which is what `ubuntu-slim` is):

| paths in one invocation | peak RSS |
|---|---|
| 610 | 422 MB |
| 1,219 (the 4-vCPU chunk) | 925 MB |
| 2,438 | 2,514 MB |
| 4,876 (the 1-vCPU chunk) | 5,754 MB |
| walk mode, no paths passed | 21 MB |

So the hook fit comfortably on four cores and went past the runner's
memory on one. `pass_filenames: false` plus a trailing `.` makes typos
walk the repo itself — the shape the `lychee` hook already uses — for a
flat ~21 MB whatever the core count. Coverage is unchanged: typos honours
.gitignore while walking, and this checkout has no untracked non-ignored
files. `.venv/` joins .gitignore for the same reason.

Three consequences worth flagging for review:

- **`codeql.yml` gives up its `ubuntu-24.04` pin** along with the four
  cores. Its Python analysis is the one genuinely CPU- and memory-bound
  job here, so it's the first place to look if a run starts timing out.
  Happy to leave that workflow pinned and on the fat runner if reviewers
  prefer.
- **No workflow sets `timeout-minutes`**, so slim's 15-minute kill becomes
  the effective timeout everywhere — stricter than the 6-hour default it
  replaces, and appropriate for a repo where every job finishes inside two
  minutes.
- **`uv tool install prek` is unpinned**, so `pre-commit.yml` tracks
  whatever prek is latest at run time. Not introduced here, but the typos
  diagnosis leaned on knowing the version, so it's worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R3wLTXcKFLKiZE992K5UHr
