### PR TITLE
feat(setup): offer an optional committed default plugin set

### DIFF
--- a/docs/designs/2026-09-10-repo-committed-setup-design.md
+++ b/docs/designs/2026-09-10-repo-committed-setup-design.md
@@ -1,0 +1,373 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Repo-committed setup: default plugin set and per-skill first-run configuration](#repo-committed-setup-default-plugin-set-and-per-skill-first-run-configuration)
+  - [Problem](#problem)
+  - [Scope](#scope)
+  - [Decisions](#decisions)
+  - [Subsystem A — the optional committed default set](#subsystem-a--the-optional-committed-default-set)
+    - [What setup offers](#what-setup-offers)
+    - [Merge rules](#merge-rules)
+    - [Harness reach](#harness-reach)
+    - [Verify, uninstall, pre-flight](#verify-uninstall-pre-flight)
+  - [Subsystem B — the per-skill first-run wizard](#subsystem-b--the-per-skill-first-run-wizard)
+    - [Declaring what a skill needs](#declaring-what-a-skill-needs)
+    - [The generated map and its drift hook](#the-generated-map-and-its-drift-hook)
+    - [Firing the wizard](#firing-the-wizard)
+    - [What the wizard does](#what-the-wizard-does)
+  - [Subsystem C — documentation and screenshots](#subsystem-c--documentation-and-screenshots)
+    - [Prose](#prose)
+    - [The screenshot set: 14 to 25](#the-screenshot-set-14-to-25)
+  - [Sequencing](#sequencing)
+  - [Acceptance criteria](#acceptance-criteria)
+  - [Alternatives considered](#alternatives-considered)
+  - [Risks](#risks)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Repo-committed setup: default plugin set and per-skill first-run configuration
+
+| | |
+|---|---|
+| **Status** | Design approved; implementation not started |
+| **Created** | 2026-09-10 |
+| **Supersedes** | Nothing. Extends the marketplace install path added for 0.2.0 and the shared pre-flight from #1193 |
+| **Spec surface** | [`tools/spec-loop/specs/adoption-and-setup.md`](../../tools/spec-loop/specs/adoption-and-setup.md) |
+
+## Problem
+
+The marketplace install became the default path in 0.2.0, and it commits
+nothing to the repository — by design. `install.md` Step M5 says so in as many
+words: no lock, no snapshot, no symlink, and `.apache-magpie-overrides/` merely
+*offered* as an aside. Three consequences follow, and all three are the same
+root cause:
+
+1. **The default plugin set is documentation only.** The
+   `extraKnownMarketplaces` + `enabledPlugins` block that lets a contributor
+   arrive Magpie-ready exists as copy-paste JSON in
+   [`docs/setup/marketplaces.md`](../setup/marketplaces.md). No code path
+   writes it, so a maintainer either transcribes it by hand or never learns it
+   exists.
+2. **The config store is never created on the default path.** The 40 template
+   files in `projects/_template/` are scaffolded by Step 9, which belongs to
+   the snapshot path. A marketplace-installed skill still reads
+   `.apache-magpie-overrides/` at run time, but nothing has put anything there.
+3. **A skill discovers its missing configuration by acting on wrong
+   assumptions.** The shared pre-flight added in #1193 answers "has this repo
+   adopted Magpie at all"; it does not answer "does *this skill* have the
+   configuration it needs". A skill whose config file is absent proceeds
+   against defaults.
+
+## Scope
+
+Three subsystems, each independently shippable, delivered in order.
+
+| | Delivers | Depends on |
+|---|---|---|
+| **A** | `setup` offers to write the committed default-set block and the config store | — |
+| **B** | Per-skill first-run configuration wizard | the config store existing (A) |
+| **C** | Documentation and screenshots for both | A settled; wizard shots need B |
+
+**Out of scope.** The three outstanding placeholder captures
+(`codex-install.png`, `vscode-install.png`, `gemini-install.png`) are unrelated
+work. The eleven existing captures stay as they are. No change to the
+pinned-snapshot install path, to lock-file handling, or to the secure-isolation
+setup.
+
+## Decisions
+
+Five forks were settled during design; each shapes the rest of the document.
+
+1. **The committed set is a fixed, framework-defined floor** — `magpie-setup`,
+   `magpie-utilities`, `magpie-agent-guard` — not "whatever the maintainer
+   installed". Maintainer-only families such as `magpie-security` stay a
+   personal, user-scope install.
+2. **Committing the block is optional and never a prerequisite.** Plugins work
+   in the repo with or without it. It is a convenience for teammates.
+3. **Setup offers it once, at Step M5, defaulting to no; staleness is reported
+   by `verify` only.** The per-skill pre-flight never mentions the block.
+4. **A skill declares only its *required* config in frontmatter**; the optional
+   set is derived by tooling from the skill's own prose.
+5. **The wizard auto-detects, asks only the gaps, writes, stages, and
+   continues** into the skill the user actually invoked.
+
+A consequence of decision 1 is worth stating plainly, because it removes work
+the original request implied: **with a fixed floor there is nothing to re-sync
+when a maintainer installs another family.** Installing `magpie-security` does
+not change the floor. No per-install hook is needed — which is fortunate, since
+#1193 established that no code runs on plugin install or upgrade on most
+harnesses. The only drift that can occur is the framework's *own* floor
+changing between releases, which is a periodic repair check.
+
+## Subsystem A — the optional committed default set
+
+### What setup offers
+
+`skills/setup/install.md` Step M5 currently lists three things the marketplace
+install "deliberately does not set up". Replace the second bullet with a single
+opt-in offer covering both repo-side artefacts together, presented as one
+question defaulting to **no**:
+
+- **The default-set block** in the repo's `.claude/settings.json`:
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "apache-magpie": {
+      "source": { "source": "github", "repo": "apache/magpie" }
+    }
+  },
+  "enabledPlugins": {
+    "magpie-setup@apache-magpie": true,
+    "magpie-utilities@apache-magpie": true,
+    "magpie-agent-guard@apache-magpie": true
+  }
+}
+```
+
+- **The config store** — `.apache-magpie-overrides/`, scaffolded from
+  `projects/_template/` exactly as Step 9 does today, with the same exclusions
+  (`.gitignore`, `pr-management-triage-ci-check-map.md`) and the same
+  `project.md` pre-population from detected fit signals.
+
+The offer must state, in the prompt itself, that the block is optional and that
+the plugins work in this repo either way. A maintainer declining it is a
+supported end state, not a partial install, and setup's recap must not describe
+the result as incomplete.
+
+Setup offers to `git add` both, and never commits.
+
+### Merge rules
+
+The repo's `.claude/settings.json` is not Magpie's file. This repository's own
+carries `sandbox` and `permissions` blocks that must survive untouched, and an
+adopter's will carry whatever they put there.
+
+- Merge **only** the two keys. Every other key is preserved byte-for-byte.
+- If `extraKnownMarketplaces` already defines `apache-magpie`, leave the
+  existing definition alone — an adopter pinning `apache/magpie@0.2.0` has made
+  a deliberate choice.
+- If `enabledPlugins` exists, **add** missing floor members and **remove
+  nothing**. A project that has enabled other plugins, Magpie's or anyone
+  else's, keeps them.
+- If the file does not exist, create it with those two keys and nothing else.
+- If the file exists but is not valid JSON, stop and say so. Do not rewrite it.
+
+### Harness reach
+
+Only Claude Code can express this. #1193 verified the constraint against the
+shipping clients: per-family plugins are Claude Code-only, so Codex could only
+default-install all ten families, and Gemini has no workspace-extension
+mechanism at all.
+
+Setup must therefore make the offer **only** when the detected agent is Claude
+Code, and on the others say plainly that the harness has no equivalent — rather
+than writing a file that does nothing. This is the same detection Step M2
+already performs.
+
+### Verify, uninstall, pre-flight
+
+- **`setup verify`** gains one check. Block absent → reported as fine, with one
+  line noting it is available; this is not a fault and must not be counted as
+  one. Block present but missing a floor member, or naming a plugin the current
+  marketplace no longer ships → reported as drift with the repair offer.
+- **`setup uninstall`** removes only the keys it added, leaving the rest of
+  `.claude/settings.json` intact, and follows the existing convention of
+  preserving `.apache-magpie-overrides/` by default.
+- **The pre-flight is unchanged by this subsystem.** It must never treat a
+  missing block as an unadopted repo — that would convert an optional
+  convenience into a de-facto requirement, contradicting decision 2.
+
+## Subsystem B — the per-skill first-run wizard
+
+### Declaring what a skill needs
+
+Each of the 65 skills that carry the pre-flight gains a `requires_config:`
+frontmatter key — the short list of config files without which the skill
+cannot do its job correctly, typically one to three entries:
+
+```yaml
+requires_config:
+  - project.md
+  - pr-management-config.md
+```
+
+Required means: absent, the skill would act on a guess. Everything else a skill
+reads is optional and degrades, which is already how skills are written —
+`pr-management-triage` states that missing config files "degrade to post the
+comment, skip the label". That behaviour does not change.
+
+### The generated map and its drift hook
+
+The optional set is **derived, never hand-written**. New tooling greps each
+skill for `<project-config>/*` references and emits
+`tools/dev/skill-config-map.json`:
+
+```json
+{
+  "pr-management-triage": {
+    "required": ["project.md", "pr-management-config.md"],
+    "optional": ["scope-labels.md", "pr-management-triage-comment-templates.md"]
+  }
+}
+```
+
+`optional` is the derived set minus `required`. A new
+`tools/dev/check-skill-config-map.py --fix` regenerates it and a pre-commit
+hook prevents drift, mirroring the `check-skill-preflight` pattern #1193
+established. The check also validates that every file named in either list
+exists in `projects/_template/`, so a skill cannot require config the framework
+cannot scaffold.
+
+### Firing the wizard
+
+The shared pre-flight block (`tools/dev/preflight-block.md`, propagated into 65
+of the 74 skills — the nine setup-family skills are excluded, since they are
+what fixes the problem) gains **one** cheap check appended to its existing
+three:
+
+> Are this skill's `requires_config` files present in
+> `.apache-magpie-overrides/`? If any are missing, hand off to
+> `/magpie-setup configure <skill>`.
+
+The same 65-skill exclusion set applies. This is the only pre-flight change in
+this design; the block-staleness check from Subsystem A deliberately stays out
+of it, so the pre-flight keeps its "silent on the happy path" property.
+
+### What the wizard does
+
+The wizard lives in **one place** — a new `configure` sub-action in the setup
+skill, documented in a new `skills/setup/configure.md` — not propagated into 65
+skill bodies. #1193 already paid the cost of propagating a 40-line block into
+every skill; propagating a full interview would multiply it.
+
+It reuses the three-beat pattern `install.md` Step 4b and Step 9 already
+implement:
+
+1. **Auto-detect first.** Read what the repo already reveals — the upstream
+   remote, label taxonomy, milestones, release trains, existing CI checks.
+2. **Batch the rest into one structured question.** Prefer the harness's
+   structured-question tool. One question, not a per-field interrogation.
+3. **Write and stage.** Copy the required templates from `projects/_template/`
+   with detected and answered values filled in, `git add` them, and say what
+   was written.
+
+Then **return control so the invoking skill continues** into the work the user
+asked for. The wizard is an interruption, not a destination.
+
+Further contract points:
+
+- **Optional config is never asked about.** It degrades as it does today.
+- **Idempotence needs no state file.** The config file existing is the marker;
+  a second invocation of the same skill sees the file and stays silent.
+- **`configure` with no argument** walks every installed family, for a
+  maintainer who would rather configure everything in one sitting.
+- **`configure <skill>` is directly invocable**, so a maintainer can prepare
+  config ahead of first use.
+- The wizard writes only into `.apache-magpie-overrides/`. It never edits skill
+  files, never commits, and never touches `.claude/settings.json` — that is
+  Subsystem A's surface.
+
+## Subsystem C — documentation and screenshots
+
+### Prose
+
+- **[`docs/quick-start.md`](../quick-start.md)** gains a subsection under
+  Step 1 describing the optional committed default set, led by the
+  optional-not-required framing, and a first-run wizard shot in *What happens
+  next*.
+- **[`docs/setup/marketplaces.md`](../setup/marketplaces.md)** — the
+  `Claude Code: the default set` section gains a pointer that setup will write
+  the block on request, with the same optionality framing, and finally carries
+  `claude-code-default-install.png`.
+- **Family READMEs** each gain a wizard screenshot beside their existing
+  install shot.
+
+### The screenshot set: 14 to 25
+
+| Added | Count |
+|---|---|
+| `assets/quickstart/families/<family>-wizard.png` | 10 |
+| `assets/quickstart/first-run-wizard.png` | 1 |
+| `assets/quickstart/claude-code-default-install.png` (already documented as optional) | 1 |
+
+`tools/dev/capture-screenshot.sh` gains `<family>-wizard` targets with their own
+briefs. `tools/dev/check-quickstart-screenshots.py` extends to expect the new
+paths, and its family-geometry consistency rule applies **per set** — wizard
+shots are checked against each other, not against the install shots, since the
+two sets are captured in different sittings. `assets/quickstart/README.md`
+documents what each wizard shot must frame.
+
+Wizard shots can only be captured once B ships.
+
+## Sequencing
+
+1. **A**, with its slice of C's prose. Self-contained: `install.md` Step M5,
+   `verify.md`, `uninstall.md`, the two docs pages, and the spec-loop
+   acceptance criteria.
+2. **B**, as its own implementation plan. It touches 65 frontmatters, adds a
+   generated map, a pre-commit hook, a setup sub-action, and one pre-flight
+   line.
+3. **C's screenshots**, after B is real.
+
+## Acceptance criteria
+
+These land in `tools/spec-loop/specs/adoption-and-setup.md`, which is how setup
+behaviour is specified and validated in this repository — the spec-loop is the
+test surface, not a unit-test suite.
+
+- A marketplace install on Claude Code offers, once, to commit the default-set
+  block and scaffold the config store; the offer defaults to no and states that
+  both are optional.
+- Declining leaves a working install, and neither setup's recap nor `verify`
+  describes the result as incomplete.
+- Writing the block preserves every other key in an existing
+  `.claude/settings.json`, adds only missing floor members to an existing
+  `enabledPlugins`, and removes nothing.
+- The offer is not made on harnesses that cannot express it; those are told
+  why.
+- `verify` reports a stale committed block and repairs it on confirmation;
+  an absent block is not a fault.
+- A skill whose `requires_config` files are missing hands off to the wizard,
+  which auto-detects, asks the gaps in one batched question, writes and stages
+  the files, and returns control so the skill proceeds in the same turn.
+- A skill whose required config is present runs with no additional output.
+- `skill-config-map.json` regenerates identically from the skill sources; the
+  hook fails on drift and on any config file absent from `projects/_template/`.
+
+## Alternatives considered
+
+- **Commit whatever the maintainer installed.** The literal reading of the
+  original request. Rejected: it auto-enables maintainer-only families such as
+  `magpie-security` for every contributor who trusts the repo.
+- **Sync the block on every plugin install.** Not implementable — no code runs
+  on plugin install or upgrade on most harnesses (#1193) — and made moot by the
+  fixed floor.
+- **Put the staleness check in the pre-flight.** Rejected: it would nag every
+  invocation in repos that deliberately declined an optional feature.
+- **Hand-written skill-to-config map.** Rejected: drifts the moment a
+  `<project-config>` reference is added without updating it.
+- **Propagate the wizard into every skill body.** Rejected on token cost and
+  on the maintenance burden of 74 copies of one interview.
+- **One wizard screenshot per skill (74).** Rejected: roughly 15 MB of PNG
+  files, 74 manual re-captures whenever config questions change, and it would bury the
+  two commands the quick start exists to show.
+
+## Risks
+
+- **The committed block changes what a contributor's agent loads on clone.**
+  Mitigated by keeping it opt-in, restricting it to a three-plugin floor whose
+  members are either inert (`magpie-setup`) or deny-only
+  (`magpie-agent-guard`), and by Claude Code still letting a contributor
+  disable any plugin enabled this way.
+- **`requires_config` is a judgement call per skill.** Marking too much
+  required turns a first run into an interrogation; too little defeats the
+  purpose. The rule — required means the skill would otherwise act on a guess —
+  needs applying skill by skill during B, not mechanically.
+- **The wizard interrupts a skill mid-invocation.** Keeping it to one batched
+  question and returning control in the same turn is what keeps it a wizard
+  rather than a wall.

--- a/docs/designs/2026-09-10-repo-committed-setup-plan-a.md
+++ b/docs/designs/2026-09-10-repo-committed-setup-plan-a.md
@@ -1,0 +1,1015 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Subsystem A — committed default set: Implementation Plan](#subsystem-a--committed-default-set-implementation-plan)
+  - [Global Constraints](#global-constraints)
+  - [File Structure](#file-structure)
+    - [Task 1: The Step M5 offer and the harness gate](#task-1-the-step-m5-offer-and-the-harness-gate)
+    - [Task 2: Merge rules for `.claude/settings.json`](#task-2-merge-rules-for-claudesettingsjson)
+    - [Task 3: `verify` reports a stale block; absent is not a fault](#task-3-verify-reports-a-stale-block-absent-is-not-a-fault)
+    - [Task 4: `uninstall` removes only what it added](#task-4-uninstall-removes-only-what-it-added)
+    - [Task 5: Documentation](#task-5-documentation)
+    - [Task 6: Spec-loop acceptance criteria](#task-6-spec-loop-acceptance-criteria)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+# Subsystem A — committed default set: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `setup` offers, once and opt-in, to commit a default-plugin block to
+the adopter's `.claude/settings.json` and to scaffold `.apache-magpie-overrides/`,
+so a teammate cloning the repo arrives Magpie-ready — while the install stays
+completely usable for anyone who declines.
+
+**Architecture:** Every change is **prose in skill markdown**, not code. A
+family-plugin install ships `.claude-plugin/` and `skills/` only — no `tools/` —
+so nothing in this subsystem may depend on a Python helper being present on the
+adopter's machine. The agent performs the merge itself using its own file tools,
+following rules written in `install.md`. Behaviour is tested with the repo's
+`skill-evals` harness, which extracts a named section from a skill file, feeds it
+to a model with a fixture repo-state report, and compares the model's JSON
+against `expected.json`.
+
+**Tech Stack:** Markdown skill files; `tools/skill-evals` (pure-stdlib Python
+runner); `prek` for the pre-commit hook suite; `tools/spec-loop` specs for
+behaviour specification.
+
+**Spec:** [`2026-09-10-repo-committed-setup-design.md`](2026-09-10-repo-committed-setup-design.md)
+
+## Global Constraints
+
+- **The floor is exactly three plugins**, verbatim:
+  `magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie`,
+  `magpie-agent-guard@apache-magpie`. Never more, never fewer, regardless of
+  what the maintainer running setup has installed.
+- **The offer defaults to no** and its prompt must state that the block is
+  optional and that the plugins work in the repo either way.
+- **Claude Code only.** Codex can only default-install all ten families and
+  Gemini has no workspace-extension mechanism; on those, say so instead of
+  writing a file that does nothing.
+- **Merge never clobbers:** only `extraKnownMarketplaces` and `enabledPlugins`
+  are touched; an existing `apache-magpie` marketplace definition is left
+  alone; missing floor members are added to an existing `enabledPlugins` and
+  **nothing is ever removed**; invalid JSON stops the operation.
+- **Setup may `git add`; setup never commits.**
+- **The shared pre-flight is not modified by this subsystem.** A missing block
+  must never read as an unadopted repo.
+- **No Python helper.** No step may add a tool the adopter would need
+  installed.
+- Every markdown file needs the SPDX header, doctoc markers, language tags on
+  fenced code (MD040) and resolvable internal anchors (MD051).
+- Commit messages must end with a `Generated-by:` trailer — a repo hook
+  rejects commits without one.
+- Signed commits fail inside the agent sandbox with
+  `No private key found for public key ...`. That is the sandbox denying reads
+  under `~/.ssh`, not a missing key; retry the same `git commit` with the
+  sandbox disabled.
+- Eval `--cli` mode needs credentials the sandbox blocks. Run print mode inside
+  the sandbox; run `--cli "claude -p"` outside it.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `skills/setup/install.md` (modify, Step M5) | The offer, the harness gate, and the merge rules the agent follows |
+| `skills/setup/verify.md` (modify) | Staleness reporting for a block that exists |
+| `skills/setup/uninstall.md` (modify) | Removing only the keys setup added |
+| `tools/skill-evals/evals/setup/` (create) | The behavioural test suite for all of the above |
+| `docs/quick-start.md` (modify) | Reader-facing explanation of the optional committed set |
+| `docs/setup/marketplaces.md` (modify) | Reference-side pointer that setup can write the block |
+| `tools/spec-loop/specs/adoption-and-setup.md` (modify) | Acceptance criteria |
+
+---
+
+### Task 1: The Step M5 offer and the harness gate
+
+**Files:**
+- Create: `tools/skill-evals/evals/setup/README.md`
+- Create: `tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/step-config.json`
+- Create: `tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md`
+- Create: `tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/user-prompt-template.md`
+- Create: `tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-{1..4}-*/{case-meta.json,report.md,expected.json}`
+- Modify: `skills/setup/install.md` — the `### Step M5 — Recap and what comes next` section
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the heading `### Step M5 — Recap and what comes next` keeps its
+  exact text (Task 2's `step-config.json` and the existing cross-links depend
+  on it), and a new `#### Merge rules` subsection anchor that Task 2 targets.
+
+- [ ] **Step 1: Write the eval step config**
+
+`tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/step-config.json`:
+
+```json
+{
+  "skill_md": "skills/setup/install.md",
+  "step_heading": "### Step M5 — Recap and what comes next"
+}
+```
+
+- [ ] **Step 2: Write the output spec**
+
+`tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md`:
+
+````markdown
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "offer_made": true | false,
+  "offer_default": "no" | "yes",
+  "artefacts_offered": ["settings-block", "config-store"],
+  "install_complete_without": true | false
+}
+```
+
+`offer_made` is `true` only when the detected agent is Claude Code. Codex CLI,
+Gemini CLI, VS Code / Copilot and any other client cannot express a committed
+per-family default set, so `offer_made` is `false` and `artefacts_offered` is
+`[]`.
+
+`offer_default` is `"no"` whenever an offer is made: the block is optional and
+is never written without the user asking for it.
+
+`artefacts_offered` lists both repo-side artefacts when an offer is made —
+`"settings-block"` and `"config-store"` — in that order.
+
+`install_complete_without` is always `true`. A marketplace install that writes
+nothing to the repo is a finished, working install; declining the offer, or
+being on a harness that cannot take it, never makes the install partial.
+
+Do not include any text outside the JSON object.
+````
+
+- [ ] **Step 3: Write the user-prompt template**
+
+`tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/user-prompt-template.md`:
+
+```markdown
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Install state
+
+{report}
+
+You are at Step M5 of the marketplace install. Decide whether to offer the
+repo-side artefacts, what the offer's default is, and whether the install is
+complete without them. Return JSON only.
+```
+
+- [ ] **Step 4: Write the four cases**
+
+`case-1-claude-code-fresh/report.md`:
+
+```markdown
+Agent detected: Claude Code.
+Plugins just installed: magpie-setup, magpie-pr-management (marketplace apache-magpie, tracking main).
+Repo root has no `.claude/settings.json`.
+Repo root has no `.apache-magpie-overrides/` directory.
+No `.apache-magpie.lock` present.
+```
+
+`case-1-claude-code-fresh/expected.json`:
+
+```json
+{"offer_made": true, "offer_default": "no", "artefacts_offered": ["settings-block", "config-store"], "install_complete_without": true}
+```
+
+`case-2-codex/report.md`:
+
+```markdown
+Agent detected: OpenAI Codex CLI.
+Plugins just installed: magpie (all-in-one, marketplace apache-magpie).
+Repo root has no `.claude/settings.json`.
+No `.apache-magpie.lock` present.
+```
+
+`case-2-codex/expected.json`:
+
+```json
+{"offer_made": false, "offer_default": "no", "artefacts_offered": [], "install_complete_without": true}
+```
+
+`case-3-gemini/report.md`:
+
+```markdown
+Agent detected: Google Gemini CLI.
+Extension just installed: magpie.
+Repo root has no `.claude/settings.json`.
+No `.apache-magpie.lock` present.
+```
+
+`case-3-gemini/expected.json`:
+
+```json
+{"offer_made": false, "offer_default": "no", "artefacts_offered": [], "install_complete_without": true}
+```
+
+`case-4-claude-code-declined/report.md`:
+
+```markdown
+Agent detected: Claude Code.
+Plugins just installed: magpie-setup, magpie-security.
+The user was offered the committed default set and the config store, and declined both.
+Repo root has no `.claude/settings.json`.
+```
+
+`case-4-claude-code-declined/expected.json`:
+
+```json
+{"offer_made": true, "offer_default": "no", "artefacts_offered": ["settings-block", "config-store"], "install_complete_without": true}
+```
+
+Each case also needs `case-meta.json`:
+
+```json
+{"tags":["local-smoke","smoke"]}
+```
+
+- [ ] **Step 5: Run the evals to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/
+```
+
+Expected: FAIL on all four cases. Step M5 currently describes the artefacts as
+things the install "deliberately does not set up", so a model reading it will
+not report an offer with a default.
+
+Run this outside the agent sandbox — `claude -p` needs credentials the sandbox
+blocks, and a blocked run reports ERROR rather than FAIL.
+
+- [ ] **Step 6: Rewrite Step M5's fourth bullet as the offer**
+
+In `skills/setup/install.md`, in `### Step M5 — Recap and what comes next`,
+replace the `project-wide agentic overrides` bullet with:
+
+```markdown
+5. **Offer the repo-side artefacts — optional, once, defaulting to no.**
+   **Claude Code only**; skip this entirely on any other client and say why
+   (Codex can only default-install all ten families; Gemini has no
+   workspace-extension mechanism), rather than writing a file that does
+   nothing.
+
+   Ask one question covering both artefacts:
+
+   - **A committed default set** — `extraKnownMarketplaces` plus an
+     `enabledPlugins` floor of `magpie-setup`, `magpie-utilities` and
+     `magpie-agent-guard` in the repo's `.claude/settings.json`, so a teammate
+     who clones and trusts the repo arrives with those three enabled.
+   - **The config store** — `.apache-magpie-overrides/`, scaffolded exactly as
+     [Step 9](#step-9--scaffold-apache-magpie-overrides-fresh-only) does, same
+     exclusions and same `project.md` pre-population.
+
+   Say in the prompt that **both are optional and neither is required to use
+   the plugins in this repo** — they are a convenience for teammates. Default
+   to **no**.
+
+   The floor is fixed. It does not grow to match what this maintainer
+   installed: a maintainer-only family such as `magpie-security` stays a
+   personal, user-scope install.
+
+   `git add` what you write. Never commit.
+
+   **Declining is a finished install.** Do not describe the result as
+   incomplete, partial, or pending in the recap or anywhere else.
+```
+
+- [ ] **Step 7: Run the evals to verify they pass**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/
+```
+
+Expected: PASS on all four cases.
+
+- [ ] **Step 8: Run the hooks**
+
+Run: `prek run --files skills/setup/install.md $(git diff --name-only --cached)`
+
+Expected: all hooks pass. `check-doc-sync` and `markdownlint` are the two most
+likely to object — the first if a cross-reference count moved, the second on an
+unresolvable anchor in the new bullet.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add skills/setup/install.md tools/skill-evals/evals/setup/
+git commit -m "feat(setup): offer the committed default set on the marketplace path
+
+Claude Code only, opt-in, defaulting to no. Both repo-side artefacts —
+the enabledPlugins floor and the config store — are offered in one
+question, and declining leaves a finished install.
+
+Generated-by: Claude Opus 5"
+```
+
+---
+
+### Task 2: Merge rules for `.claude/settings.json`
+
+**Files:**
+- Create: `tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/step-config.json`
+- Create: `tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md`
+- Create: `tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/user-prompt-template.md`
+- Create: `tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-{1..5}-*/{case-meta.json,report.md,expected.json}`
+- Modify: `skills/setup/install.md` — add `#### Merge rules` under Step M5
+
+**Interfaces:**
+- Consumes: the `### Step M5 — Recap and what comes next` section and its
+  offer text from Task 1.
+- Produces: a `#### Merge rules` heading, targeted verbatim by this task's
+  `step-config.json`.
+
+- [ ] **Step 1: Write the eval step config**
+
+```json
+{
+  "skill_md": "skills/setup/install.md",
+  "step_heading": "#### Merge rules"
+}
+```
+
+- [ ] **Step 2: Write the output spec**
+
+`output-spec.md` body, after the SPDX header:
+
+````markdown
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "action": "create" | "merge" | "refuse",
+  "keys_preserved": ["<key>", "..."],
+  "plugins_added": ["<plugin@marketplace>", "..."],
+  "plugins_removed": [],
+  "marketplace_definition_changed": true | false
+}
+```
+
+`action` is `"create"` when no `.claude/settings.json` exists, `"merge"` when
+one exists and parses as JSON, and `"refuse"` when one exists but does not
+parse — a malformed file is reported, never rewritten.
+
+`keys_preserved` lists every top-level key already in the file that is not
+`extraKnownMarketplaces` or `enabledPlugins`, in the order they appear. On
+`"create"` it is `[]`.
+
+`plugins_added` lists only the floor members not already enabled, in floor
+order: `magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie`,
+`magpie-agent-guard@apache-magpie`.
+
+`plugins_removed` is always `[]`. Nothing is ever removed from an existing
+`enabledPlugins`, including non-Magpie plugins and Magpie plugins outside the
+floor.
+
+`marketplace_definition_changed` is `false` when `extraKnownMarketplaces`
+already defines `apache-magpie` — an adopter pinning a tag has made a
+deliberate choice — and `true` only when the definition is being added for the
+first time.
+
+Do not include any text outside the JSON object.
+````
+
+- [ ] **Step 3: Write the user-prompt template**
+
+```markdown
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Current `.claude/settings.json`
+
+{report}
+
+The user accepted the offer to commit the default set. Decide how to write it.
+Return JSON only.
+```
+
+- [ ] **Step 4: Write the five cases**
+
+`case-1-no-file/report.md`:
+
+```markdown
+No `.claude/settings.json` exists in the repo root.
+```
+
+`case-1-no-file/expected.json`:
+
+```json
+{"action": "create", "keys_preserved": [], "plugins_added": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": true}
+```
+
+`case-2-other-keys/report.md`:
+
+```markdown
+`.claude/settings.json` exists and parses as JSON. Its top-level keys, in order:
+`$schema`, `sandbox`, `permissions`. It has no `extraKnownMarketplaces` and no
+`enabledPlugins`.
+```
+
+`case-2-other-keys/expected.json`:
+
+```json
+{"action": "merge", "keys_preserved": ["$schema", "sandbox", "permissions"], "plugins_added": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": true}
+```
+
+`case-3-existing-plugins/report.md`:
+
+```markdown
+`.claude/settings.json` exists and parses as JSON. Top-level keys, in order:
+`permissions`, `enabledPlugins`. `enabledPlugins` currently contains
+`magpie-setup@apache-magpie: true`, `magpie-security@apache-magpie: true` and
+`some-other-plugin@vendor-marketplace: true`. There is no
+`extraKnownMarketplaces`.
+```
+
+`case-3-existing-plugins/expected.json`:
+
+```json
+{"action": "merge", "keys_preserved": ["permissions"], "plugins_added": ["magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": true}
+```
+
+`case-4-pinned-marketplace/report.md`:
+
+```markdown
+`.claude/settings.json` exists and parses as JSON. Top-level keys, in order:
+`extraKnownMarketplaces`, `enabledPlugins`. `extraKnownMarketplaces` defines
+`apache-magpie` with `{"source": {"source": "github", "repo": "apache/magpie@0.2.0"}}`.
+`enabledPlugins` contains `magpie-setup@apache-magpie: true`.
+```
+
+`case-4-pinned-marketplace/expected.json`:
+
+```json
+{"action": "merge", "keys_preserved": [], "plugins_added": ["magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": false}
+```
+
+`case-5-malformed/report.md`:
+
+```markdown
+`.claude/settings.json` exists but does not parse: it ends mid-object after a
+trailing comma on the `permissions` key.
+```
+
+`case-5-malformed/expected.json`:
+
+```json
+{"action": "refuse", "keys_preserved": [], "plugins_added": [], "plugins_removed": [], "marketplace_definition_changed": false}
+```
+
+Each case needs `case-meta.json` with `{"tags":["local-smoke","smoke"]}`.
+
+- [ ] **Step 5: Run the evals to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/
+```
+
+Expected: ERROR with `Heading '#### Merge rules' not found in
+skills/setup/install.md` — the section does not exist yet.
+
+- [ ] **Step 6: Write the merge rules**
+
+Append to `### Step M5 — Recap and what comes next` in `skills/setup/install.md`:
+
+```markdown
+#### Merge rules
+
+`.claude/settings.json` is not Magpie's file. This repository's own carries
+`sandbox` and `permissions` blocks; an adopter's will carry whatever they put
+there. When the user accepts the offer:
+
+- **Touch only two keys** — `extraKnownMarketplaces` and `enabledPlugins`.
+  Every other top-level key is preserved exactly as it was.
+- **Leave an existing `apache-magpie` marketplace definition alone.** An
+  adopter pinning `apache/magpie@0.2.0` has made a deliberate choice; do not
+  rewrite it to track `main`.
+- **Add missing floor members to an existing `enabledPlugins`, and remove
+  nothing** — not other Magpie plugins, not other vendors' plugins.
+- **If the file does not exist**, create it with those two keys and nothing
+  else.
+- **If the file exists but does not parse as JSON, stop and say so.** Do not
+  rewrite a file you cannot read; a malformed settings file is the user's to
+  fix.
+
+Then `git add .claude/settings.json`. Never commit it.
+```
+
+- [ ] **Step 7: Run the evals to verify they pass**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/
+```
+
+Expected: PASS on all five cases. Case 5 is the one most likely to fail first —
+if the model reports `"merge"` for malformed JSON, the refuse rule needs to be
+stated earlier in the section, not last.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add skills/setup/install.md tools/skill-evals/evals/setup/
+git commit -m "feat(setup): merge-never-clobber rules for the committed default set
+
+Only extraKnownMarketplaces and enabledPlugins are touched; an existing
+apache-magpie definition is left alone; floor members are added and
+nothing is removed; a malformed file is reported, never rewritten.
+
+Generated-by: Claude Opus 5"
+```
+
+---
+
+### Task 3: `verify` reports a stale block; absent is not a fault
+
+**Files:**
+- Create: `tools/skill-evals/evals/setup/verify-default-set/fixtures/{step-config.json,output-spec.md,user-prompt-template.md}`
+- Create: `tools/skill-evals/evals/setup/verify-default-set/fixtures/case-{1..3}-*/{case-meta.json,report.md,expected.json}`
+- Modify: `skills/setup/verify.md`
+
+**Interfaces:**
+- Consumes: the floor definition from Task 1.
+- Produces: a `## Committed default set` heading in `verify.md`, targeted by
+  this task's `step-config.json`.
+
+- [ ] **Step 1: Write the eval step config**
+
+```json
+{
+  "skill_md": "skills/setup/verify.md",
+  "step_heading": "## Committed default set"
+}
+```
+
+- [ ] **Step 2: Write the output spec**
+
+`output-spec.md` body, after the SPDX header:
+
+````markdown
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "status": "absent" | "current" | "stale",
+  "is_fault": true | false,
+  "missing": ["<plugin@marketplace>", "..."]
+}
+```
+
+`status` is `"absent"` when the repo commits no `enabledPlugins` block,
+`"current"` when it commits all three floor members, and `"stale"` when it
+commits some but not all of them.
+
+`is_fault` is `true` **only** for `"stale"`. An absent block is a supported,
+deliberate end state — the committed default set is optional and is not
+required to use the plugins — so `"absent"` is reported informationally and
+never counted as a failed check.
+
+`missing` lists the floor members not present, in floor order. It is `[]` for
+`"current"`, and `[]` for `"absent"` — there is no block to be missing members
+from.
+
+Do not include any text outside the JSON object.
+````
+
+- [ ] **Step 3: Write the user-prompt template**
+
+```markdown
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Repo state
+
+{report}
+
+You are running the committed-default-set check of `setup verify`. Report its
+status. Return JSON only.
+```
+
+- [ ] **Step 4: Write the three cases**
+
+`case-1-absent/report.md`:
+
+```markdown
+`.claude/settings.json` exists with `sandbox` and `permissions` keys. It has no
+`enabledPlugins` key. The user has magpie-setup and magpie-pr-management
+installed at user scope.
+```
+
+`case-1-absent/expected.json`:
+
+```json
+{"status": "absent", "is_fault": false, "missing": []}
+```
+
+`case-2-current/report.md`:
+
+```markdown
+`.claude/settings.json` commits `enabledPlugins` with
+`magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie` and
+`magpie-agent-guard@apache-magpie`, all `true`.
+```
+
+`case-2-current/expected.json`:
+
+```json
+{"status": "current", "is_fault": false, "missing": []}
+```
+
+`case-3-stale/report.md`:
+
+```markdown
+`.claude/settings.json` commits `enabledPlugins` with
+`magpie-setup@apache-magpie: true` and `magpie-utilities@apache-magpie: true`.
+There is no `magpie-agent-guard@apache-magpie` entry.
+```
+
+`case-3-stale/expected.json`:
+
+```json
+{"status": "stale", "is_fault": true, "missing": ["magpie-agent-guard@apache-magpie"]}
+```
+
+Each case needs `case-meta.json` with `{"tags":["local-smoke","smoke"]}`.
+
+- [ ] **Step 5: Run the evals to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/verify-default-set/fixtures/
+```
+
+Expected: ERROR with `Heading '## Committed default set' not found in
+skills/setup/verify.md`.
+
+- [ ] **Step 6: Write the verify check**
+
+Add to `skills/setup/verify.md`:
+
+```markdown
+## Committed default set
+
+Read `.claude/settings.json` at the repo root and compare its `enabledPlugins`
+against the floor: `magpie-setup@apache-magpie`,
+`magpie-utilities@apache-magpie`, `magpie-agent-guard@apache-magpie`.
+
+- **No `enabledPlugins` key** — report it in one line as available but not in
+  use, and move on. **This is not a fault.** The committed default set is
+  optional and is not required to use the plugins in this repo; a project that
+  never took the offer, or took it and later removed it, is correctly
+  configured. Do not count it as a failed check, and do not re-offer it here —
+  `setup` is where the offer lives.
+- **All three present** — report current.
+- **Some but not all present** — report drift, name the missing members, and
+  offer to add them under the merge rules in
+  [`install.md`](install.md#merge-rules). This is the case a framework release
+  that changes the floor produces.
+- **A member naming a plugin the marketplace no longer ships** — report it the
+  same way and offer to drop that entry.
+```
+
+- [ ] **Step 7: Run the evals to verify they pass**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/verify-default-set/fixtures/
+```
+
+Expected: PASS on all three cases. Case 1 is the one that matters — a model
+reporting `is_fault: true` for an absent block means the optionality is not
+stated strongly enough.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add skills/setup/verify.md tools/skill-evals/evals/setup/
+git commit -m "feat(setup): verify reports a stale committed default set
+
+An absent block is reported informationally and is never a fault — the
+committed set is optional. A block missing floor members is drift, with
+a repair offer.
+
+Generated-by: Claude Opus 5"
+```
+
+---
+
+### Task 4: `uninstall` removes only what it added
+
+**Files:**
+- Create: `tools/skill-evals/evals/setup/uninstall-default-set/fixtures/{step-config.json,output-spec.md,user-prompt-template.md}`
+- Create: `tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-{1,2}-*/{case-meta.json,report.md,expected.json}`
+- Modify: `skills/setup/uninstall.md`
+
+**Interfaces:**
+- Consumes: the floor definition from Task 1 and the merge rules from Task 2.
+- Produces: a `## Committed default set` heading in `uninstall.md`.
+
+- [ ] **Step 1: Write the eval step config**
+
+```json
+{
+  "skill_md": "skills/setup/uninstall.md",
+  "step_heading": "## Committed default set"
+}
+```
+
+- [ ] **Step 2: Write the output spec**
+
+`output-spec.md` body, after the SPDX header:
+
+````markdown
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "plugins_removed": ["<plugin@marketplace>", "..."],
+  "plugins_kept": ["<plugin@marketplace>", "..."],
+  "keys_preserved": ["<key>", "..."],
+  "file_deleted": false
+}
+```
+
+`plugins_removed` lists only the floor members setup added, in floor order.
+
+`plugins_kept` lists every other entry in `enabledPlugins` — Magpie plugins
+outside the floor and other vendors' plugins alike. Uninstall removes what it
+added and nothing else.
+
+`keys_preserved` lists every top-level key other than `enabledPlugins` and
+`extraKnownMarketplaces`.
+
+`file_deleted` is always `false`. `.claude/settings.json` belongs to the
+project, not to Magpie; uninstall empties its own keys and leaves the file.
+
+Do not include any text outside the JSON object.
+````
+
+- [ ] **Step 3: Write the user-prompt template**
+
+```markdown
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Current `.claude/settings.json`
+
+{report}
+
+You are uninstalling Magpie from this repo. Decide what to remove from the
+settings file. Return JSON only.
+```
+
+- [ ] **Step 4: Write the two cases**
+
+`case-1-floor-only/report.md`:
+
+```markdown
+Top-level keys, in order: `$schema`, `sandbox`, `extraKnownMarketplaces`,
+`enabledPlugins`. `enabledPlugins` contains exactly the three floor members,
+all `true`.
+```
+
+`case-1-floor-only/expected.json`:
+
+```json
+{"plugins_removed": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_kept": [], "keys_preserved": ["$schema", "sandbox"], "file_deleted": false}
+```
+
+`case-2-mixed/report.md`:
+
+```markdown
+Top-level keys, in order: `permissions`, `enabledPlugins`. `enabledPlugins`
+contains the three floor members plus `magpie-security@apache-magpie: true` and
+`some-other-plugin@vendor-marketplace: true`.
+```
+
+`case-2-mixed/expected.json`:
+
+```json
+{"plugins_removed": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_kept": ["magpie-security@apache-magpie", "some-other-plugin@vendor-marketplace"], "keys_preserved": ["permissions"], "file_deleted": false}
+```
+
+Each case needs `case-meta.json` with `{"tags":["local-smoke","smoke"]}`.
+
+- [ ] **Step 5: Run the evals to verify they fail**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/uninstall-default-set/fixtures/
+```
+
+Expected: ERROR with `Heading '## Committed default set' not found in
+skills/setup/uninstall.md`.
+
+- [ ] **Step 6: Write the uninstall step**
+
+Add to `skills/setup/uninstall.md`:
+
+```markdown
+## Committed default set
+
+If `.claude/settings.json` commits the block, remove **only** what setup added:
+
+- Delete the three floor entries from `enabledPlugins` —
+  `magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie`,
+  `magpie-agent-guard@apache-magpie`. Keep every other entry, including Magpie
+  plugins outside the floor and other vendors' plugins.
+- Delete the `apache-magpie` entry from `extraKnownMarketplaces`, keeping any
+  other marketplace.
+- If either key is left empty, remove the empty key.
+- **Never delete the file** and never touch any other top-level key. The
+  settings file belongs to the project.
+
+This mirrors the existing rule that `.apache-magpie-overrides/` is preserved by
+default: uninstall reverses Magpie's own additions, not the project's
+configuration.
+```
+
+- [ ] **Step 7: Run the evals to verify they pass**
+
+Run:
+
+```bash
+PYTHONPATH=tools/skill-evals/src python3 -m skill_evals.runner --cli "claude -p" \
+    tools/skill-evals/evals/setup/uninstall-default-set/fixtures/
+```
+
+Expected: PASS on both cases.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add skills/setup/uninstall.md tools/skill-evals/evals/setup/
+git commit -m "feat(setup): uninstall removes only the floor it added
+
+Other plugins in enabledPlugins survive, other marketplaces survive, the
+settings file is never deleted.
+
+Generated-by: Claude Opus 5"
+```
+
+---
+
+### Task 5: Documentation
+
+**Files:**
+- Modify: `docs/quick-start.md` — new subsection under `### Claude Code`
+- Modify: `docs/setup/marketplaces.md` — the `### Claude Code: the default set` section
+
+**Interfaces:**
+- Consumes: the behaviour from Tasks 1–4.
+- Produces: no anchors other tasks depend on.
+
+- [ ] **Step 1: Add the quick-start subsection**
+
+After the Claude Code install block in `docs/quick-start.md`, add:
+
+```markdown
+#### Optional: commit a default set for your teammates
+
+Everything above installs Magpie for **you, on this machine** — nothing is
+written to the repository, and your teammates are unaffected.
+
+A project can go one step further and commit a small block to its
+`.claude/settings.json` naming the marketplace and three plugins, so anyone who
+clones the repo and trusts it arrives with `magpie-setup`, `magpie-utilities`
+and `magpie-agent-guard` already enabled. `/magpie-setup` offers to write it —
+see [the default set](setup/marketplaces.md#claude-code-the-default-set).
+
+**This is entirely optional.** The plugins work in the repo whether or not the
+block is committed, and a project that never commits it is not missing
+anything: the install you just did is complete. It is a convenience for
+teams — nobody has to run the install by hand — not a requirement.
+```
+
+- [ ] **Step 2: Add the marketplaces.md pointer**
+
+In `docs/setup/marketplaces.md`, immediately after the JSON block in
+`### Claude Code: the default set`, add:
+
+```markdown
+> [!TIP]
+> `/magpie-setup` offers to write this block for you at the end of a
+> marketplace install, and `/magpie-setup verify` reports it if it falls
+> behind a later release's floor. Both are opt-in: the block is a convenience
+> for teammates, never a prerequisite, and declining leaves a complete,
+> working install.
+```
+
+- [ ] **Step 3: Run the hooks**
+
+Run:
+
+```bash
+prek run --files docs/quick-start.md docs/setup/marketplaces.md
+```
+
+Expected: all pass. `doctoc` will rewrite both TOCs to include the new
+headings — stage the result. `markdownlint` MD051 will fail if the
+`setup/marketplaces.md#claude-code-the-default-set` anchor is wrong; confirm it
+against the heading text.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/quick-start.md docs/setup/marketplaces.md
+git commit -m "docs: explain the optional committed default set
+
+Says plainly in both places that committing the block is optional and
+that the plugins work in the repo either way.
+
+Generated-by: Claude Opus 5"
+```
+
+---
+
+### Task 6: Spec-loop acceptance criteria
+
+**Files:**
+- Modify: `tools/spec-loop/specs/adoption-and-setup.md` — the `acceptance:` list
+
+**Interfaces:**
+- Consumes: the behaviour from Tasks 1–4.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the acceptance criteria**
+
+Append to the `acceptance:` list in the frontmatter of
+`tools/spec-loop/specs/adoption-and-setup.md`:
+
+```yaml
+  - A marketplace install on Claude Code offers once, opt-in and defaulting to
+    no, to commit the default-set block and scaffold the config store; the
+    offer states that both are optional and that the plugins work in the repo
+    either way.
+  - Declining the offer, or running on a harness that cannot express it,
+    leaves a complete install; neither the recap nor verify describes the
+    result as incomplete or partial.
+  - Writing the block preserves every other key in an existing
+    .claude/settings.json, leaves an existing apache-magpie marketplace
+    definition alone, adds only missing floor members to an existing
+    enabledPlugins, removes nothing, and refuses to rewrite a settings file
+    that does not parse.
+  - verify reports a committed block that is missing floor members as drift
+    with a repair offer, and reports an absent block informationally without
+    counting it as a fault.
+  - uninstall removes only the floor entries and the apache-magpie marketplace
+    entry, keeps every other plugin and marketplace, and never deletes
+    .claude/settings.json.
+```
+
+- [ ] **Step 2: Validate the spec**
+
+Run:
+
+```bash
+prek run spec-validate --files tools/spec-loop/specs/adoption-and-setup.md
+```
+
+Expected: PASS. The hook checks frontmatter shape and required sections; a YAML
+indentation slip in the appended list is the likely failure.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/spec-loop/specs/adoption-and-setup.md
+git commit -m "spec(adoption): acceptance criteria for the committed default set
+
+Generated-by: Claude Opus 5"
+```

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -1,0 +1,29 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Designs](#designs)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+# Designs
+
+Design documents for changes that are in flight or recently landed. Each one
+records what was decided and, more usefully, what was rejected and why — the
+alternatives section is the part that saves the next person the argument.
+
+A design here is not a promise that the work shipped as described. Each
+carries a status line; read that first.
+
+| Design | Status |
+|---|---|
+| [Repo-committed setup: default plugin set and per-skill first-run configuration](2026-09-10-repo-committed-setup-design.md) | Subsystem A implemented; B and C not started |
+| [Subsystem A implementation plan](2026-09-10-repo-committed-setup-plan-a.md) | Complete |
+
+These sit outside [`tools/spec-loop/specs/`](../../tools/spec-loop/specs/),
+which is the durable record of what the framework guarantees. A design argues
+for a change; a spec states what the shipped system does. When the two
+disagree, the spec is right.

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,6 +133,7 @@ from mailing lists, slack etc.
 | Set up the secure agent sandbox | [setup/](setup/README.md) |
 | Understand the security workflow | [security/](security/README.md) |
 | Know what it costs to run | [mode-economics.md](mode-economics.md) |
+| Read the design behind a change in flight | [designs/](designs/README.md) |
 | Understand the privacy model | [rfcs/RFC-AI-0003.md](rfcs/RFC-AI-0003.md) |
 | Contribute to the framework | [CONTRIBUTING.md](../CONTRIBUTING.md) |
 | Learn to build and extend skills | [education/](education/README.md) |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -99,6 +99,22 @@ command for that family and a few things to try once it is in:
 <!-- CAPTURE: assets/quickstart/README.md -->
 ![Claude Code after installing two family plugins — `magpie-setup` and `magpie-pr-management` listed as installed and enabled](../assets/quickstart/claude-code-install.png)
 
+#### Optional: commit a default set for your teammates
+
+Everything above installs Magpie for **you, on this machine** — nothing is
+written to the repository, and your teammates are unaffected.
+
+A project can go one step further and commit a small block to its
+`.claude/settings.json` naming the marketplace and three plugins, so anyone who
+clones the repo and trusts it arrives with `magpie-setup`, `magpie-utilities`
+and `magpie-agent-guard` already enabled. `/magpie-setup` offers to write it —
+see [the default set](setup/marketplaces.md#claude-code-the-default-set).
+
+**This is entirely optional.** The plugins work in the repo whether or not the
+block is committed, and a project that never commits it is not missing
+anything: the install you just did is complete. It is a convenience for
+teams — nobody has to run the install by hand — not a requirement.
+
 ### OpenAI Codex CLI
 
 ```bash

--- a/docs/setup/marketplaces.md
+++ b/docs/setup/marketplaces.md
@@ -556,6 +556,13 @@ everyone who trusts the repo:
 }
 ```
 
+> [!TIP]
+> `/magpie-setup` offers to write this block for you at the end of a
+> marketplace install, and `/magpie-setup verify` reports it if it falls
+> behind a later release's floor. Both are opt-in: the block is a convenience
+> for teammates, never a prerequisite, and declining leaves a complete,
+> working install.
+
 Three plugins, for two different reasons.
 
 `setup` and `utilities` are the framework's two **always-on families** — the

--- a/skills/setup/install.md
+++ b/skills/setup/install.md
@@ -253,6 +253,27 @@ Tell the user, in this order:
 
 Then stop. Do not continue into Step 0.
 
+#### Merge rules
+
+`.claude/settings.json` is not Magpie's file. This repository's own carries
+`sandbox` and `permissions` blocks; an adopter's will carry whatever they put
+there. When the user accepts the offer:
+
+- **Touch only two keys** — `extraKnownMarketplaces` and `enabledPlugins`.
+  Every other top-level key is preserved exactly as it was.
+- **Leave an existing `apache-magpie` marketplace definition alone.** An
+  adopter pinning `apache/magpie@0.2.0` has made a deliberate choice; do not
+  rewrite it to track `main`.
+- **Add missing floor members to an existing `enabledPlugins`, and remove
+  nothing** — not other Magpie plugins, not other vendors' plugins.
+- **If the file does not exist**, create it with those two keys and nothing
+  else.
+- **If the file exists but does not parse as JSON, stop and say so.** Do not
+  rewrite a file you cannot read; a malformed settings file is the user's to
+  fix.
+
+Then `git add .claude/settings.json`. Never commit it.
+
 ## Step 0 — Pre-flight
 
 **This pre-flight is the snapshot path's.** The marketplace path

--- a/skills/setup/install.md
+++ b/skills/setup/install.md
@@ -268,13 +268,16 @@ there. When the user accepts the offer:
   `enabledPlugins`, and remove nothing** — not other Magpie plugins, not
   other vendors' plugins. The floor is `magpie-setup@apache-magpie`,
   `magpie-utilities@apache-magpie`, `magpie-agent-guard@apache-magpie`.
-- **If the file does not exist**, create it with those two keys and nothing
-  else.
+- **If the file does not exist**, create it with exactly those two keys:
+  `extraKnownMarketplaces` defining `apache-magpie`, and `enabledPlugins`
+  containing the floor.
 - **If the file exists but does not parse as JSON, stop and say so.** Do not
   rewrite a file you cannot read; a malformed settings file is the user's to
   fix.
 
-Then `git add .claude/settings.json`. Never commit it.
+When you write the file — creating it or merging into it — `git add
+.claude/settings.json`. Never commit it. When you refuse because the file
+doesn't parse, nothing was written; stop without staging anything.
 
 ## Step 0 — Pre-flight
 

--- a/skills/setup/install.md
+++ b/skills/setup/install.md
@@ -264,8 +264,10 @@ there. When the user accepts the offer:
 - **Leave an existing `apache-magpie` marketplace definition alone.** An
   adopter pinning `apache/magpie@0.2.0` has made a deliberate choice; do not
   rewrite it to track `main`.
-- **Add missing floor members to an existing `enabledPlugins`, and remove
-  nothing** — not other Magpie plugins, not other vendors' plugins.
+- **Add whichever of the floor's three entries are missing from an existing
+  `enabledPlugins`, and remove nothing** — not other Magpie plugins, not
+  other vendors' plugins. The floor is `magpie-setup@apache-magpie`,
+  `magpie-utilities@apache-magpie`, `magpie-agent-guard@apache-magpie`.
 - **If the file does not exist**, create it with those two keys and nothing
   else.
 - **If the file exists but does not parse as JSON, stop and say so.** Do not

--- a/skills/setup/install.md
+++ b/skills/setup/install.md
@@ -219,16 +219,37 @@ Tell the user, in this order:
    - the **committed version pin** and drift detection — add the
      [pinned snapshot install](#step-0--pre-flight) when the
      project wants every contributor and CI job on one version;
-   - **project-wide agentic overrides** — a marketplace-installed
-     skill still reads `.apache-magpie-overrides/<skill>.md` from
-     the repo at run time, so if the project wants them, offer to
-     scaffold that directory now
-     ([Step 9](#step-9--scaffold-apache-magpie-overrides-fresh-only))
-     and nothing else; it is the one repo-side artefact that is
-     useful without the snapshot;
    - **personal overrides** — `.apache-magpie-local/` works in any
      repo, adopted or not, once its `.gitignore` line exists;
      offer to add that single line.
+5. **Offer the repo-side artefacts — optional, once, defaulting to no.**
+   **Claude Code only**; skip this entirely on any other client and say why
+   (Codex can only default-install all ten families; Gemini has no
+   workspace-extension mechanism), rather than writing a file that does
+   nothing.
+
+   Ask one question covering both artefacts:
+
+   - **A committed default set** — `extraKnownMarketplaces` plus an
+     `enabledPlugins` floor of `magpie-setup`, `magpie-utilities` and
+     `magpie-agent-guard` in the repo's `.claude/settings.json`, so a teammate
+     who clones and trusts the repo arrives with those three enabled.
+   - **The config store** — `.apache-magpie-overrides/`, scaffolded exactly as
+     [Step 9](#step-9--scaffold-apache-magpie-overrides-fresh-only) does, same
+     exclusions and same `project.md` pre-population.
+
+   Say in the prompt that **both are optional and neither is required to use
+   the plugins in this repo** — they are a convenience for teammates. Default
+   to **no**.
+
+   The floor is fixed. It does not grow to match what this maintainer
+   installed: a maintainer-only family such as `magpie-security` stays a
+   personal, user-scope install.
+
+   `git add` what you write. Never commit.
+
+   **Declining is a finished install.** Do not describe the result as
+   incomplete, partial, or pending in the recap or anywhere else.
 
 Then stop. Do not continue into Step 0.
 

--- a/skills/setup/uninstall.md
+++ b/skills/setup/uninstall.md
@@ -334,6 +334,29 @@ Each step is independently surfaced as it runs (one
 `✓ Removed <path>` line per artefact), so a mid-flow abort
 leaves a clean record of what made it out.
 
+## Committed default set
+
+If `.claude/settings.json` commits the block described in
+[`install.md` § Merge rules](install.md#merge-rules), remove **only** what
+`setup` added:
+
+- Delete the three floor entries from `enabledPlugins` —
+  `magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie`,
+  `magpie-agent-guard@apache-magpie`, in that order. Keep every other entry
+  untouched, whether it is a Magpie plugin outside the floor or another
+  vendor's plugin.
+- Delete the `apache-magpie` entry from `extraKnownMarketplaces`. Keep any
+  other marketplace entry untouched.
+- If removing its members leaves `enabledPlugins` or
+  `extraKnownMarketplaces` empty, remove that now-empty key too.
+- **Never delete `.claude/settings.json` itself, and never touch any
+  top-level key other than these two.** The settings file belongs to the
+  project, not to Magpie.
+
+This mirrors the existing rule that `.apache-magpie-overrides/` is preserved
+by default: uninstall reverses Magpie's own additions, not the project's
+configuration.
+
 ## Step 5 — Sanity check
 
 After the deletions, verify the post-state:

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -820,6 +820,34 @@ When `.codex/` is absent this check is skipped — the Codex profile is
 opt-in per runtime; see
 [the Codex adapter](../../docs/adapters/codex.md).
 
+## Committed default set
+
+Read `.claude/settings.json` at the repo root and compare its committed
+`enabledPlugins` block against the floor of three: `magpie-setup@apache-magpie`,
+`magpie-utilities@apache-magpie`, `magpie-agent-guard@apache-magpie`. This
+block is `setup`'s opt-in offer (Claude Code only) to pin that floor in the
+repo; committing it is optional and is not required to use the plugins in
+this repo.
+
+- **No `enabledPlugins` key** — status `absent`. Report it in one line as
+  available but not in use, and move on. **This is not a fault.** A project
+  that never took the offer, or took it and later removed it, is correctly
+  configured. Do not count it as a failed check, and do not re-offer it
+  here — `setup` is where the offer lives.
+- **All three floor members present** — status `current`. Also not a fault.
+- **Some but not all of the three floor members present** — status `stale`.
+  This **is** the only fault this check reports: it is drift, typically
+  produced by a framework release that changed the floor. Name the missing
+  members — the floor entries above that are not present, listed in floor
+  order — and offer to add them under the merge rules in
+  [`install.md`](install.md#merge-rules).
+- **A member naming a plugin the marketplace no longer ships** — report it
+  the same way (as drift, i.e. a fault) and offer to drop that entry.
+
+`absent` and `current` are both correctly-configured end states and are
+reported informationally, never as a failed check; `stale` is the one status
+this check treats as a fault.
+
 ## After the report
 
 If every check is ✓ (or ⚠ on items the adopter has

--- a/skills/setup/verify.md
+++ b/skills/setup/verify.md
@@ -829,24 +829,27 @@ block is `setup`'s opt-in offer (Claude Code only) to pin that floor in the
 repo; committing it is optional and is not required to use the plugins in
 this repo.
 
-- **No `enabledPlugins` key** — status `absent`. Report it in one line as
-  available but not in use, and move on. **This is not a fault.** A project
-  that never took the offer, or took it and later removed it, is correctly
-  configured. Do not count it as a failed check, and do not re-offer it
-  here — `setup` is where the offer lives.
-- **All three floor members present** — status `current`. Also not a fault.
-- **Some but not all of the three floor members present** — status `stale`.
-  This **is** the only fault this check reports: it is drift, typically
-  produced by a framework release that changed the floor. Name the missing
-  members — the floor entries above that are not present, listed in floor
-  order — and offer to add them under the merge rules in
-  [`install.md`](install.md#merge-rules).
-- **A member naming a plugin the marketplace no longer ships** — report it
-  the same way (as drift, i.e. a fault) and offer to drop that entry.
+- **No `enabledPlugins` key** — ✓, status `absent`. Report it in one line
+  as available but not in use, and move on. **This is not a fault.** A
+  project that never took the offer, or took it and later removed it, is
+  correctly configured. Do not count it as a failed check, and do not
+  re-offer it here — `setup` is where the offer lives. There is no block
+  to diff the floor against, so `missing` is empty: the floor's entries
+  are not "missing" from a block that does not exist.
+- **All three floor members present** — ✓, status `current`. Also not a
+  fault.
+- **Some but not all of the three floor members present** — ✗, status
+  `stale`. This is the only case this check treats as a fault: it is
+  drift, typically produced by a framework release that changed the
+  floor. Name the missing members — the floor entries above that are not
+  present, listed in floor order — and offer to add them under the merge
+  rules in [`install.md`](install.md#merge-rules).
+- **A member naming a plugin the marketplace no longer ships** — ✗, same
+  treatment as drift. Offer to drop that entry.
 
-`absent` and `current` are both correctly-configured end states and are
-reported informationally, never as a failed check; `stale` is the one status
-this check treats as a fault.
+The glyph carries the fault rule: ✓ covers both correctly-configured end
+states, absent and current alike; ✗ is reserved for the one state this
+check treats as a fault, stale (and the retired-plugin case above it).
 
 ## After the report
 

--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -11,7 +11,7 @@ Behavioral eval harness for Apache Magpie skills. Each eval suite tests a skill 
 
 Suites are currently implemented for:
 
-- **setup** — 24 cases across 6 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts, step-m5-settings-merge, verify-default-set)
+- **setup** — 26 cases across 7 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts, step-m5-settings-merge, verify-default-set, uninstall-default-set)
 - **setup-isolated-setup-install** — 9 cases across 3 steps (runtime-routing, step-snapshot-drift, step-scope-confirm)
 - **setup-shared-config-sync** — 11 cases across 2 steps (step-3-decide-action, step-5-draft-commit)
 - **pairing-multi-agent-review** — 15 cases across 6 steps (step-1-collect-diff, step-2a-correctness-pass, step-2b-security-pass, step-2c-conventions-pass, step-3-merge-findings, step-4-compose-report)

--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -11,6 +11,7 @@ Behavioral eval harness for Apache Magpie skills. Each eval suite tests a skill 
 
 Suites are currently implemented for:
 
+- **setup** — 16 cases across 4 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts)
 - **setup-isolated-setup-install** — 9 cases across 3 steps (runtime-routing, step-snapshot-drift, step-scope-confirm)
 - **setup-shared-config-sync** — 11 cases across 2 steps (step-3-decide-action, step-5-draft-commit)
 - **pairing-multi-agent-review** — 15 cases across 6 steps (step-1-collect-diff, step-2a-correctness-pass, step-2b-security-pass, step-2c-conventions-pass, step-3-merge-findings, step-4-compose-report)

--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -11,7 +11,7 @@ Behavioral eval harness for Apache Magpie skills. Each eval suite tests a skill 
 
 Suites are currently implemented for:
 
-- **setup** — 16 cases across 4 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts)
+- **setup** — 21 cases across 5 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts, step-m5-settings-merge)
 - **setup-isolated-setup-install** — 9 cases across 3 steps (runtime-routing, step-snapshot-drift, step-scope-confirm)
 - **setup-shared-config-sync** — 11 cases across 2 steps (step-3-decide-action, step-5-draft-commit)
 - **pairing-multi-agent-review** — 15 cases across 6 steps (step-1-collect-diff, step-2a-correctness-pass, step-2b-security-pass, step-2c-conventions-pass, step-3-merge-findings, step-4-compose-report)

--- a/tools/skill-evals/README.md
+++ b/tools/skill-evals/README.md
@@ -11,7 +11,7 @@ Behavioral eval harness for Apache Magpie skills. Each eval suite tests a skill 
 
 Suites are currently implemented for:
 
-- **setup** — 21 cases across 5 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts, step-m5-settings-merge)
+- **setup** — 24 cases across 6 steps (step-verify-drift, step-overrides-surface, step-override-bypass, step-m5-repo-artefacts, step-m5-settings-merge, verify-default-set)
 - **setup-isolated-setup-install** — 9 cases across 3 steps (runtime-routing, step-snapshot-drift, step-scope-confirm)
 - **setup-shared-config-sync** — 11 cases across 2 steps (step-3-decide-action, step-5-draft-commit)
 - **pairing-multi-agent-review** — 15 cases across 6 steps (step-1-collect-diff, step-2a-correctness-pass, step-2b-security-pass, step-2c-conventions-pass, step-3-merge-findings, step-4-compose-report)

--- a/tools/skill-evals/evals/setup/README.md
+++ b/tools/skill-evals/evals/setup/README.md
@@ -5,12 +5,13 @@
 
 Behavioral evals for the `setup` skill.
 
-## Suites (24 cases total)
+## Suites (26 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
 | step-verify-drift | verify.md § Check 3 (drift) | 5 | clean, method/URL mismatch, ref mismatch, svn-zip SHA-512 mismatch, local lock missing |
 | verify-default-set | verify.md § Committed default set | 3 | no committed `enabledPlugins` block (absent, not a fault), all three floor members present (current), some but not all present (stale — the only fault this check reports) |
+| uninstall-default-set | uninstall.md § Committed default set | 2 | committed block is exactly the floor (all three removed, nothing kept), a mixed block with other Magpie and other-vendor plugins (only the floor removed, everything else kept) |
 | step-overrides-surface | overrides.md § Step 0b | 4 | adopted no flag (offer choice), --local flag (personal), not adopted (personal only), both surfaces exist |
 | step-override-bypass | agentic-overrides.md § One-shot defaults run | 3 | `--no-overrides` flag + override exists, `--no-overrides` + no override, no flag + override exists |
 | step-m5-repo-artefacts | install.md § Step M5 — Recap and what comes next | 4 | Claude Code fresh install (offer made, defaults to no), Codex (no offer), Gemini (no offer), Claude Code where the offer was already declined (still a finished install) |
@@ -44,6 +45,15 @@ uv run --directory tools/skill-evals skill-eval --cli "claude -p" \
   plain list. Case 1 (absent) is the one that matters most — it checks
   that the skill states the optionality strongly enough that `is_fault`
   comes back `false` for a block that was never committed.
+- `uninstall-default-set` cases are fully auto-comparable: `plugins_removed`,
+  `plugins_kept`, and `keys_preserved` are plain lists, and `file_deleted` is
+  a boolean. Both cases report only the raw shape of
+  `.claude/settings.json` (its top-level keys and the contents of
+  `enabledPlugins`), never which entries the answer should sort into which
+  list — the model has to apply the floor-removal rule itself. Case 2
+  (mixed) is the one that matters most — it checks that non-floor Magpie
+  plugins and other vendors' plugins both survive untouched alongside an
+  unrelated top-level key.
 - `step-overrides-surface` tests the new `--local` flag and personal-
   vs-shared surface selection introduced by the `magpie-local-convention`
   work item.  The default surface when the repo is adopted and no flag is

--- a/tools/skill-evals/evals/setup/README.md
+++ b/tools/skill-evals/evals/setup/README.md
@@ -5,13 +5,14 @@
 
 Behavioral evals for the `setup` skill.
 
-## Suites (12 cases total)
+## Suites (16 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
 | step-verify-drift | verify.md § Check 3 (drift) | 5 | clean, method/URL mismatch, ref mismatch, svn-zip SHA-512 mismatch, local lock missing |
 | step-overrides-surface | overrides.md § Step 0b | 4 | adopted no flag (offer choice), --local flag (personal), not adopted (personal only), both surfaces exist |
 | step-override-bypass | agentic-overrides.md § One-shot defaults run | 3 | `--no-overrides` flag + override exists, `--no-overrides` + no override, no flag + override exists |
+| step-m5-repo-artefacts | install.md § Step M5 — Recap and what comes next | 4 | Claude Code fresh install (offer made, defaults to no), Codex (no offer), Gemini (no offer), Claude Code where the offer was already declined (still a finished install) |
 
 ## Run
 

--- a/tools/skill-evals/evals/setup/README.md
+++ b/tools/skill-evals/evals/setup/README.md
@@ -5,11 +5,12 @@
 
 Behavioral evals for the `setup` skill.
 
-## Suites (21 cases total)
+## Suites (24 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
 | step-verify-drift | verify.md § Check 3 (drift) | 5 | clean, method/URL mismatch, ref mismatch, svn-zip SHA-512 mismatch, local lock missing |
+| verify-default-set | verify.md § Committed default set | 3 | no committed `enabledPlugins` block (absent, not a fault), all three floor members present (current), some but not all present (stale — the only fault this check reports) |
 | step-overrides-surface | overrides.md § Step 0b | 4 | adopted no flag (offer choice), --local flag (personal), not adopted (personal only), both surfaces exist |
 | step-override-bypass | agentic-overrides.md § One-shot defaults run | 3 | `--no-overrides` flag + override exists, `--no-overrides` + no override, no flag + override exists |
 | step-m5-repo-artefacts | install.md § Step M5 — Recap and what comes next | 4 | Claude Code fresh install (offer made, defaults to no), Codex (no offer), Gemini (no offer), Claude Code where the offer was already declined (still a finished install) |
@@ -38,6 +39,11 @@ uv run --directory tools/skill-evals skill-eval --cli "claude -p" \
 
 - `step-verify-drift` cases are fully auto-comparable: all three output
   fields (`status`, `severity`, `remediation`) are enumerated strings.
+- `verify-default-set` cases are fully auto-comparable: `status` and
+  `is_fault` are an enumerated string and a boolean, and `missing` is a
+  plain list. Case 1 (absent) is the one that matters most — it checks
+  that the skill states the optionality strongly enough that `is_fault`
+  comes back `false` for a block that was never committed.
 - `step-overrides-surface` tests the new `--local` flag and personal-
   vs-shared surface selection introduced by the `magpie-local-convention`
   work item.  The default surface when the repo is adopted and no flag is

--- a/tools/skill-evals/evals/setup/README.md
+++ b/tools/skill-evals/evals/setup/README.md
@@ -5,7 +5,7 @@
 
 Behavioral evals for the `setup` skill.
 
-## Suites (16 cases total)
+## Suites (21 cases total)
 
 | Suite | Step | Cases | What it covers |
 |---|---|---|---|
@@ -13,6 +13,7 @@ Behavioral evals for the `setup` skill.
 | step-overrides-surface | overrides.md § Step 0b | 4 | adopted no flag (offer choice), --local flag (personal), not adopted (personal only), both surfaces exist |
 | step-override-bypass | agentic-overrides.md § One-shot defaults run | 3 | `--no-overrides` flag + override exists, `--no-overrides` + no override, no flag + override exists |
 | step-m5-repo-artefacts | install.md § Step M5 — Recap and what comes next | 4 | Claude Code fresh install (offer made, defaults to no), Codex (no offer), Gemini (no offer), Claude Code where the offer was already declined (still a finished install) |
+| step-m5-settings-merge | install.md § Merge rules | 5 | no `.claude/settings.json` (create), file with unrelated keys (merge, preserve them), existing `enabledPlugins` with non-floor and non-Magpie entries (add only the missing floor members, remove nothing), existing pinned `apache-magpie` marketplace definition (left alone), malformed JSON (refuse, never rewrite) |
 
 ## Run
 

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-1-claude-code-fresh/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-1-claude-code-fresh/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-1-claude-code-fresh/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-1-claude-code-fresh/expected.json
@@ -1,0 +1,1 @@
+{"offer_made": true, "offer_default": "no", "artefacts_offered": ["settings-block", "config-store"], "install_complete_without": true}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-1-claude-code-fresh/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-1-claude-code-fresh/report.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Agent detected: Claude Code.
+Plugins just installed: magpie-setup, magpie-pr-management (marketplace apache-magpie, tracking main).
+Repo root has no `.claude/settings.json`.
+Repo root has no `.apache-magpie-overrides/` directory.
+No `.apache-magpie.lock` present.

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-2-codex/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-2-codex/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-2-codex/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-2-codex/expected.json
@@ -1,0 +1,1 @@
+{"offer_made": false, "offer_default": "no", "artefacts_offered": [], "install_complete_without": true}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-2-codex/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-2-codex/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Agent detected: OpenAI Codex CLI.
+Plugins just installed: magpie (all-in-one, marketplace apache-magpie).
+Repo root has no `.claude/settings.json`.
+No `.apache-magpie.lock` present.

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-3-gemini/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-3-gemini/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-3-gemini/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-3-gemini/expected.json
@@ -1,0 +1,1 @@
+{"offer_made": false, "offer_default": "no", "artefacts_offered": [], "install_complete_without": true}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-3-gemini/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-3-gemini/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Agent detected: Google Gemini CLI.
+Extension just installed: magpie.
+Repo root has no `.claude/settings.json`.
+No `.apache-magpie.lock` present.

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-4-claude-code-declined/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-4-claude-code-declined/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-4-claude-code-declined/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-4-claude-code-declined/expected.json
@@ -1,0 +1,1 @@
+{"offer_made": true, "offer_default": "no", "artefacts_offered": ["settings-block", "config-store"], "install_complete_without": true}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-4-claude-code-declined/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/case-4-claude-code-declined/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Agent detected: Claude Code.
+Plugins just installed: magpie-setup, magpie-security.
+The user was offered the committed default set and the config store, and declined both.
+Repo root has no `.claude/settings.json`.

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md
@@ -14,19 +14,14 @@ Return ONLY valid JSON with this structure:
 }
 ```
 
-`offer_made` is `true` only when the detected agent is Claude Code. Codex CLI,
-Gemini CLI, VS Code / Copilot and any other client cannot express a committed
-per-family default set, so `offer_made` is `false` and `artefacts_offered` is
-`[]`.
+`offer_made` is a boolean.
 
-`offer_default` is `"no"` whenever an offer is made: the block is optional and
-is never written without the user asking for it.
+`offer_default` is one of `"no"` or `"yes"`.
 
-`artefacts_offered` lists both repo-side artefacts when an offer is made —
-`"settings-block"` and `"config-store"` — in that order.
+`artefacts_offered` is a list whose only possible members are
+`"settings-block"` and `"config-store"`; when both appear, `"settings-block"`
+comes before `"config-store"`.
 
-`install_complete_without` is always `true`. A marketplace install that writes
-nothing to the repo is a finished, working install; declining the offer, or
-being on a harness that cannot take it, never makes the install partial.
+`install_complete_without` is a boolean.
 
 Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md
@@ -1,0 +1,32 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "offer_made": true | false,
+  "offer_default": "no" | "yes",
+  "artefacts_offered": ["settings-block", "config-store"],
+  "install_complete_without": true | false
+}
+```
+
+`offer_made` is `true` only when the detected agent is Claude Code. Codex CLI,
+Gemini CLI, VS Code / Copilot and any other client cannot express a committed
+per-family default set, so `offer_made` is `false` and `artefacts_offered` is
+`[]`.
+
+`offer_default` is `"no"` whenever an offer is made: the block is optional and
+is never written without the user asking for it.
+
+`artefacts_offered` lists both repo-side artefacts when an offer is made —
+`"settings-block"` and `"config-store"` — in that order.
+
+`install_complete_without` is always `true`. A marketplace install that writes
+nothing to the repo is a finished, working install; declining the offer, or
+being on a harness that cannot take it, never makes the install partial.
+
+Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/output-spec.md
@@ -9,7 +9,7 @@ Return ONLY valid JSON with this structure:
 {
   "offer_made": true | false,
   "offer_default": "no" | "yes",
-  "artefacts_offered": ["settings-block", "config-store"],
+  "artefacts_offered": [...],
   "install_complete_without": true | false
 }
 ```

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup/install.md",
+  "step_heading": "### Step M5 — Recap and what comes next"
+}

--- a/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup/step-m5-repo-artefacts/fixtures/user-prompt-template.md
@@ -1,0 +1,10 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Install state
+
+{report}
+
+You are at Step M5 of the marketplace install. Decide whether to offer the
+repo-side artefacts, what the offer's default is, and whether the install is
+complete without them. Return JSON only.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-1-no-file/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-1-no-file/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-1-no-file/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-1-no-file/expected.json
@@ -1,0 +1,1 @@
+{"action": "create", "keys_preserved": [], "plugins_added": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": true}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-1-no-file/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-1-no-file/report.md
@@ -1,0 +1,4 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+No `.claude/settings.json` exists in the repo root.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-2-other-keys/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-2-other-keys/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-2-other-keys/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-2-other-keys/expected.json
@@ -1,0 +1,1 @@
+{"action": "merge", "keys_preserved": ["$schema", "sandbox", "permissions"], "plugins_added": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": true}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-2-other-keys/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-2-other-keys/report.md
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` exists and parses as JSON. Its top-level keys, in order:
+`$schema`, `sandbox`, `permissions`. It has no `extraKnownMarketplaces` and no
+`enabledPlugins`.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-3-existing-plugins/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-3-existing-plugins/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-3-existing-plugins/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-3-existing-plugins/expected.json
@@ -1,0 +1,1 @@
+{"action": "merge", "keys_preserved": ["permissions"], "plugins_added": ["magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": true}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-3-existing-plugins/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-3-existing-plugins/report.md
@@ -1,0 +1,8 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` exists and parses as JSON. Top-level keys, in order:
+`permissions`, `enabledPlugins`. `enabledPlugins` currently contains
+`magpie-setup@apache-magpie: true`, `magpie-security@apache-magpie: true` and
+`some-other-plugin@vendor-marketplace: true`. There is no
+`extraKnownMarketplaces`.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-4-pinned-marketplace/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-4-pinned-marketplace/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-4-pinned-marketplace/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-4-pinned-marketplace/expected.json
@@ -1,0 +1,1 @@
+{"action": "merge", "keys_preserved": [], "plugins_added": ["magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_removed": [], "marketplace_definition_changed": false}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-4-pinned-marketplace/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-4-pinned-marketplace/report.md
@@ -1,0 +1,7 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` exists and parses as JSON. Top-level keys, in order:
+`extraKnownMarketplaces`, `enabledPlugins`. `extraKnownMarketplaces` defines
+`apache-magpie` with `{"source": {"source": "github", "repo": "apache/magpie@0.2.0"}}`.
+`enabledPlugins` contains `magpie-setup@apache-magpie: true`.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-5-malformed/case-meta.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-5-malformed/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-5-malformed/expected.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-5-malformed/expected.json
@@ -1,0 +1,1 @@
+{"action": "refuse", "keys_preserved": [], "plugins_added": [], "plugins_removed": [], "marketplace_definition_changed": false}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-5-malformed/report.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/case-5-malformed/report.md
@@ -1,0 +1,5 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` exists but does not parse: it ends mid-object after a
+trailing comma on the `permissions` key.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md
@@ -1,0 +1,30 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "action": "create" | "merge" | "refuse",
+  "keys_preserved": [...],
+  "plugins_added": [...],
+  "plugins_removed": [...],
+  "marketplace_definition_changed": true | false
+}
+```
+
+`action` is one of `"create"`, `"merge"`, or `"refuse"`.
+
+`keys_preserved` is a list of strings — top-level key names from the
+settings file, in the order they appear there.
+
+`plugins_added` and `plugins_removed` are lists of `<plugin>@<marketplace>`
+strings. Where more than one of the floor members appears in
+`plugins_added`, list them in floor order: `magpie-setup@apache-magpie`,
+`magpie-utilities@apache-magpie`, `magpie-agent-guard@apache-magpie`.
+
+`marketplace_definition_changed` is a boolean.
+
+Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md
@@ -18,8 +18,9 @@ Return ONLY valid JSON with this structure:
 `action` reports which operation this merge performed on
 `.claude/settings.json`: one of `"create"`, `"merge"`, or `"refuse"`.
 
-`keys_preserved` is a list of strings — the top-level keys the merge left
-untouched, in the order they appear in the settings file.
+`keys_preserved` is a list of strings — the top-level keys other than the
+ones the merge rules say this merge touches, in the order they appear in
+the settings file.
 
 `plugins_added` is a list of `<plugin>@<marketplace>` strings — the entries
 the merge added to `enabledPlugins`. Where it adds more than one, list them

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/output-spec.md
@@ -15,16 +15,20 @@ Return ONLY valid JSON with this structure:
 }
 ```
 
-`action` is one of `"create"`, `"merge"`, or `"refuse"`.
+`action` reports which operation this merge performed on
+`.claude/settings.json`: one of `"create"`, `"merge"`, or `"refuse"`.
 
-`keys_preserved` is a list of strings — top-level key names from the
-settings file, in the order they appear there.
+`keys_preserved` is a list of strings — the top-level keys the merge left
+untouched, in the order they appear in the settings file.
 
-`plugins_added` and `plugins_removed` are lists of `<plugin>@<marketplace>`
-strings. Where more than one of the floor members appears in
-`plugins_added`, list them in floor order: `magpie-setup@apache-magpie`,
-`magpie-utilities@apache-magpie`, `magpie-agent-guard@apache-magpie`.
+`plugins_added` is a list of `<plugin>@<marketplace>` strings — the entries
+the merge added to `enabledPlugins`. Where it adds more than one, list them
+in the order the merge rules give them.
 
-`marketplace_definition_changed` is a boolean.
+`plugins_removed` is a list of `<plugin>@<marketplace>` strings — the
+entries the merge removed from `enabledPlugins`.
+
+`marketplace_definition_changed` is a boolean — whether this merge added or
+changed the `apache-magpie` entry in `extraKnownMarketplaces`.
 
 Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup/install.md",
+  "step_heading": "#### Merge rules"
+}

--- a/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup/step-m5-settings-merge/fixtures/user-prompt-template.md
@@ -1,0 +1,9 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Current `.claude/settings.json`
+
+{report}
+
+The user accepted the offer to commit the default set. Decide how to write it.
+Return JSON only.

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-1-floor-only/case-meta.json
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-1-floor-only/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-1-floor-only/expected.json
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-1-floor-only/expected.json
@@ -1,0 +1,1 @@
+{"plugins_removed": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_kept": [], "keys_preserved": ["$schema", "sandbox"], "file_deleted": false}

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-1-floor-only/report.md
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-1-floor-only/report.md
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Top-level keys, in order: `$schema`, `sandbox`, `extraKnownMarketplaces`,
+`enabledPlugins`. `enabledPlugins` contains exactly the three floor members,
+all `true`.

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-2-mixed/case-meta.json
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-2-mixed/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-2-mixed/expected.json
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-2-mixed/expected.json
@@ -1,0 +1,1 @@
+{"plugins_removed": ["magpie-setup@apache-magpie", "magpie-utilities@apache-magpie", "magpie-agent-guard@apache-magpie"], "plugins_kept": ["magpie-security@apache-magpie", "some-other-plugin@vendor-marketplace"], "keys_preserved": ["permissions"], "file_deleted": false}

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-2-mixed/report.md
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/case-2-mixed/report.md
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+Top-level keys, in order: `permissions`, `enabledPlugins`. `enabledPlugins`
+contains the three floor members plus `magpie-security@apache-magpie: true` and
+`some-other-plugin@vendor-marketplace: true`.

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/output-spec.md
@@ -1,0 +1,30 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "plugins_removed": [...],
+  "plugins_kept": [...],
+  "keys_preserved": [...],
+  "file_deleted": true | false
+}
+```
+
+`plugins_removed` is a list of `<plugin>@<marketplace>` strings — the
+`enabledPlugins` entries the rules above say to remove, in the order the
+rules list them.
+
+`plugins_kept` is a list of `<plugin>@<marketplace>` strings — the
+`enabledPlugins` entries the rules above say to leave in place.
+
+`keys_preserved` is a list of top-level key names — the keys of
+`.claude/settings.json` the rules above say to leave untouched.
+
+`file_deleted` reports whether the rules above call for deleting
+`.claude/settings.json` itself.
+
+Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup/uninstall.md",
+  "step_heading": "## Committed default set"
+}

--- a/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup/uninstall-default-set/fixtures/user-prompt-template.md
@@ -1,0 +1,9 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Current `.claude/settings.json`
+
+{report}
+
+You are uninstalling Magpie from this repo. Decide what to remove from the
+settings file. Return JSON only.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-1-absent/case-meta.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-1-absent/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-1-absent/expected.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-1-absent/expected.json
@@ -1,0 +1,1 @@
+{"status": "absent", "is_fault": false, "missing": []}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-1-absent/report.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-1-absent/report.md
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` exists with `sandbox` and `permissions` keys. It has no
+`enabledPlugins` key. The user has magpie-setup and magpie-pr-management
+installed at user scope.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/case-meta.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/expected.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/expected.json
@@ -1,0 +1,1 @@
+{"status": "current", "is_fault": false, "missing": []}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/report.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/report.md
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` commits `enabledPlugins` with
+`magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie` and
+`magpie-agent-guard@apache-magpie`, all `true`.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/report.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-2-current/report.md
@@ -2,5 +2,6 @@
      https://www.apache.org/licenses/LICENSE-2.0 -->
 
 `.claude/settings.json` commits `enabledPlugins` with
-`magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie` and
-`magpie-agent-guard@apache-magpie`, all `true`.
+`magpie-setup@apache-magpie`, `magpie-utilities@apache-magpie`,
+`magpie-agent-guard@apache-magpie` and `magpie-security@apache-magpie`, all
+`true`.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/case-meta.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/case-meta.json
@@ -1,0 +1,1 @@
+{"tags":["local-smoke","smoke"]}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/expected.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/expected.json
@@ -1,0 +1,1 @@
+{"status": "stale", "is_fault": true, "missing": ["magpie-agent-guard@apache-magpie"]}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/report.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/report.md
@@ -1,0 +1,6 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+`.claude/settings.json` commits `enabledPlugins` with
+`magpie-setup@apache-magpie: true` and `magpie-utilities@apache-magpie: true`.
+There is no `magpie-agent-guard@apache-magpie` entry.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/report.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/case-3-stale/report.md
@@ -3,4 +3,3 @@
 
 `.claude/settings.json` commits `enabledPlugins` with
 `magpie-setup@apache-magpie: true` and `magpie-utilities@apache-magpie: true`.
-There is no `magpie-agent-guard@apache-magpie` entry.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/output-spec.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/output-spec.md
@@ -1,0 +1,25 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Output format
+
+Return ONLY valid JSON with this structure:
+
+```json
+{
+  "status": "absent" | "current" | "stale",
+  "is_fault": true | false,
+  "missing": [...]
+}
+```
+
+`status` reports which of the three states the repo's committed default set
+is in, per the rules in the check above.
+
+`is_fault` reports whether that state is a fault to be fixed, per the same
+rules.
+
+`missing` is a list of `<plugin>@<marketplace>` strings — the entries the
+rules above say belong in it, in floor order.
+
+Do not include any text outside the JSON object.

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/step-config.json
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/step-config.json
@@ -1,0 +1,4 @@
+{
+  "skill_md": "skills/setup/verify.md",
+  "step_heading": "## Committed default set"
+}

--- a/tools/skill-evals/evals/setup/verify-default-set/fixtures/user-prompt-template.md
+++ b/tools/skill-evals/evals/setup/verify-default-set/fixtures/user-prompt-template.md
@@ -1,0 +1,9 @@
+<!-- SPDX-License-Identifier: Apache-2.0
+     https://www.apache.org/licenses/LICENSE-2.0 -->
+
+## Repo state
+
+{report}
+
+You are running the committed-default-set check of `setup verify`. Report its
+status. Return JSON only.

--- a/tools/spec-loop/specs/adoption-and-setup.md
+++ b/tools/spec-loop/specs/adoption-and-setup.md
@@ -27,6 +27,39 @@ acceptance:
     layer above the committed `.apache-magpie-overrides/`, cannot weaken the
     safety baseline, and can be ignored for a single run via a one-shot
     default switch.
+  - A marketplace install on Claude Code offers once, opt-in and defaulting
+    to no, to write the committed default-set block and scaffold the
+    `.apache-magpie-overrides/` config store together in a single question
+    that states both are optional and that the plugins work in the repo
+    either way; the offer is never asked on any other client.
+  - Declining the offer, or running on a client where it is never asked,
+    leaves a complete install; neither the recap nor verify describes the
+    result as incomplete or partial.
+  - The default-set floor stays fixed at the same three plugins regardless
+    of which other families this maintainer installed; it never grows to
+    include a maintainer-only family.
+  - Writing the committed default-set block touches only
+    `extraKnownMarketplaces` and `enabledPlugins` in
+    `.claude/settings.json`, preserves every other top-level key and an
+    existing `apache-magpie` marketplace definition, adds only the floor
+    members missing from an existing `enabledPlugins` and removes nothing,
+    creates the file with just those two keys when it is absent, refuses to
+    rewrite a settings file that does not parse, and stages only the file
+    it wrote — never commits it.
+  - verify reports an absent committed default-set block through the
+    non-fault glyph with an empty `missing` list, reports all three floor
+    members present as current and equally non-faulting, reports
+    some-but-not-all floor members present as stale, the one fault this
+    check raises, naming the missing members in floor order with a repair
+    offer, and gives an entry naming a plugin the marketplace no longer
+    ships the same drift treatment.
+  - uninstall removes only the three floor entries from `enabledPlugins`
+    and the `apache-magpie` entry from `extraKnownMarketplaces`, keeps
+    every other plugin and marketplace entry untouched, drops either key
+    left empty by the removal, and never deletes `.claude/settings.json`.
+  - docs/quick-start.md and docs/setup/marketplaces.md both state that the
+    committed default-set block is optional and not a prerequisite to using
+    the plugins in the repo.
 ---
 
 # Adoption & setup


### PR DESCRIPTION
**Stacked on #1195.** Until that merges this PR also shows its commits; the 16 commits from `docs(design)` onward are this one's.

A marketplace install is per-machine and commits nothing, so every contributor installs Magpie by hand. A project can instead commit a small `.claude/settings.json` block naming the marketplace and a three-plugin floor — `magpie-setup`, `magpie-utilities`, `magpie-agent-guard` — so anyone who clones and trusts the repo arrives ready. That block was documented but nothing ever wrote it.

`setup` now offers to, once, opt-in, defaulting to no, Claude Code only (Codex can only default-install all ten families; Gemini has no workspace-extension mechanism). **Committing the block is optional and is not a prerequisite** — the plugins work in the repo either way, and declining leaves a complete install. `verify` reports a block that falls behind the floor as drift, and reports an absent one informationally, never as a fault. `uninstall` removes only the three entries it added.

Everything here is prose in skill files: a family plugin ships no `tools/`, so nothing may depend on a helper existing on the adopter's machine. Behaviour is covered by four new `skill-evals` suites (14 cases).

**A caveat reviewers should know about that evidence.** The eval harness's documented automated mode, `--cli "claude -p"` from the repo root, is unsound in two ways I measured: that CLI has file tools and can read the fixtures' own `expected.json`, and even with every tool disabled it absorbs project context from its working directory. A skill section stubbed to one sentence scored full marks under the documented command. These suites were validated with tools disabled **and** the runner invoked from outside the repository — 14/14 green, and failing as expected against stubbed sections. The harness issue itself is not fixed here; it affects all 75 suites and deserves its own change.

Subsystems B (per-skill first-run wizard) and C (wizard screenshots) are designed in `docs/designs/` but not implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M7zttXzAM1wbTdBAjJCECv
