### PR TITLE
chore(version): stamp the dev version to 0.2.0.dev202609110041

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,79 +9,79 @@
     {
       "name": "magpie",
       "source": ".",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "All Apache Magpie skills (all 10 families; ~8.6k always-on tokens)."
     },
     {
       "name": "magpie-agent-guard",
       "source": "./plugins/magpie-agent-guard",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie \u2014 deterministic pre-execution command guard: a PreToolUse hook that denies shell commands which would break a hard framework rule. Runs from the installed plugin, so no repository or worktree needs a local copy."
     },
     {
       "name": "magpie-vetted-ops",
       "source": "./plugins/magpie-vetted-ops",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie \u2014 vetted-ops: a dispatcher for fixed, policy-scoped forge operations, so a session needs one allowlist entry instead of a dozen wildcard `ask` rules. Runs from the installed plugin, which is what keeps the operation catalogue out of reach of the agent that calls it."
     },
     {
       "name": "magpie-contributor-growth",
       "source": "./plugins/magpie-contributor-growth",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie contributor-growth family (6 skills)."
     },
     {
       "name": "magpie-issue",
       "source": "./plugins/magpie-issue",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie issue family (8 skills)."
     },
     {
       "name": "magpie-mentoring",
       "source": "./plugins/magpie-mentoring",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie mentoring family (4 skills)."
     },
     {
       "name": "magpie-pairing",
       "source": "./plugins/magpie-pairing",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie pairing family (2 skills)."
     },
     {
       "name": "magpie-pr-management",
       "source": "./plugins/magpie-pr-management",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie pr-management family (8 skills)."
     },
     {
       "name": "magpie-release-management",
       "source": "./plugins/magpie-release-management",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie release-management family (10 skills)."
     },
     {
       "name": "magpie-repo-health",
       "source": "./plugins/magpie-repo-health",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie repo-health family (7 skills)."
     },
     {
       "name": "magpie-security",
       "source": "./plugins/magpie-security",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie security family (15 skills)."
     },
     {
       "name": "magpie-setup",
       "source": "./plugins/magpie-setup",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie setup family (9 skills)."
     },
     {
       "name": "magpie-utilities",
       "source": "./plugins/magpie-utilities",
-      "version": "0.2.0.dev202609100826",
+      "version": "0.2.0.dev202609110041",
       "description": "Apache Magpie utilities family (5 skills)."
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "description": "Apache Magpie — a reusable, governance-agnostic framework of agentic skills for maintaining open-source projects: release management, security triage, PR and issue workflows, contributor growth, and repo health.",
   "author": { "name": "Apache Magpie", "url": "https://magpie.apache.org/" },
   "homepage": "https://magpie.apache.org/",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "description": "Apache Magpie — agentic skills for maintaining open-source projects.",
   "skills": "./skills",
   "hooks": {

--- a/apm.yml
+++ b/apm.yml
@@ -6,7 +6,7 @@
 # Gemini). Schema is v0.1 and may change — verify against the current
 # https://microsoft.github.io/apm/ before publishing.
 name: magpie
-version: 0.2.0.dev202609100826
+version: 0.2.0.dev202609110041
 type: skill
 description: >-
   Apache Magpie — a reusable, governance-agnostic framework of agentic skills

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "magpie",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "description": "Apache Magpie — agentic skills for maintaining open-source projects. Skills are auto-discovered from ./skills.",
   "contextFileName": "GEMINI.md"
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "magpie",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "description": "Apache Magpie — a reusable, governance-agnostic framework of agentic skills for maintaining open-source projects: release management, security triage, PR and issue workflows, contributor growth, and repo health.",
   "author": { "name": "Apache Magpie", "url": "https://magpie.apache.org/" },
   "homepage": "https://magpie.apache.org/",

--- a/plugins/magpie-agent-guard/.claude-plugin/plugin.json
+++ b/plugins/magpie-agent-guard/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-agent-guard",
   "description": "Apache Magpie \u2014 deterministic pre-execution command guard: a PreToolUse hook that denies shell commands which would break a hard framework rule. Runs from the installed plugin, so no repository or worktree needs a local copy.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-contributor-growth/.claude-plugin/plugin.json
+++ b/plugins/magpie-contributor-growth/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-contributor-growth",
   "description": "Apache Magpie \u2014 path-to-committer: activity sweeps, nominations, sentiment, readiness, committer/post-vote onboarding.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-issue/.claude-plugin/plugin.json
+++ b/plugins/magpie-issue/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-issue",
   "description": "Apache Magpie \u2014 issue lifecycle: triage, reproduction, fix drafting, reassess, stale-sweep, dedup, backlog stats.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-mentoring/.claude-plugin/plugin.json
+++ b/plugins/magpie-mentoring/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-mentoring",
   "description": "Apache Magpie \u2014 newcomer mentoring: welcome, newcomer-issue explanations, good-first-issue authoring + sweep.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-pairing/.claude-plugin/plugin.json
+++ b/plugins/magpie-pairing/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-pairing",
   "description": "Apache Magpie \u2014 pair a change with a structured self-review or a multi-agent adversarial review.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-pr-management/.claude-plugin/plugin.json
+++ b/plugins/magpie-pr-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-pr-management",
   "description": "Apache Magpie \u2014 PR-queue management: triage, stats, deep code review, quick-merge, stale-sweep, reviewer routing, pre-first-PR checks.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-release-management/.claude-plugin/plugin.json
+++ b/plugins/magpie-release-management/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-release-management",
   "description": "Apache Magpie \u2014 ASF release lifecycle: plan, RC cut/sign, vote, tally, promote, announce, archive, audit.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-repo-health/.claude-plugin/plugin.json
+++ b/plugins/magpie-repo-health/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-repo-health",
   "description": "Apache Magpie \u2014 read-only repo-health audits: runner labels, workflow security, dependency/license/NOTICE, flaky tests, audit-finding fixes.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-security/.claude-plugin/plugin.json
+++ b/plugins/magpie-security/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-security",
   "description": "Apache Magpie \u2014 security-issue handling lifecycle \u2014 import through CVE publication, triage, sync, dedup, invalidate. Maintainer-only.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-setup/.claude-plugin/plugin.json
+++ b/plugins/magpie-setup/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-setup",
   "description": "Apache Magpie \u2014 framework install/maintenance: install (adopt), upgrade, verify, override, status, secure-agent setup, shared-config sync.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-utilities/.claude-plugin/plugin.json
+++ b/plugins/magpie-utilities/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-utilities",
   "description": "Apache Magpie \u2014 framework meta-skills: write-skill, optimize-skill, skill-reconciler, list-skills.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/plugins/magpie-vetted-ops/.claude-plugin/plugin.json
+++ b/plugins/magpie-vetted-ops/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "magpie-vetted-ops",
   "description": "Apache Magpie \u2014 vetted-ops: a dispatcher for fixed, policy-scoped forge operations, so a session needs one allowlist entry instead of a dozen wildcard `ask` rules. Runs from the installed plugin, which is what keeps the operation catalogue out of reach of the agent that calls it.",
-  "version": "0.2.0.dev202609100826",
+  "version": "0.2.0.dev202609110041",
   "author": {
     "name": "Apache Magpie",
     "url": "https://magpie.apache.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@
 # Package name matches the project's canonical name. Not published to
 # PyPI — this name only frames the framework root as a uv-managed project.
 name = "apache-magpie"
-version = "0.2.0.dev202609100826"
+version = "0.2.0.dev202609110041"
 description = "Reusable, governance-agnostic framework of agentic skills for maintaining open-source projects."
 requires-python = ">=3.11"
 

--- a/uv.lock
+++ b/uv.lock
@@ -120,7 +120,7 @@ wheels = [
 
 [[package]]
 name = "apache-magpie"
-version = "0.2.0.dev202609100826"
+version = "0.2.0.dev202609110041"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Four changes have landed behind the previous stamp (`0.2.0.dev202609100826`,
#1193):

- guarded Bitbucket cloud PR decline (#1194)
- setup: an optional committed default plugin set (#1196)
- cve-json: `affected[].packageURL` on generated CVE records (#1197)
- docs: the marketplace plugin install is now the documented default (#1195)

`claude plugin update` compares version strings, not commit SHAs, so none of
that reaches an adopter until the stamp moves.

Mechanical, per `docs/setup/marketplaces.md` (*Versioning*): `project.version`
edited in `pyproject.toml`, then `tools/dev/check-family-plugins.py --fix`
propagated it to the five ecosystem manifests and the twelve per-family plugin
manifests plus the marketplace entries, and `uv lock` refreshed the workspace's
own package version. The diff is version strings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CPC1wBowFdMo4jnCvLZDJ2
